### PR TITLE
Dev simulators

### DIFF
--- a/biosimulations/apps/dispatch/src/app/app.component.scss
+++ b/biosimulations/apps/dispatch/src/app/app.component.scss
@@ -1,6 +1,6 @@
 biosimulations-topbar-menu {
   padding-left: 0;
-  
+
   ::ng-deep biosimulations-topbar-menu-item {
     margin-left: 1rem;
   }

--- a/biosimulations/apps/dispatch/src/app/components/help/help-routing.module.ts
+++ b/biosimulations/apps/dispatch/src/app/components/help/help-routing.module.ts
@@ -15,7 +15,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -28,7 +28,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -41,7 +41,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -68,7 +68,7 @@ const routes: Routes = [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
             ]
         }
     },

--- a/biosimulations/apps/dispatch/src/app/components/run/dispatch/dispatch.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/run/dispatch/dispatch.component.spec.ts
@@ -9,6 +9,7 @@ import { HttpClient, HttpHandler } from '@angular/common/http';
 import { SharedUiModule } from '@biosimulations/shared/ui';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IonicStorageModule } from '@ionic/storage';
 
 describe('DispatchComponent', () => {
   let component: DispatchComponent;
@@ -26,6 +27,9 @@ describe('DispatchComponent', () => {
         MatSelectModule,
         NgxMatFileInputModule,
         NoopAnimationsModule,
+        IonicStorageModule.forRoot({
+          driverOrder: ['indexeddb', 'websql', 'localstorage']
+        }),
       ],
       declarations: [DispatchComponent],
       providers: [HttpClient, HttpHandler],

--- a/biosimulations/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
@@ -7,8 +7,9 @@ import {
 } from '@angular/forms';
 import { HttpErrorResponse } from '@angular/common/http';
 import { DispatchService } from '../../../services/dispatch/dispatch.service';
-import { VisualisationService } from '../../../services/visualisation/visualisation.service';
+import { SimulationService } from '../../../services/simulation/simulation.service';
 import { environment } from '@biosimulations/shared/environments';
+import { SimulationStatus } from '../../../datamodel';
 
 @Component({
   selector: 'biosimulations-dispatch',
@@ -28,7 +29,8 @@ export class DispatchComponent implements OnInit {
 
   constructor(
     private formBuilder: FormBuilder,
-    private dispatchService: DispatchService
+    private dispatchService: DispatchService,
+    private simulationService: SimulationService,
   ) {
     this.formGroup = formBuilder.group({
       projectFile: ['', [Validators.required]],
@@ -87,6 +89,17 @@ export class DispatchComponent implements OnInit {
           this.dispatchService.uuidsDispatched.push(simulationId);
           this.dispatchService.uuidUpdateEvent.next(simulationId);
           this.simulationId = simulationId;
+
+          this.simulationService.storeSimulation({
+            id: simulationId,
+            name: name,
+            email: email,
+            submittedLocally: true,
+            status: SimulationStatus.queued,
+            runtime: undefined,
+            submitted: new Date(),
+            updated: new Date(),
+          });
         },
         (error: HttpErrorResponse) => {
           this.submitError = error.message;

--- a/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.html
@@ -1,4 +1,9 @@
 <biosimulations-page heading="Your simulations">
+  <ng-container id="buttons">
+    <button mat-icon-button title="Export simulations" (click)="exportSimulations()"><biosimulations-icon icon="download"></biosimulations-icon></button>
+    <button mat-icon-button title="Import simulations" (click)="importSimulations()"><biosimulations-icon icon="upload"></biosimulations-icon></button>
+  </ng-container>
+
   <biosimulations-table
     [columns]="columns"
   ></biosimulations-table>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.spec.ts
@@ -2,8 +2,10 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { IonicStorageModule } from '@ionic/storage';
 
 import { SharedUiModule } from '@biosimulations/shared/ui';
+import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { BrowseComponent } from './browse.component';
 
 describe('BrowseComponent', () => {
@@ -12,7 +14,16 @@ describe('BrowseComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule, NoopAnimationsModule, SharedUiModule],
+      imports: [
+        HttpClientTestingModule,
+        RouterTestingModule,
+        NoopAnimationsModule,
+        SharedUiModule,
+        BiosimulationsIconsModule,
+        IonicStorageModule.forRoot({
+          driverOrder: ['indexeddb', 'websql', 'localstorage']
+        }),
+      ],
       declarations: [BrowseComponent],
     }).compileComponents();
   }));

--- a/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
@@ -134,11 +134,11 @@ export class BrowseComponent implements AfterViewInit {
       id: 'visualize',
       heading: "Visualize",
       center: true,
-      linkType: ColumnLinkType.routerLink,
-      routerLink: (simulation: Simulation): string[] => {
+      leftIcon: 'chart',
+      leftLinkType: ColumnLinkType.routerLink,
+      leftRouterLink: (simulation: Simulation): string[] => {
         return ['/simulations', simulation.id];
       },
-      leftIcon: 'chart',
       minWidth: 66,
       filterable: false,
       sortable: false,
@@ -147,15 +147,15 @@ export class BrowseComponent implements AfterViewInit {
       id: 'download',
       heading: "Download",
       center: true,
-      linkType: ColumnLinkType.href,
-      href: (simulation: Simulation): string | null => {
+      leftIcon: 'download',
+      leftLinkType: ColumnLinkType.href,
+      leftHref: (simulation: Simulation): string | null => {
         if (simulation.status === SimulationStatus.succeeded) {
           return 'download-results/' + simulation.id;
         } else {
           return null;
         }
       },
-      leftIcon: 'download',
       minWidth: 66,
       filterable: false,
       sortable: false,
@@ -164,15 +164,15 @@ export class BrowseComponent implements AfterViewInit {
       id: 'log',
       heading: "Log",
       center: true,
-      linkType: ColumnLinkType.routerLink,
-      routerLink: (simulation: Simulation): string[] | null => {
+      leftIcon: 'logs',
+      leftLinkType: ColumnLinkType.routerLink,
+      leftRouterLink: (simulation: Simulation): string[] | null => {
         if (simulation.status === SimulationStatus.succeeded || simulation.status === SimulationStatus.failed) {
           return ['/simulations', simulation.id];
         } else {
           return null;
         }
       },
-      leftIcon: 'logs',
       minWidth: 66,
       filterable: false,
       sortable: false,

--- a/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
@@ -1,28 +1,13 @@
-import { Component, AfterViewInit, ViewChild } from '@angular/core';
-import { DispatchService } from '../../../services/dispatch/dispatch.service';
+import { Component, ViewChild } from '@angular/core';
+import { Simulation, SimulationStatus } from '../../../datamodel';
+import { SimulationService } from '../../../services/simulation/simulation.service';
 import { TableComponent, Column, ColumnLinkType, ColumnFilterType } from '@biosimulations/shared/ui';
-
-enum SimulationStatus {
-  queued = 'queued',
-  started = 'started',
-  succeeded = 'succeeded',
-  failed = 'failed',
-}
-
-interface Simulation {
-  id: string;
-  name: string;
-  status: SimulationStatus;
-  runtime?: number;
-  submitted: Date;
-  updated: Date;
-}
 
 @Component({
   templateUrl: './browse.component.html',
   styleUrls: ['./browse.component.scss'],
 })
-export class BrowseComponent implements AfterViewInit {
+export class BrowseComponent {
   @ViewChild(TableComponent) table!: TableComponent;
 
   columns: Column[] = [
@@ -131,6 +116,17 @@ export class BrowseComponent implements AfterViewInit {
       minWidth: 140,
     },
     {
+      id: 'submittedLocally',
+      heading: "Submitted locally",
+      key: 'submittedLocally',
+      formatter: (value: boolean): string => {
+        return value ? 'Yes' : 'No';
+      },
+      minWidth: 134,
+      center: true,
+      show: false,
+    },
+    {
       id: 'visualize',
       heading: "Visualize",
       center: true,
@@ -179,29 +175,56 @@ export class BrowseComponent implements AfterViewInit {
     },
   ];
 
-  data: Simulation[] = [];
-
-  constructor(private dispatchService: DispatchService) {}
+  constructor(private simulationService: SimulationService) {}
 
   ngAfterViewInit() {
     this.table.defaultSort = {active: 'id', direction: 'asc'};
 
-    this.dispatchService.uuidUpdateEvent.subscribe(
-      (uuid: string): void => {
-        // TODO: get name, status, runtime, dates from dispatch service
-        this.data.push({
-          id: uuid,
-          name: '',
-          status: SimulationStatus.queued,
-          runtime: undefined,
-          submitted: new Date(),
-          updated: new Date(),
-        });
-        this.table.setData(this.data);
-      },
-      (error): void => {
-        console.log('Error occured while fetching UUIds: ', error);
-      },
+    this.simulationService.simulations$.subscribe(
+      (simulations: Simulation[]): void => {
+        setTimeout(() => this.table.setData(simulations));
+      }
     );
+  }
+
+  exportSimulations() {
+    const simulations = [...this.simulationService.getSimulations()] as any[];
+    simulations.forEach((simulation: any) => {
+      simulation.submitted = simulation.submitted.getTime();
+      simulation.updated = simulation.updated.getTime();
+    });
+
+    const blob = new Blob([JSON.stringify(simulations, null, 2)], {type: 'application/json'});
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = 'simulations.json';
+    a.click();
+  }
+
+  importSimulations() {
+    const input = document.createElement('input');
+    input.setAttribute('type', 'file');
+    input.onchange = () => {
+      if (input.files == null || input.files.length === 0) {
+        return;
+      }
+      const file = input.files[0];
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        if (e.target == null || typeof e.target.result !== 'string') {
+          return;
+        }
+
+        const simulations = JSON.parse(e.target.result);
+        simulations.forEach((simulation: any) => {
+          simulation.submitted = new Date(simulation.submitted);
+          simulation.updated = new Date(simulation.updated);
+          simulation.submittedLocally = false;
+        });
+        this.simulationService.setSimulations(simulations, true);
+      };
+      reader.readAsText(file);      
+    };
+    input.click();
   }
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
@@ -11,6 +11,7 @@ import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { IonicStorageModule } from '@ionic/storage';
 describe('ViewComponent', () => {
   let component: ViewComponent;
   let fixture: ComponentFixture<ViewComponent>;
@@ -28,6 +29,9 @@ describe('ViewComponent', () => {
         MatSelectModule,
         SharedUiModule,
         BiosimulationsIconsModule,
+        IonicStorageModule.forRoot({
+          driverOrder: ['indexeddb', 'websql', 'localstorage']
+        }),
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/forms';
 import { MatSelectChange } from '@angular/material/select';
 import { MatTabChangeEvent } from '@angular/material/tabs';
+import { SimulationService } from '../../../services/simulation/simulation.service';
 import { VisualisationService } from '../../../services/visualisation/visualisation.service';
 import { VisualisationComponent } from './visualisation/visualisation.component';
 
@@ -43,7 +44,8 @@ export class ViewComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private formBuilder: FormBuilder,
-    private visualisationService: VisualisationService
+    private simulationService: SimulationService,
+    private visualisationService: VisualisationService,
   ) {
     this.formGroup = formBuilder.group({
       sedml: ['', [Validators.required]],
@@ -57,7 +59,9 @@ export class ViewComponent implements OnInit {
       this.visualisationService
         .getResultStructure(this.uuid)
         .subscribe((data: any) => {
+          data['data'].submittedLocally = false;
           this.setProjectResults(data['data']);
+          this.simulationService.storeSimulation(data['data']);
         });
     }
   }

--- a/biosimulations/apps/dispatch/src/app/datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/datamodel.ts
@@ -1,0 +1,17 @@
+export enum SimulationStatus {
+  queued = 'queued',
+  started = 'started',
+  succeeded = 'succeeded',
+  failed = 'failed',
+}
+
+export interface Simulation {
+  id: string;
+  name: string;
+  email?: string;
+  submittedLocally?: boolean;
+  status: SimulationStatus;
+  runtime?: number;
+  submitted: Date;
+  updated: Date;  
+}

--- a/biosimulations/apps/dispatch/src/app/services/simulation/simulation.service.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/services/simulation/simulation.service.spec.ts
@@ -1,0 +1,24 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient, HttpHandler } from '@angular/common/http';
+import { IonicStorageModule } from '@ionic/storage';
+import { SimulationService } from './simulation.service';
+
+describe('SimulationService', () => {
+  let service: SimulationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [HttpClient, HttpHandler],
+      imports: [
+        IonicStorageModule.forRoot({
+          driverOrder: ['indexeddb', 'websql', 'localstorage']
+        }),
+      ],
+    });
+    service = TestBed.inject(SimulationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/biosimulations/apps/dispatch/src/app/services/simulation/simulation.service.ts
+++ b/biosimulations/apps/dispatch/src/app/services/simulation/simulation.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@angular/core';
+import { Simulation, SimulationStatus } from '../../datamodel';
+import { Storage } from '@ionic/storage';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, BehaviorSubject } from 'rxjs';
+import { urls } from '@biosimulations/config/common';
+import { environment } from '@biosimulations/shared/environments';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SimulationService {
+  private key = 'simulations';
+  private simulations: Simulation[] = [];  
+  private simulationIds: string[] = [];
+  private simulationsSubject = new BehaviorSubject<Simulation[]>(this.simulations);
+  public simulations$: Observable<Simulation[]> = this.simulationsSubject.asObservable();  
+
+  // TODO: connect with application configuration
+  static refreshIntervalLength = 5 * 60 * 1000; // 5 minutes
+  private refreshInterval!: number;
+
+  constructor(private storage: Storage, private httpClient: HttpClient) {
+    this.storage.ready().then(() => {
+      this.storage.keys().then((keys) => {
+        if (keys.includes(this.key)) {
+          this.storage.get(this.key).then((simulations): void => {
+            this.simulations = simulations;
+            this.simulationIds = simulations.map((simulation: Simulation) => simulation.id);
+            this.simulationsSubject.next(simulations);
+            this.updateSimulations();
+            this.refreshInterval = setInterval(() => this.updateSimulations(), SimulationService.refreshIntervalLength);
+          });
+        } else {
+          const simulations: Simulation[] = [];
+          this.simulations = simulations;
+          this.simulationIds = [];
+          this.simulationsSubject.next(simulations);
+          this.refreshInterval = setInterval(() => this.updateSimulations(), SimulationService.refreshIntervalLength);
+        }
+      });
+    });
+  }
+
+  storeSimulation(simulation: Simulation): void {    
+    if (this.simulationIds.includes(simulation.id)) {
+      return;
+    }
+
+    this.simulations.push(simulation);
+    this.simulationIds.push(simulation.id);
+    this.simulationsSubject.next(this.simulations);
+    this.storage.set(this.key, this.simulations);
+  }
+
+  updateSimulations(): void {
+    // no updates needed if no simulations
+    if (this.simulations.length === 0) {
+      return;
+    }
+
+    // no updates needed if no simulation is queued or running
+    let activeSimulation = false;
+    for (const simulation of this.simulations) {
+      if (simulation.status !== SimulationStatus.failed && simulation.status !== SimulationStatus.succeeded) {
+        activeSimulation = true;
+        break;
+      }
+    }
+    if (!activeSimulation) {
+      return;
+    }
+
+    // update status
+    // TODO: connect with API
+    const endpoint = `${urls.dispatchApi}/simulations`;
+    const ids = this.simulations.map((simulation: Simulation): string => {return simulation.id;}).join(',');
+
+    this.httpClient
+      .get(`${endpoint}?ids=${ids}`)
+      .subscribe(
+        (data: any) => {
+          this.setSimulations(data.data);
+        },
+        (error: HttpErrorResponse) => {
+          if (!environment.production) {
+            console.error('Unable to update simulations: ' + error.status.toString() + ': ' + error.message);
+          }
+        }
+      );
+  }
+
+  setSimulations(simulations: Simulation[], update = false): void {
+    this.simulations = simulations;
+    this.simulationIds = simulations.map((simulation: Simulation) => simulation.id);
+    this.simulationsSubject.next(simulations);
+    this.storage.set(this.key, simulations);
+
+    if (update) {
+      this.updateSimulations();
+    }
+  }
+
+  getSimulations(): Simulation[] {
+    return this.simulations;
+  }
+}

--- a/biosimulations/apps/platform/src/app/help/help-routing.module.ts
+++ b/biosimulations/apps/platform/src/app/help/help-routing.module.ts
@@ -15,7 +15,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -28,7 +28,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -41,7 +41,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -68,7 +68,7 @@ const routes: Routes = [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
             ]
         }
     },

--- a/biosimulations/apps/platform/src/app/models/browse-models/browse-models.component.scss
+++ b/biosimulations/apps/platform/src/app/models/browse-models/browse-models.component.scss
@@ -34,7 +34,7 @@ mat-paginator {
   align-items: start;
   .cell {
     overflow: hidden;
-    text-overflow: ellipsis;    
+    text-overflow: ellipsis;
     -webkit-line-clamp: 2;
     display: -webkit-box;
     -webkit-box-orient: vertical;

--- a/biosimulations/apps/simulators/src/app/app.component.scss
+++ b/biosimulations/apps/simulators/src/app/app.component.scss
@@ -1,6 +1,6 @@
 biosimulations-topbar-menu {
   padding-left: 0;
-  
+
   ::ng-deep biosimulations-topbar-menu-item {
     margin-left: 1rem;
   }

--- a/biosimulations/apps/simulators/src/app/help/help-routing.module.ts
+++ b/biosimulations/apps/simulators/src/app/help/help-routing.module.ts
@@ -15,7 +15,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -28,7 +28,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -41,7 +41,7 @@ const routes: Routes = [
             contextButtons: [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
                 {route: ['/help', 'privacy'], icon: 'policy', label: 'Privacy policy'},
             ]
         }
@@ -68,7 +68,7 @@ const routes: Routes = [
                 {route: ['/help'], icon: 'tutorial', label: 'Tutorial'},
                 {route: ['/help', 'faq'], icon: 'help', label: 'FAQ'},
                 {route: ['/help', 'about'], icon: 'info', label: 'About'},
-                {route: ['/help', 'terms'], icon: 'policy', label: 'Terms of service'},
+                {route: ['/help', 'terms'], icon: 'legal', label: 'Terms of service'},
             ]
         }
     },

--- a/biosimulations/apps/simulators/src/app/help/help/help.component.html
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.html
@@ -1,6 +1,6 @@
 <biosimulations-text-page heading="Tutorial">
   <ng-container id="sideBar">
-    <biosimulations-text-page-side-bar-section heading="Related resources">     
+    <biosimulations-text-page-side-bar-section heading="Related resources">
       <div class="hanging-indent">
         <a [href]="apiUrl" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -56,7 +56,7 @@
       shortHeading="Executing simulations"
     >
       <p>Two web applications are available for using the BioSimulators simulation tools to execute simulations. runBioSimulations <a href="https://submit.biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> is a simple application that uses BioSimulators to execute modeling studies. BioSimulations <a href="https://biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> is a platform for publishing modeling studies that also uses BioSimulators to executed published modeling studies.</p>
-        
+
       <p>The BioSimulators simulation tools can also be used to execute simulations on your own machine. Please follow these steps to use a containerized simulation tool to execute a modeling study on your own machine.</p>
 
       <ol class="vertically-spaced">
@@ -75,13 +75,13 @@
           <pre>docker run \
   --tty \
   --rm \
-  --mount type=bind,source={{ '{' }} path-to-directory-of-OMEX-file {{ '}' }},target=/tmp/project,readonly \
+  --mount type=bind,source={{ '{' }} path-to-directory-of-COMBINE-archive {{ '}' }},target=/tmp/project,readonly \
   --mount type=bind,source={{ '{' }} path-to-save-results {{ '}' }},target=/tmp/results \
   biosimulators/{{ '{' }} simulator-id {{ '}' }} \
-    --archive /tmp/project/{{ '{' }} name-of-OMEX-file {{ '}' }} \
+    --archive /tmp/project/{{ '{' }} name-of-COMBINE-archive {{ '}' }} \
     --out-dir /tmp/results</pre>
 
-          <p>Your OMEX file should be located at <code>path-to-directory-of-OMEX-file/name-of-OMEX-file</code>. This will save your results to <code>path-to-save-results</code>.</p>
+          <p>Your COMBINE archive should be located at <code>path-to-directory-of-COMBINE-archive/name-of-COMBINE-archive</code>. This will save your results to <code>path-to-save-results</code>.</p>
         </li>
       </ol>
     </biosimulations-text-page-content-section>
@@ -119,8 +119,22 @@
             <li>Set the <code>ENTRYPOINT</code> directive to the path to your command-line interface.</li>
             <li>Set the <code>CMD</code> directive to <code>[]</code>.</li>
             <li>
-              <p>Use the <code>LABEL</code> directive to describe basic metadata about your simulation tool. This metadata is necessary to also submit your container to BioContainers <a href="https://biocontainers.pro" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, a broad registry of containers for biological research. Below is an example of the metadata for the BioNetGen container.</p>
+              <p>Use the <code>LABEL</code> directive to provide the metadata about your simulation tool described below. This metadata is necessary to also submit your image to BioContainers <a href="https://biocontainers.pro" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, a broad registry of images for biological research.</p>
+              <ul>
+                <li><code>version</code>: the version of your image (e.g., <code>1.0.0</code>)</li>
+                <li><code>software</code>: the simulation program wrapped into your image (e.g., <code>BioNetGen</code>).</li>
+                <li><code>software.version</code>: the version of the simulation program wrapped into your image (e.g., <code>2.5.0</code>).</li>
+                <li><code>about.summary</code>: short description of the simulation tool (e.g., <code>Package for rule-based modeling of complex biochemical systems</code>).</li>
+                <li><code>about.home</code>: URL for the simulation tool (e.g., <code>https://bionetgen.org/</code>).</li>
+                <li><code>about.documentation</code>: URL for documentation for the simulation program (e.g., <code>https://bionetgen.org/</code>).</li>
+                <li><code>about.license_file</code>: URL for the license for the simulation program (e.g., <code>https://github.com/RuleWorld/bionetgen/blob/master/LICENSE</code>).</li>
+                <li><code>about.license</code>: SPDX license id for the license for the simulation program (e.g., <code>SPDX:MIT</code>). See SPDX <a href="https://spdx.dev/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for a list of licenses and their ids.</li>
+                <li><code>about.tags</code>: comma-separated list of tags which describe the simulation tool (e.g., <code>rule-based modeling,dynamical simulation,systems biology,BNGL,BioSimulators</code>). Plese include the tag <code>BioSimulators</code>.</li>
+                <li><code>extra.identifiers.biotools</code>: optionally, the bio.tools identifier for the simulation program (e.g., <code>bionetgen</code>). Visit bio.tools <a href="https://bio.tools/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> to request an identifier for your simulation program.</li>
+                <li><code>maintainer</code>: the name and email of the person/team who developed the image (e.g., <code>Jonathan Karr &lt;karr@mssm.edu&gt;</code>).</li>
+              </ul>
 
+              <p>Below is an example of metadata for the BioNetGen image.</p>
               <pre>LABEL base_image="ubuntu:18.04"
 LABEL version="1.0.0"
 LABEL software="BioNetGen"
@@ -130,7 +144,7 @@ LABEL about.home="https://bionetgen.org/"
 LABEL about.documentation="https://bionetgen.org/"
 LABEL about.license_file="https://github.com/RuleWorld/bionetgen/blob/master/LICENSE"
 LABEL about.license="SPDX:MIT"
-LABEL about.tags="rule-based modeling,dynamical simulation,systems biology,BNGL"
+LABEL about.tags="rule-based modeling,dynamical simulation,systems biology,BNGL,BioSimulators"
 LABEL extra.identifiers.biotools="bionetgen"
 LABEL maintainer="Jonathan Karr &lt;karr@mssm.edu&gt;"
 </pre>
@@ -168,7 +182,10 @@ biosimulators-test-suite validate {{ '{' }} dockerhub-user-id {{ '}' }}/{{ '{' }
           <b>Submit an issue <a href="https://github.com/biosimulations/Biosimulations/issues/new/choose" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a></b> that describes briefly describes your tool and the URL for the Docker image for your tool.
         </li>
         <li>
-          <b>Optionally, also submit your containerized tool to BioContainers.</b> BioContainers accepts contributions via pull requests. See the BioContainers containers repository <a href="https://github.com/BioContainers/containers/pulls" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information.
+          <b>Optionally, also register your tool with bio.tools.</b> Visit bio.tools <a href="https://bio.tools" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> to submit your tool to their regsitry of research tools.
+        </li>
+        <li>
+          <b>Optionally, also submit your Dockerfile to BioContainers.</b> BioContainers accepts contributions via pull requests. See the BioContainers image registry <a href="https://github.com/BioContainers/containers/pulls" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information.
         </li>
       </ol>
     </biosimulations-text-page-content-section>

--- a/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.scss
@@ -1,0 +1,5 @@
+biosimulations-table {
+  ::ng-deep a:first-child {
+    margin-right: 0.25rem;
+  }
+}

--- a/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.ts
@@ -178,8 +178,8 @@ export class BrowseSimulatorsComponent implements AfterViewInit {
     {
       id: 'moreInfo',
       heading: "More info",
-      leftIcon: 'link',
-      rightIcon: 'internalLink',
+      leftIcon: 'internalLink',
+      rightIcon: 'link',
       leftIconTitle: (element: Simulator): string => {
         return element.name + ' image';
       },

--- a/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/browse-simulators/browse-simulators.component.ts
@@ -41,18 +41,18 @@ export class BrowseSimulatorsComponent implements AfterViewInit {
 
   columns: Column[] = [
     {
+      id: 'id',
+      heading: "Id",
+      key: 'id',
+      filterable: false,
+      minWidth: 90,
+    },
+    {
       id: 'name',
       heading: "Name",
       key: 'name',
-      rightIcon: 'link',
-      iconTitle: (element: Simulator): string => {
-        return element.name;
-      },
-      linkType: ColumnLinkType.href,
-      href: (element: Simulator): string => {
-        return element.url;
-      },
-      filterable: false
+      filterable: false,
+      minWidth: 90,
     },
     {
       id: 'frameworks',
@@ -120,7 +120,7 @@ export class BrowseSimulatorsComponent implements AfterViewInit {
         return false;
       },
       filterComparator: TableComponent.comparator,
-      minWidth: 300,
+      minWidth: 250,
     },
     {
       id: 'formats',
@@ -178,11 +178,22 @@ export class BrowseSimulatorsComponent implements AfterViewInit {
     {
       id: 'moreInfo',
       heading: "More info",
-      linkType: ColumnLinkType.routerLink,
-      routerLink: (element: any): string[] => {
+      leftIcon: 'link',
+      rightIcon: 'internalLink',
+      leftIconTitle: (element: Simulator): string => {
+        return element.name + ' image';
+      },
+      rightIconTitle: (element: Simulator): string => {
+        return element.name + ' website';
+      },
+      leftLinkType: ColumnLinkType.routerLink,
+      rightLinkType: ColumnLinkType.href,
+      leftRouterLink: (element: any): string[] => {
         return ['/simulators', element.id];
       },
-      leftIcon: 'internalLink',
+      rightHref: (element: Simulator): string => {
+        return element.url;
+      },
       minWidth: 66,
       center: true,
       filterable: false,
@@ -200,7 +211,7 @@ export class BrowseSimulatorsComponent implements AfterViewInit {
     this.table.defaultSort = {active: 'name', direction: 'asc'};
 
     setTimeout(() => {
-      
+
 
       this.data = SimulatorService.data.map((simulator: any): Simulator => {
         const frameworks = new Set();

--- a/biosimulations/apps/simulators/src/app/simulators/simulator.service.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/simulator.service.ts
@@ -388,6 +388,7 @@ export class SimulatorService {
           parameters: [
             {
               kisaoId: {ontology: 'KISAO', id: "0000209"},
+              id: 'rTol',
               name: "Relative tolerance",
               type: AlgorithmParameterType.float,
               value: 0.000001,
@@ -395,48 +396,56 @@ export class SimulatorService {
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000211"},
+              id: 'aTol',
               name: "Absolute tolerance",
               type: AlgorithmParameterType.float,
               value: 1e-12
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000220"},
+              id: 'bdfOrder',
               name: "Maximum Backward Differentiation Formula (BDF) order",
               type: AlgorithmParameterType.integer,
               value: 5
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000219"},
+              id: 'adamsOrder',
               name: "Maximum Adams order",
               type: AlgorithmParameterType.integer,
               value: 12
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000415"},
+              id: 'nSteps',
               name: "Maximum number of steps",
               type: AlgorithmParameterType.integer,
               value: 20000
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000467"},
+              id: 'maxStep',
               name: "Maximum time step",
               type: AlgorithmParameterType.float,
               value: 0
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000485"},
+              id: 'minStep',
               name: "Minimum time step",
               type: AlgorithmParameterType.float,
               value: 0
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000332"},
+              id: 'firstStep',
               name: "Initial time step",
               type: AlgorithmParameterType.float,
               value: 0
             },
             {
               kisaoId: {ontology: 'KISAO', id: "0000107"},
+              id: 'adaptiveSteps',
               name: "Adaptive time steps",
               type: AlgorithmParameterType.boolean,
               value: false

--- a/biosimulations/apps/simulators/src/app/simulators/simulators-routing.module.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/simulators-routing.module.ts
@@ -12,6 +12,12 @@ const routes: Routes = [
   {
     path: ':id',
     component: ViewSimulatorComponent,
+    children: [
+      {
+        path: ':version',
+        component: ViewSimulatorComponent,
+      },
+    ]
   },
 ];
 

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -26,7 +26,7 @@
       <div class="border">
         <div class="section">
           <h3>Docker pull command</h3>
-          <div class="section-content">
+          <div class="section-content code">
             docker pull {{ image }}
           </div>
         </div>
@@ -63,7 +63,7 @@
 
       <ng-container id="content">
         <biosimulations-text-page-content-section *ngFor="let algorithm of algorithms"
-          [heading]="algorithm.name + ' (KISAO:' + algorithm.id + ')'"
+          [heading]="algorithm.heading"
           [shortHeading]="algorithm.name"
         >
           <p class="subsection-heading no-bottom-margin">Description</p>
@@ -208,7 +208,7 @@
       <div class="border">
         <div class="section">
           <h3>Docker pull command</h3>
-          <div class="section-content">
+          <div class="section-content code">
             docker pull {{ '{' }}  image-url {{ '}' }}
           </div>
         </div>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -1,167 +1,232 @@
 <biosimulations-tab-page [loading]="loading$ | async">
-  <biosimulations-tab-page-tab heading="Overview" icon="overview">
+  <biosimulations-tab-page-tab heading="Overview" icon="overview" [partialWidth]="true">
     <div class="overview grid">
       <div>
-        <h2>{{ id }}: {{ name }}</h2>    
-            <p>
-                {{ description }}
-            </p>
+        <h2>{{ name }} ({{ id }} / {{ version }})</h2>
+        <p>
+          {{ description }}
+        </p>
 
-            <table class="icon-list">
-                <tbody>
-                    <tr>
-                        <th><biosimulations-icon icon="docker"></biosimulations-icon></th>
-                        <td><a [href]="image" target="_blank">{{ image }}</a></td>
-                    </tr>
-                    <tr>
-                        <th><biosimulations-icon icon="link"></biosimulations-icon></th>
-                        <td><a [href]="url" target="_blank">{{ url }}</a></td>
-                    </tr>
-                    <tr>
-                        <th><biosimulations-icon icon="legal"></biosimulations-icon></th>
-                        <td><a [href]="licenseUrl" target="_blank">{{ licenseName }}</a></td>
-                    </tr>
-                    <tr>
-                        <th><biosimulations-icon icon="user"></biosimulations-icon></th>
-                        <td>{{ authors }}</td>
-                    </tr>
-                </tbody>
+        <table class="icon-list">
+          <tbody>
+            <tr>
+              <th><biosimulations-icon icon="user"></biosimulations-icon></th>
+              <td>{{ authors }}</td>
+            </tr>
+          </tbody>
 
-                <tbody class="citations">
-                    <tr *ngFor="let citation of citations">
-                        <th><biosimulations-icon icon="tutorial"></biosimulations-icon></th>
-                        <td><a [href]="citation.url" target="_blank" [innerHTML]="citation.text"></a></td>
-                    </tr>
-                </tbody>
-            </table>    
+          <tbody class="citations">
+            <tr *ngFor="let citation of citations">
+              <th><biosimulations-icon icon="tutorial"></biosimulations-icon></th>
+              <td><a [href]="citation.url" target="_blank" [innerHTML]="citation.text"></a></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="border">
+        <div class="section">
+          <h3>Docker pull command</h3>
+          <div class="section-content">
+            docker pull {{ image }}
+          </div>
         </div>
-        <div>
-            <p class="subsection-heading">Docker pull command</p>
-            <pre>docker pull {{ image }}</pre>
+
+        <div class="section">
+          <h3>License</h3>
+          <div class="section-content">
+            <p>{{ licenseName }} <a [href]="licenseUrl" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a></p>
+          </div>
         </div>
-    </div>
-  </biosimulations-tab-page-tab>
 
-  <biosimulations-tab-page-tab heading="Algorithms" icon="simulator" class="algorithms">
-    <div *ngFor="let algorithm of algorithms" class="section algorithm">
-      <h2>{{ algorithm.id}}: {{ algorithm.name }}</h2>
-      <div class="section-content">
-        <p class="subsection-heading no-bottom-margin">Description</p>
-        <p>{{ algorithm.description }}</p>
-
-        <p class="subsection-heading no-bottom-margin">Modeling frameworks</p>
-        <ul class="icon-list">
-            <li *ngFor="let framework of algorithm.frameworks">
-                <biosimulations-icon icon="simulator"></biosimulations-icon>            
-                <a [href]="framework.url" target="_blank">{{ framework.name }}</a>
-            </li>
-        </ul>
-
-        <p class="subsection-heading no-bottom-margin">Model formats</p>
-        <ul class="icon-list">
-            <li *ngFor="let format of algorithm.formats">
-                <biosimulations-icon icon="format"></biosimulations-icon>            
-                <a [href]="format.url" target="_blank">{{ format.name }}</a>
-            </li>
-        </ul>
-
-        <p class="subsection-heading no-bottom-margin">Citations</p>
-        <ul class="icon-list">
-            <li *ngFor="let citation of algorithm.citations">
-                <biosimulations-icon icon="tutorial"></biosimulations-icon>
-                <a [href]="citation.url" target="_blank" [innerHTML]="citation.text"></a>
-            </li>
-        </ul>
-
-        <p class="subsection-heading no-bottom-margin">Parameters</p>
-        <mat-table [dataSource]="algorithm.parameters" class="algorithm-parameters">          
-          <ng-container matColumnDef="id">
-            <mat-header-cell *matHeaderCellDef>Id</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                {{ parameter.id }}
-            </div>
-            </mat-cell>
-          </ng-container>
-          <ng-container matColumnDef="name">
-            <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                {{ parameter.name }}
-            </div>
-            </mat-cell>
-          </ng-container>
-          <ng-container matColumnDef="type">
-            <mat-header-cell *matHeaderCellDef>Type</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                {{ parameter.type }}
-            </div>
-            </mat-cell>
-          </ng-container>
-          <ng-container matColumnDef="value">
-            <mat-header-cell *matHeaderCellDef>Value</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                {{ parameter.value }}
-            </div>
-            </mat-cell>
-          </ng-container>
-          <ng-container matColumnDef="range">
-            <mat-header-cell *matHeaderCellDef>Recommended range</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                {{ parameter.range }}
-            </div>
-            </mat-cell>
-          </ng-container>
-          <ng-container matColumnDef="kisaoId">
-            <mat-header-cell *matHeaderCellDef>KiSAO id</mat-header-cell>
-            <mat-cell *matCellDef="let parameter">
-              <div class="cell-content-container lines-one">
-                KISAO:{{ parameter.kisaoId }}
-                <a *ngIf="parameter.kisaoUrl" [href]="parameter.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
-            </div>
-            </mat-cell>
-          </ng-container>
-
-          <mat-header-row *matHeaderRowDef="parameterColumns; sticky: true"></mat-header-row>
-          <mat-row *matRowDef="let row; columns: parameterColumns"></mat-row>
-        </mat-table>
+        <div class="section">
+          <h3>More info</h3>
+          <div class="section-content">
+            <p>{{ url }} <a [href]="url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a></p>
+          </div>
+        </div>
       </div>
     </div>
   </biosimulations-tab-page-tab>
 
-  <biosimulations-tab-page-tab heading="Versions" icon="version">
-    <mat-table [dataSource]="versions" class="versions">
-      <ng-container matColumnDef="label">
-        <mat-header-cell *matHeaderCellDef>Version</mat-header-cell>
-        <mat-cell *matCellDef="let version">
-          <div class="cell-content-container lines-one">
-            {{ version.label }}
-        </div>
-        </mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="date">
-        <mat-header-cell *matHeaderCellDef>Date</mat-header-cell>
-        <mat-cell *matCellDef="let version">
-          <div class="cell-content-container lines-one">
-            {{ version.date }}
-        </div>
-        </mat-cell>
-      </ng-container>
-      <ng-container matColumnDef="image">
-        <mat-header-cell *matHeaderCellDef>Image</mat-header-cell>
-        <mat-cell *matCellDef="let version">
-          <div class="cell-content-container lines-one">
-            {{ version.image }}
-            <a *ngIf="version.url" [href]="version.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
+  <biosimulations-tab-page-tab heading="Algorithms" icon="simulator" class="algorithms">
+    <biosimulations-text-page contentsHeading="Algorithms" [padded]="false" alwaysFixed="calc(64px + 32px + 32px + 2rem)">
+      <ng-container id="sideBar">
+        <biosimulations-text-page-side-bar-section heading="More info">
+          <div class="hanging-indent">
+            <a [href]="url" target="_blank">
+              <biosimulations-icon icon="link"></biosimulations-icon>
+              Documentation
+            </a>
           </div>
-        </mat-cell>
+        </biosimulations-text-page-side-bar-section>
       </ng-container>
 
-      <mat-header-row *matHeaderRowDef="versionColumns; sticky: true"></mat-header-row>
-      <mat-row *matRowDef="let row; columns: versionColumns"></mat-row>
-    </mat-table>
+      <ng-container id="content">
+        <biosimulations-text-page-content-section *ngFor="let algorithm of algorithms"
+          [heading]="algorithm.name + ' (KISAO:' + algorithm.id + ')'"
+          [shortHeading]="algorithm.name"
+        >
+          <p class="subsection-heading no-bottom-margin">Description</p>
+          <p>
+            <ng-template ngFor let-fragment [ngForOf]="algorithm.description">
+              <span *ngIf="fragment.type == 'text'; else descriptionLink">
+                {{ fragment.value }}
+              </span>
+              <ng-template #descriptionLink>
+                <a [href]="fragment.value"><biosimulations-icon icon="link"></biosimulations-icon></a>
+              </ng-template>
+            </ng-template>
+          </p>
+
+          <p class="subsection-heading no-bottom-margin">Modeling frameworks</p>
+          <ul class="icon-list">
+              <li *ngFor="let framework of algorithm.frameworks">
+                  <biosimulations-icon icon="simulator"></biosimulations-icon>
+                  <a [href]="framework.url" target="_blank">{{ framework.name }}</a>
+              </li>
+          </ul>
+
+          <p class="subsection-heading no-bottom-margin">Model formats</p>
+          <ul class="icon-list">
+              <li *ngFor="let format of algorithm.formats">
+                  <biosimulations-icon icon="format"></biosimulations-icon>
+                  <a [href]="format.url" target="_blank">{{ format.name }}</a>
+              </li>
+          </ul>
+
+          <p class="subsection-heading no-bottom-margin">Parameters</p>
+          <mat-table [dataSource]="algorithm.parameters" class="algorithm-parameters">
+            <ng-container matColumnDef="id">
+              <mat-header-cell *matHeaderCellDef>Id</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.id }}
+              </div>
+              </mat-cell>
+            </ng-container>
+            <ng-container matColumnDef="name">
+              <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.name }}
+              </div>
+              </mat-cell>
+            </ng-container>
+            <ng-container matColumnDef="type">
+              <mat-header-cell *matHeaderCellDef>Type</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.type }}
+              </div>
+              </mat-cell>
+            </ng-container>
+            <ng-container matColumnDef="value">
+              <mat-header-cell *matHeaderCellDef>Value</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.value }}
+              </div>
+              </mat-cell>
+            </ng-container>
+            <ng-container matColumnDef="range">
+              <mat-header-cell *matHeaderCellDef>Recommended range</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.range }}
+              </div>
+              </mat-cell>
+            </ng-container>
+            <ng-container matColumnDef="kisaoId">
+              <mat-header-cell *matHeaderCellDef>KiSAO id</mat-header-cell>
+              <mat-cell *matCellDef="let parameter">
+                <div class="cell-content-container lines-one">
+                  {{ parameter.kisaoId }}
+                  <a *ngIf="parameter.kisaoUrl" [href]="parameter.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
+              </div>
+              </mat-cell>
+            </ng-container>
+
+            <mat-header-row *matHeaderRowDef="parameterColumns; sticky: true"></mat-header-row>
+            <mat-row *matRowDef="let row; columns: parameterColumns"></mat-row>
+          </mat-table>
+
+          <p class="subsection-heading no-bottom-margin">Citations</p>
+          <ul class="icon-list">
+              <li *ngFor="let citation of algorithm.citations">
+                  <biosimulations-icon icon="tutorial"></biosimulations-icon>
+                  <a [href]="citation.url" target="_blank" [innerHTML]="citation.text"></a>
+              </li>
+          </ul>
+
+          <p class="subsection-heading no-bottom-margin">More info</p>
+          <ul class="icon-list">
+              <li>
+                  <biosimulations-icon icon="link"></biosimulations-icon>
+                  <a [href]="algorithm.url" target="_blank">KISAO:{{ algorithm.id }}</a>
+              </li>
+          </ul>
+        </biosimulations-text-page-content-section>
+      </ng-container>
+    </biosimulations-text-page>
+  </biosimulations-tab-page-tab>
+
+  <biosimulations-tab-page-tab heading="Versions" icon="version" [partialWidth]="true">
+    <div class="grid">
+      <div>
+        <mat-table [dataSource]="versions" class="versions">
+          <ng-container matColumnDef="label">
+            <mat-header-cell *matHeaderCellDef>Version</mat-header-cell>
+            <mat-cell *matCellDef="let aVersion">
+              <div class="cell-content-container lines-one">
+                {{ aVersion.label }}
+                <a [routerLink]="['/simulators', id, aVersion.label]"><biosimulations-icon icon="internalLink"></biosimulations-icon></a>
+            </div>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="date">
+            <mat-header-cell *matHeaderCellDef>Date</mat-header-cell>
+            <mat-cell *matCellDef="let aVersion">
+              <div class="cell-content-container lines-one">
+                {{ aVersion.date }}
+            </div>
+            </mat-cell>
+          </ng-container>
+          <ng-container matColumnDef="image">
+            <mat-header-cell *matHeaderCellDef>Image</mat-header-cell>
+            <mat-cell *matCellDef="let aVersion">
+              <div class="cell-content-container lines-one">
+                {{ aVersion.image }}
+                <a *ngIf="aVersion.url" [href]="aVersion.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
+              </div>
+            </mat-cell>
+          </ng-container>
+
+          <mat-header-row *matHeaderRowDef="versionColumns; sticky: true"></mat-header-row>
+          <mat-row *matRowDef="let aVersion; columns: versionColumns" [ngClass]="{'highlight-row': aVersion.label === version}"></mat-row>
+        </mat-table>
+      </div>
+      <div class="border">
+        <div class="section">
+          <h3>Docker pull command</h3>
+          <div class="section-content">
+            docker pull {{ '{' }}  image-url {{ '}' }}
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>License</h3>
+          <div class="section-content">
+            <p>{{ licenseName }} <a [href]="licenseUrl" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a></p>
+          </div>
+        </div>
+
+        <div class="section">
+          <h3>More info</h3>
+          <div class="section-content">
+            <p>{{ url }} <a [href]="url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a></p>
+          </div>
+        </div>
+      </div>
+    </div>
   </biosimulations-tab-page-tab>
 </biosimulations-tab-page>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
@@ -70,3 +70,9 @@
     }
   }
 }
+
+.code {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
@@ -27,7 +27,7 @@
 }
 
 .grid > *:last-child {
-    padding: 0.5rem 0.5rem 0 0.5rem;
+    padding: 0.5rem 0.5rem 0;
 }
 
 .citations tr:first-child {

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
@@ -1,17 +1,33 @@
+@import 'biosimulations-colors';
 @import 'biosimulations-typography';
 
 ::ng-deep .mat-typography {
     h2, h3 {
         margin: 0;
     }
+
+    h3 {
+        padding-left: 0.5rem;
+        padding-right: 0.5rem;
+        border-radius: 4px;
+        background: $light-background;
+    }
+}
+
+.section:not(:last-child) {
+    margin-bottom: 1rem;
 }
 
 .subsection-heading {
     font-weight: bold;
 }
 
-.overview.grid {
-    grid-template-columns: 1fr 35rem;
+.grid {
+    grid-template-columns: 1fr 25rem;
+}
+
+.grid > *:last-child {
+    padding: 0.5rem 0.5rem 0 0.5rem;
 }
 
 .citations tr:first-child {
@@ -20,21 +36,37 @@
     }
 }
 
-.algorithm:not(:last-child) {
-    margin-bottom: 2rem;
+.algorithm-parameters {
+    .mat-header-cell {
+        white-space: nowrap;
+    }
+
+    .mat-header-cell:nth-child(1),
+    .mat-header-cell:nth-child(3),
+    .mat-header-cell:nth-child(4),
+    .mat-header-cell:nth-child(6),
+    .mat-cell:nth-child(1),
+    .mat-cell:nth-child(3),
+    .mat-cell:nth-child(4),
+    .mat-cell:nth-child(6) {
+        flex: 0.75;
+    }
 }
 
 .versions {
-    max-width: 600px;
-
     .mat-header-cell:nth-child(1),
     .mat-header-cell:nth-child(2),
     .mat-cell:nth-child(1),
     .mat-cell:nth-child(2) {
         flex: 0.3;
     }
+}
 
-    a {
-        margin-left: 0.5rem;
+.icon-list {
+  a {
+    color: $dark-primary-text;
+    &:hover {
+      color: mat-color($theme-primary);
     }
+  }
 }

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.ts
@@ -16,6 +16,7 @@ const spdxTerms = spdxJson as { [id: string]: {name: string, url: string}};
 
 interface Algorithm {
   id: string;
+  heading: string;
   name: string;
   description: DescriptionFragment[];
   url: string;
@@ -158,6 +159,7 @@ export class ViewSimulatorComponent implements OnInit {
         this.algorithms = simulator.algorithms.map((algorithm): Algorithm => {
           return {
             id: algorithm.kisaoId.id,
+            heading: kisaoTerms[algorithm.kisaoId.id].name + ' (KISAO:' + algorithm.kisaoId.id + ')',
             name: kisaoTerms[algorithm.kisaoId.id].name,
             description: this.formatKisaoDescription(kisaoTerms[algorithm.kisaoId.id].description),
             url: kisaoTerms[algorithm.kisaoId.id].url,

--- a/biosimulations/libs/platform/view/src/lib/resource-home/resource-home.component.html
+++ b/biosimulations/libs/platform/view/src/lib/resource-home/resource-home.component.html
@@ -1,4 +1,4 @@
-<div class="partial-width">
+<div class="partial-width padded">
   <div class="section banner">
     <img [src]="imageUrl" />
     <h1>{{ pluralName }}</h1>

--- a/biosimulations/libs/shared/icons/src/lib/icon/icon.component.ts
+++ b/biosimulations/libs/shared/icons/src/lib/icon/icon.component.ts
@@ -39,6 +39,7 @@ export type biosimulationsIcon =
   | 'overview'
   | 'report'
   | 'download'
+  | 'upload'
   | 'logs'
   | 'compare'
   | 'filter'
@@ -125,6 +126,7 @@ export class IconComponent implements OnInit {
     overview: { type: 'fas', name: 'list' },
     report: { type: 'fas', name: 'table' },
     download: { type: 'fas', name: 'download' },
+    upload: { type: 'fas', name: 'upload' },
     logs: { type: 'fas', name: 'terminal' },
     compare: { type: 'mat', name: 'stacked_line_chart' },
     filter: { type: 'fas', name: 'filter' },

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -111,8 +111,8 @@ ul.icon-list {
   }
 
   li {
-    margin-left: calc(20px + 0.25rem);
-    text-indent: calc(-1 * (20px + 0.25rem));
+    margin-left: calc(12px + 0.25rem);
+    text-indent: calc(-1 * (12px + 0.25rem));
   }
 
   a {
@@ -346,6 +346,10 @@ table {
     min-height: 28px;
   }
 
+  .highlight-row {
+    background: mat-color($theme-primary, lightest);
+  }
+
   .mat-cell, .mat-header-cell {
     color: $dark-primary-text;
     @include mat-typography-level-to-styles($fontConfig, body-1);
@@ -400,7 +404,10 @@ table {
 
 /* section */
 .section-content {
-  border: 1px solid $light-bg-darker-5;
-  border-radius: 4px;
   padding: 0.5rem;
+}
+
+.border {
+  border: 1px solid $light-bg-darker-5;
+  border-radius: 4px;  
 }

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -283,7 +283,7 @@ code {
 }
 
 code, pre {
-  font-size: 90%;  
+  font-size: 90%;
   background: $light-background;
 }
 
@@ -414,5 +414,5 @@ table {
 
 .border {
   border: 1px solid $light-bg-darker-5;
-  border-radius: 4px;  
+  border-radius: 4px;
 }

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -17,7 +17,6 @@ body {
   max-width: 1200px;
   margin-left: auto;
   margin-right: auto;
-  padding: 2rem;
   overflow: auto;
 }
 

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -283,7 +283,12 @@ code {
 }
 
 code, pre {
+  font-size: 90%;  
   background: $light-background;
+}
+
+.code {
+  font-family: monospace;
 }
 
 /* range slider */

--- a/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
@@ -10,8 +10,8 @@
 
   ::ng-deep .mat-drawer-inner-container {
     overflow: hidden;
-  }  
-  
+  }
+
   ::ng-deep .mat-toolbar {
     justify-content: center;
   }

--- a/biosimulations/libs/shared/ui/src/lib/home/home-teaser.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-teaser.component.scss
@@ -25,9 +25,8 @@ img {
   text-align: center;
 }
 
-.text {
-  padding-top: 0;
-  padding-bottom: 0;
+.text {  
+  padding: 0 2rem;
   font-size: 18px;
   line-height: 150%;
   text-align: center;

--- a/biosimulations/libs/shared/ui/src/lib/home/home-teaser.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-teaser.component.scss
@@ -25,7 +25,7 @@ img {
   text-align: center;
 }
 
-.text {  
+.text {
   padding: 0 2rem;
   font-size: 18px;
   line-height: 150%;

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.html
@@ -1,4 +1,9 @@
 <div class="partial-width" [ngClass]="{'padded': padded}">
-  <h1 *ngIf="heading">{{ heading }}</h1>
+  <h1 *ngIf="heading">
+    {{ heading }}
+    <div class="buttons">
+      <ng-content select="#buttons"></ng-content>
+    </div>
+  </h1>
   <ng-content></ng-content>
 </div>

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.html
@@ -1,4 +1,4 @@
-<div class="partial-width padded">
-  <h1>{{ heading }}</h1>
+<div class="partial-width" [ngClass]="{'padded': padded}">
+  <h1 *ngIf="heading">{{ heading }}</h1>
   <ng-content></ng-content>
 </div>

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.html
@@ -1,4 +1,4 @@
-<div class="partial-width">
+<div class="partial-width padded">
   <h1>{{ heading }}</h1>
   <ng-content></ng-content>
 </div>

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.scss
@@ -1,3 +1,18 @@
 h1 {
   margin: 0 0 2rem;
+
+  .buttons {
+    float: right;
+    margin-top: -0.125rem;
+
+    ::ng-deep .mat-icon-button {
+      width: auto;
+      height: auto;
+      font-size: 85%;
+
+      &:not(:first-child) {
+        margin-left: 0.5rem;
+      }
+    }
+  }
 }

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.ts
@@ -12,5 +12,8 @@ export class PageComponent {
   @Input()
   heading = '';
 
+  @Input()
+  padded = true;
+
   constructor() {}
 }

--- a/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page-tab.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page-tab.component.html
@@ -4,5 +4,7 @@
     {{ heading }}
   </ng-template>
 
-  <ng-content></ng-content>
+  <div [ngClass]="{'partial-width': partialWidth}">
+    <ng-content></ng-content>
+  </div>
 </mat-tab>

--- a/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page-tab.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page-tab.component.ts
@@ -14,6 +14,9 @@ export class TabPageTabComponent {
   icon!: string;
 
   @Input()
+  partialWidth = false;
+
+  @Input()
   disabled = false;
 
   @ViewChild(MatTab) tab!: MatTab;

--- a/biosimulations/libs/shared/ui/src/lib/table/table.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/table/table.component.html
@@ -115,7 +115,7 @@
             'min-width.em': column.minWidth !== undefined ? column.minWidth / 14 : null
           }"
         >
-          <div [ngSwitch]="column.linkType" class="cell-content-container"
+          <div class="cell-content-container"
             [ngClass]="{
               'lines-one': linesPerRow === 1,
               'lines-multiple': linesPerRow > 1,
@@ -126,43 +126,51 @@
               'height.px': 20 * linesPerRow
             }">
 
-            <ng-template #iconTemplate let-icon="icon">
-              <biosimulations-icon *ngIf="icon" [icon]="icon" [title]="getIconTitle(element, column)"></biosimulations-icon>
-            </ng-template>
+            <span [ngSwitch]="column.leftLinkType">
+              <ng-template [ngSwitchCase]="'routerLink'">
+                <a *ngIf="getElementRouterLink(element, column, 'left') as routerLink" [routerLink]="routerLink">
+                  <ng-container *ngTemplateOutlet="leftIconTemplate; context: {icon: column.leftIcon}"></ng-container>
+                </a>
+              </ng-template>
 
-            <ng-template [ngSwitchCase]="'routerLink'">
-              <a *ngIf="getElementRouterLink(element, column) as routerLink" [routerLink]="routerLink">
-                <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.leftIcon}"></ng-container>
-              </a>
-            </ng-template>
+              <ng-template [ngSwitchCase]="'href'">
+                <a *ngIf="getElementHref(element, column, 'left') as href" [href]="href" target="_blank" >
+                  <ng-container *ngTemplateOutlet="leftIconTemplate; context: {icon: column.leftIcon}"></ng-container>
+                </a>
+              </ng-template>
 
-            <ng-template [ngSwitchCase]="'href'">
-              <a *ngIf="getElementHref(element, column) as href" [href]="href" target="_blank" >
-                <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.leftIcon}"></ng-container>
-              </a>
-            </ng-template>
+              <ng-template ngSwitchDefault>
+                <ng-container *ngTemplateOutlet="leftIconTemplate; context: {icon: column.leftIcon}"></ng-container>
+              </ng-template>
 
-            <ng-template ngSwitchDefault>
-              <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.leftIcon}"></ng-container>
-            </ng-template>
+              <ng-template #leftIconTemplate let-icon="icon">
+                <biosimulations-icon *ngIf="icon" [icon]="icon" [title]="getIconTitle(element, column, 'left')"></biosimulations-icon>
+              </ng-template>
+            </span>
 
             {{ formatElementValue(getElementValue(element, column), column) }}
 
-            <ng-template [ngSwitchCase]="'routerLink'">
-              <a *ngIf="getElementRouterLink(element, column) as routerLink" [routerLink]="routerLink">
-                <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.rightIcon}"></ng-container>
-              </a>
-            </ng-template>
+            <span [ngSwitch]="column.rightLinkType">
+              <ng-template [ngSwitchCase]="'routerLink'">
+                <a *ngIf="getElementRouterLink(element, column, 'right') as routerLink" [routerLink]="routerLink">
+                  <ng-container *ngTemplateOutlet="rightIconTemplate; context: {icon: column.rightIcon}"></ng-container>
+                </a>
+              </ng-template>
 
-            <ng-template [ngSwitchCase]="'href'">
-              <a *ngIf="getElementHref(element, column) as href" [href]="href" target="_blank" >
-                <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.rightIcon}"></ng-container>
-              </a>
-            </ng-template>
+              <ng-template [ngSwitchCase]="'href'">
+                <a *ngIf="getElementHref(element, column, 'right') as href" [href]="href" target="_blank" >
+                  <ng-container *ngTemplateOutlet="rightIconTemplate; context: {icon: column.rightIcon}"></ng-container>
+                </a>
+              </ng-template>
 
-            <ng-template ngSwitchDefault>
-              <ng-container *ngTemplateOutlet="iconTemplate; context: {icon: column.rightIcon}"></ng-container>
-            </ng-template>
+              <ng-template ngSwitchDefault>
+                <ng-container *ngTemplateOutlet="rightIconTemplate; context: {icon: column.rightIcon}"></ng-container>
+              </ng-template>
+
+              <ng-template #rightIconTemplate let-icon="icon">
+                <biosimulations-icon *ngIf="icon" [icon]="icon" [title]="getIconTitle(element, column, 'right')"></biosimulations-icon>
+              </ng-template>
+            </span>
           </div>
         </mat-cell>
       </ng-container>

--- a/biosimulations/libs/shared/ui/src/lib/table/table.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/table/table.component.ts
@@ -18,6 +18,11 @@ export enum ColumnFilterType {
   date = 'date',
 }
 
+export enum Side {
+  left = 'left',
+  right = 'right'
+}
+
 export interface Column {
   id: string;
   heading: string;
@@ -29,10 +34,14 @@ export interface Column {
   filterFormatter?: (cellValue: any) => any;
   leftIcon?: string;
   rightIcon?: string;
-  iconTitle?: (rowData: any) => string | null;
-  linkType?: ColumnLinkType;
-  routerLink?: (rowData: any) => any[] | null;
-  href?: (rowData: any) => string | null;
+  leftIconTitle?: (rowData: any) => string | null;
+  rightIconTitle?: (rowData: any) => string | null;
+  leftLinkType?: ColumnLinkType;
+  rightLinkType?: ColumnLinkType;
+  leftRouterLink?: (rowData: any) => any[] | null;
+  rightRouterLink?: (rowData: any) => any[] | null;
+  leftHref?: (rowData: any) => string | null;
+  rightHref?: (rowData: any) => string | null;
   minWidth?: number;
   center?: boolean;
   filterable?: boolean;
@@ -131,17 +140,21 @@ export class TableComponent implements OnInit, AfterViewInit {
     this.table.dataSource = this.dataSource;
   }
 
-  getElementRouterLink(element: any, column: Column): any {
-    if (column.linkType === ColumnLinkType.routerLink && column.routerLink !== undefined) {
-      return column.routerLink(element);
+  getElementRouterLink(element: any, column: Column, side: Side): any {
+    if (side == Side.left && column.leftLinkType === ColumnLinkType.routerLink && column.leftRouterLink !== undefined) {
+      return column.leftRouterLink(element);
+    } else if (side == Side.right && column.rightLinkType === ColumnLinkType.routerLink && column.rightRouterLink !== undefined) {
+      return column.rightRouterLink(element);
     } else {
       return null;
     }
   }
 
-  getElementHref(element: any, column: Column): any {
-    if (column.linkType === ColumnLinkType.href && column.href !== undefined) {
-      return column.href(element);
+  getElementHref(element: any, column: Column, side: Side): any {
+    if (side == Side.left && column.leftLinkType === ColumnLinkType.href && column.leftHref !== undefined) {
+      return column.leftHref(element);
+    } else if (side == Side.right && column.rightLinkType === ColumnLinkType.href && column.rightHref !== undefined) {
+      return column.rightHref(element);
     } else {
       return null;
     }
@@ -178,11 +191,13 @@ export class TableComponent implements OnInit, AfterViewInit {
     }
   }
 
-  getIconTitle(element: any, column: Column): string | null {
-    if (column.iconTitle === undefined) {
-      return column.heading;
+  getIconTitle(element: any, column: Column, side: Side): string | null {
+    if (side == Side.left && column.leftIconTitle !== undefined) {
+      return column.leftIconTitle(element);
+    } else if (side == Side.right && column.rightIconTitle !== undefined) {
+      return column.rightIconTitle(element);
     } else {
-      return column.iconTitle(element);
+      return column.heading;
     }
   }
 
@@ -408,7 +423,7 @@ export class TableComponent implements OnInit, AfterViewInit {
       } else {
         passesFilter = column.passesFilter;
       }
-      
+
       const filterValue = this.filter[column.id];
 
       if (!passesFilter(datum, filterValue)) {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
@@ -1,8 +1,8 @@
 @import 'biosimulations-colors';
 
-biosimulations-text-page-section ::ng-deep h2 {
-  color: $dark-primary-text;
-  background: $light-background;
+biosimulations-text-page-section ::ng-deep h2 {  
+  color: mat-color($theme-primary);
+  background: mat-color($theme-primary, lighter);  
 
   .icon-container {
     color: $dark-primary-text;

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
@@ -1,8 +1,8 @@
 @import 'biosimulations-colors';
 
-biosimulations-text-page-section ::ng-deep h2 {  
+biosimulations-text-page-section ::ng-deep h2 {
   color: mat-color($theme-primary);
-  background: mat-color($theme-primary, lighter);  
+  background: mat-color($theme-primary, lighter);
 
   .icon-container {
     color: $dark-primary-text;

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-side-bar-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-side-bar-section.component.scss
@@ -1,8 +1,8 @@
 @import 'biosimulations-colors';
 
 biosimulations-text-page-section ::ng-deep h2 {
-  color: mat-color($theme-primary);
-  background: mat-color($theme-primary, lighter);
+  color: $dark-primary-text;
+  background: $light-background;
 
   .icon-container {
     color: mat-color($theme-primary);

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
@@ -1,8 +1,13 @@
-<biosimulations-page [heading]="heading">
+<biosimulations-page [heading]="heading" [padded]="padded">
   <div class="grid grid-2">
     <div class="side-bar">
-      <div class="side-bar-inner sections-container" [ngStyle]="{position: fixed ? 'fixed': null}">
-        <biosimulations-text-page-side-bar-section heading="Contents">
+      <div class="side-bar-inner sections-container"
+        [ngStyle]="{
+          position: !heading || alwaysFixed != null || fixed ? 'fixed': null,
+          top: alwaysFixed == null ? 'calc(64px + 32px + 2rem)' : alwaysFixed
+        }"
+      >
+        <biosimulations-text-page-side-bar-section [heading]="contentsHeading">
           <ul>
             <biosimulations-text-page-toc-item *ngFor="let section of tocSections" [heading]="section.heading" [scrollTarget]="section.target">
             </biosimulations-text-page-toc-item>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -3,7 +3,7 @@
 }
 
 .side-bar-inner {
-  width: 16rem;  
+  width: 16rem;
 }
 
 .sections-container {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -3,8 +3,7 @@
 }
 
 .side-bar-inner {
-  width: 16rem;
-  top: calc(64px + 32px + 2rem);
+  width: 16rem;  
 }
 
 .sections-container {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -1,8 +1,8 @@
 import {
   Component,
-  OnInit,
   Input,
   ViewChild,
+  ElementRef,
 } from '@angular/core';
 
 interface TocItem {
@@ -15,30 +15,62 @@ interface TocItem {
   templateUrl: './text-page.component.html',
   styleUrls: ['./text-page.component.scss'],
 })
-export class TextPageComponent implements OnInit {
+export class TextPageComponent {
   @Input()
   heading = '';
+
+  @Input()
+  contentsHeading = 'Contents';
+
+  @Input()
+  padded = true;
+
+  @Input()
+  alwaysFixed: string | null = null;
 
   fixed = false;
 
   tocSections: TocItem[] = [];
+  tocSectionObservers: MutationObserver[] = [];
 
-  /* TODO (low priority): switch to monitoring ContentChildren so that the TOC is dynamically updated with the section or their headings change.
-       low priority because none of the instances of TextPageComponent currently need this.
-  */
-  @ViewChild('sectionsContainer')
-  set sectionsContainer(container: any) {
+  @ViewChild('sectionsContainer', {read: ElementRef})
+  set sectionsContainer(container: ElementRef) {
+    while(this.tocSections.length) {
+      this.tocSections.pop();
+    }
+    while(this.tocSectionObservers.length) {
+      const observer = this.tocSectionObservers.pop();
+      if (observer !== undefined) {
+        observer.disconnect();
+      }
+    }
     this.getTocSections(container.nativeElement);
   }
 
   getTocSections(container: any) {
     for (const section of container.children) {
-      const heading = section.getAttribute('shortHeading') || section.getAttribute('heading');
-      if (heading) {
-        this.tocSections.push({
+      if (section.localName === 'biosimulations-text-page-content-section') {
+        const heading = section.getAttribute('shortHeading') || section.getAttribute('ng-reflect-shortHeading') || section.getAttribute('heading') || section.getAttribute('ng-reflect-heading');
+        const tocSection = {
           heading: heading,
           target: section,
+        };
+        this.tocSections.push(tocSection);
+
+        const observer = new MutationObserver((mutations) => {
+          mutations.forEach((mutation) => {
+            const heading = section.getAttribute('shortHeading')
+              || section.getAttribute('ng-reflect-shortHeading')
+              || section.getAttribute('heading')
+              || section.getAttribute('ng-reflect-heading');
+            tocSection.heading = heading;
+          });
         });
+
+        observer.observe(section, {
+          attributeFilter: ['shortHeading', 'ng-reflect-shortHeading', 'heading', 'ng-reflect-heading'],
+        });
+        this.tocSectionObservers.push(observer);
       } else {
         this.getTocSections(section);
       }
@@ -49,9 +81,13 @@ export class TextPageComponent implements OnInit {
     window.addEventListener('scroll', this.scroll, true);
   }
 
-  ngOnInit(): void {}
-
   ngOnDestroy() {
+    while(this.tocSectionObservers.length) {
+      const observer = this.tocSectionObservers.pop();
+      if (observer !== undefined) {
+        observer.disconnect();
+      }
+    }
     window.removeEventListener('scroll', this.scroll, true);
   }
 

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -50,7 +50,10 @@ export class TextPageComponent {
   getTocSections(container: any) {
     for (const section of container.children) {
       if (section.localName === 'biosimulations-text-page-content-section') {
-        const heading = section.getAttribute('shortHeading') || section.getAttribute('ng-reflect-shortHeading') || section.getAttribute('heading') || section.getAttribute('ng-reflect-heading');
+        const heading = section.getAttribute('shortHeading')
+            || section.getAttribute('ng-reflect-short-heading')
+            || section.getAttribute('heading')
+            || section.getAttribute('ng-reflect-heading');
         const tocSection = {
           heading: heading,
           target: section,
@@ -60,7 +63,7 @@ export class TextPageComponent {
         const observer = new MutationObserver((mutations) => {
           mutations.forEach((mutation) => {
             const heading = section.getAttribute('shortHeading')
-              || section.getAttribute('ng-reflect-shortHeading')
+              || section.getAttribute('ng-reflect-short-heading')
               || section.getAttribute('heading')
               || section.getAttribute('ng-reflect-heading');
             tocSection.heading = heading;
@@ -68,7 +71,7 @@ export class TextPageComponent {
         });
 
         observer.observe(section, {
-          attributeFilter: ['shortHeading', 'ng-reflect-shortHeading', 'heading', 'ng-reflect-heading'],
+          attributeFilter: ['shortHeading', 'ng-reflect-short-heading', 'heading', 'ng-reflect-heading'],
         });
         this.tocSectionObservers.push(observer);
       } else {


### PR DESCRIPTION
- Adding id column to simulators table
- Styling browse and view simulators
- Setup service for local storage of simulations submitted to dispatch app
  - Stores a simulation each time one is submitted (marked with submittedLocally=true).
  - Stores a simulation each time one is accessed (marked with submittedLocally=false)
  - The saved list of simulations is loaded when the application initializes
  - Added buttons to export/import simulations to the browse page
  - When simulations are imported, they are marked as submittedLocally=false
  - Added a column to the browse table to indicate which simulations were submitted with the current computer and which weren't.
  - Every 5 minutes, the service will poll for status updates from the API -- the API still needs to be implemented (when there is at least one simulation with status = queued or running

  - Strictly speaking, "submitted locally" means that the simulation is guaranteed to be submitted from the current machine. When submittedLocally=false, this means can be due to one of several reasons.
    - The user cleared their browse cache and then accessed the simulation again
    - The user accessed a simulation on a different machine
    - A colleague shared a simulation with a user