### PR TITLE
Correct dispatch HPC path for NFS mount layout

### DIFF
--- a/biosimulations/apps/biosimulations-dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/biosimulations/apps/biosimulations-dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -36,7 +36,7 @@ export class SbatchService {
         echo ENVIRONMENT
         env
         
-        command="singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out /home/FCAM/crbmapi/${simulator}.img -i /root/in/${omexName} -o /root/out"
+        command="singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out /home/FCAM/crbmapi/nfs/biosimulations/singularity_images/${simulator}.img -i /root/in/${omexName} -o /root/out"
         echo $command
         
         eval $command;`

--- a/biosimulations/libs/shared/biosimulations-config/src/lib/biosimulations-hpc-config.ts
+++ b/biosimulations/libs/shared/biosimulations-config/src/lib/biosimulations-hpc-config.ts
@@ -19,7 +19,7 @@ export default registerAs('hpc', () => {
       privateKey: process.env.HPC_SFTP_PRIVATE_KEY,
     },
     // TODO: Move Simdir base to config file
-    simDirBase: '/home/FCAM/crbmapi/simulations',
+    simDirBase: '/home/FCAM/crbmapi/nfs/biosimulations/simulations',
   };
 
   return config;


### PR DESCRIPTION
I tested locally, NFS mount path is accessible from the service user and, simulations results are accessible