### PR TITLE
Styling for mobile

### DIFF
--- a/biosimulations/apps/dispatch/src/app/components/help/about/about.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/about/about.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="About runBioSimulations">
+<biosimulations-text-page heading="About runBioSimulations" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Motivation and goals of runBioSimulations"
-      shortHeading="Motivation and goals"
+      tocSection="Motivation and goals"
     >
       <p>
         More comprehensive and more predictive models have the potential to advance biology, bioengineering, and medicine. Building more predictive models will likely require the collaborative efforts of many investigators. This requires teams to be able to share and reuse model components and simulations. Despite extensive efforts to develop standards such as COMBINE/OMEX <a target="_blank" href="https://combinearchive.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, SBML <a target="_blank" href="http://sbml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, and SED-ML <a target="_blank" href="https://www.sed-ml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a> and repositories such as BioModels, it is still often difficult to reuse models and simulations. One challenge to sharing and reusing models is the disparate formats and simulation tools for different types of models. The proliferation of numerous similar formats and tools makes it difficult, especially for non-experts, to find an appropriate simulation tool for each model.
@@ -25,7 +25,7 @@
 
     <biosimulations-text-page-content-section
       heading="Supported modeling frameworks, algorithms, formats and software tools"
-      shortHeading="Supported frameworks &amp; formats"
+      tocSection="Supported frameworks &amp; formats"
     >
       <p>
         runBioSimulations can simulate logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) models that are described in using the BioNetGen Language (BNGL) <a href="https://bionetgen.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> or the Systems Biology Markup Language (SBML) <a href="http://sbml.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -153,7 +153,7 @@
 
     <biosimulations-text-page-content-section
       heading="Technological foundation of runBioSimulations"
-      shortHeading="Technological foundation"
+      tocSection="Technological foundation"
     >
       <p>
         runBioSimulations is implemented using several open-source tools and cloud platforms.
@@ -227,7 +227,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the containerized simulation tools"
-      shortHeading="Obtaining the simulators"
+      tocSection="Obtaining the simulators"
     >
       <p>
         The containerized simulation software tools are available from BioSimulators <a target="_blank" href="https://biosimulators.org"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -236,7 +236,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the runBioSimulations source code"
-      shortHeading="Obtaining the source code"
+      tocSection="Obtaining the source code"
     >
       <p>
         The source code for runBioSimulations is available from GitHub <a href="https://github.com/biosimulations/Biosimulations/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -245,7 +245,7 @@
 
     <biosimulations-text-page-content-section
       heading="License"
-      shortHeading="License"
+      tocSection="License"
     >
       <p>The source code is provided under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -257,7 +257,7 @@
 
     <biosimulations-text-page-content-section
       heading="runBioSimulations team"
-      shortHeading="runBioSimulations team"
+      tocSection="runBioSimulations team"
     >
       <p>
         runBioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="http://reproduciblebiomodels.org/" target="_blank">
@@ -355,7 +355,7 @@
 
     <biosimulations-text-page-content-section
       heading="Contributing to runBioSimulations"
-      shortHeading="Contributing to runBioSimulations"
+      tocSection="Contributing to runBioSimulations"
     >
       <p>
         We welcome contributions to runBioSimulations!
@@ -369,7 +369,7 @@
 
     <biosimulations-text-page-content-section
       heading="Acknowledgements"
-      shortHeading="Acknowledgements"
+      tocSection="Acknowledgements"
     >
       <p>
         runBioSimulations was developed with support from the Center for

--- a/biosimulations/apps/dispatch/src/app/components/help/about/about.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/about/about.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="About runBioSimulations">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/dispatch/src/app/components/help/about/about.component.sass
+++ b/biosimulations/apps/dispatch/src/app/components/help/about/about.component.sass
@@ -11,3 +11,9 @@
 
   img
     height: 2.5rem
+
+@media screen and (max-width: 959px)
+  .logos
+    text-align: center
+  .logos-row
+    display: inline

--- a/biosimulations/apps/dispatch/src/app/components/help/about/about.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/help/about/about.component.ts
@@ -1,18 +1,22 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-about',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.sass'],
 })
-export class AboutComponent implements OnInit {
+export class AboutComponent {
   // TODO: get from app config
   appUrl = 'https://biosimulations.org/'
   apiUrl = 'https://api.biosimulations.org/'
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="FAQ">
+<biosimulations-text-page heading="FAQ" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Models"
-      shortHeading="Models"
+      tocSection="Models"
     >
       <biosimulations-q-a heading="Which modeling frameworks does runBioSimulations support?">
         This application can simulate the logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) frameworks. This includes rule-based models. runBioSimulations uses the BioSimulators collection of simulations tools to simulate models. Please see BioSimulators <a href="https://biosimulators.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information about supported modeling frameworks.
@@ -35,7 +35,7 @@
 
     <biosimulations-text-page-content-section
       heading="Simulations"
-      shortHeading="Simulations"
+      tocSection="Simulations"
     >
       <biosimulations-q-a heading="Which simulation algorithms does runBioSimulations support?">
         runBioSimulations supports numerous algorithms for simulating logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) models. runBioSimulations uses the BioSimulators collection of simulations tools to simulate models. Please see BioSimulators <a href="https://biosimulators.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information about supported simulation algorithms.
@@ -56,7 +56,7 @@
 
     <biosimulations-text-page-content-section
       heading="Simulation software tools"
-      shortHeading="Simulation algorithms and tools"
+      tocSection="Simulation algorithms and tools"
     >
       <biosimulations-q-a heading="Which simulation tools does runBioSimulations support?">
         runBioSimulations uses the BioSimulators collection of containerized simulation software tools. Please see <a href="https://biosimulators.org" target="_blank">https://biosimulators.org</a> for information about the available simulation tools, including the modeling frameworks, simulation algorithms, and model formats supported by each tool.

--- a/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="FAQ">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/help/faq/faq.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './faq.component.html',
   styleUrls: ['./faq.component.sass'],
 })
-export class FaqComponent implements OnInit {
+export class FaqComponent {
   // TODO: get from app config
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
@@ -12,7 +13,10 @@ export class FaqComponent implements OnInit {
   submitAppUrl = 'https://submit.biosimulations.org/'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/dispatch/src/app/components/help/help/help.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/help/help.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Tutorial">
+<biosimulations-text-page heading="Tutorial" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
@@ -23,10 +23,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Creating COMBINE/OMEX files that describe modeling projects"
-      shortHeading="Creating modeling projects"
+      tocSection="Creating modeling projects"
     >
       <p>
         runBioSimulations requires modeling projects (one or more simulations of one or more models) to be described by an OMEX file and packaged into a COMBINE archive. Please follow these steps to create OMEX and COMBINE files. Alternatively, COMBINE/OMEX files which describe modeling projects can be obtained from the BioSimulations repository of modeling projects <a href="https://biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -53,14 +53,14 @@
 
     <biosimulations-text-page-content-section
       heading="Finding a simulation tool that is capable of executing a modeling project"
-      shortHeading="Finding simulation tools"
+      tocSection="Finding simulation tools"
     >
       runBioSimulations uses the BioSimulators collection of simulation tools. These tools each support different modeling frameworks, different simulation algorithms, and different model formats. The BioSimulators website <a href="https://biosimulators.org/simulators"><biosimulations-icon icon="link"></biosimulations-icon></a> outlines the modeling frameworks, simulation algorithms, and model formats supported by each tool. After determining the framework and format of your model and the simulation algorithm which you would like to execute, use this website to identify a simulation tool which is capable of executing your modeling project.
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
       heading="Executing projects"
-      shortHeading="Executing projects"
+      tocSection="Executing projects"
     >
       <p>Please follow these steps to execute a modeling project:</p>
 
@@ -77,7 +77,7 @@
 
     <biosimulations-text-page-content-section
       heading="Checking the status of a project"
-      shortHeading="Checking the status of a project"
+      tocSection="Checking the status of a project"
     >
       <p>Please follow these steps to view the status of a project:</p>
 
@@ -90,7 +90,7 @@
 
     <biosimulations-text-page-content-section
       heading="Retrieiving simulation results"
-      shortHeading="Retrieiving simulation results"
+      tocSection="Retrieiving simulation results"
     >
       <p class="no-bottom-margin">After your project has completed, please follow these steps to retrieve its results:</p>
       <ol class="vertically-spaced">
@@ -103,7 +103,7 @@
 
     <biosimulations-text-page-content-section
       heading="Visualizing simulation results"
-      shortHeading="Visualizing simulation results"
+      tocSection="Visualizing simulation results"
     >
       <p class="no-bottom-margin">After your project has completed, please follow these steps to visualize its results:</p>
 
@@ -120,7 +120,7 @@
 
     <biosimulations-text-page-content-section
       heading="Programmatically executing projects with the REST API"
-      shortHeading="REST API"
+      tocSection="REST API"
     >
       In addition to this web application, a REST API for executing projects is available at <a [href]="webserviceUrl" target="_blank">{{ webserviceUrl }}</a>. This API supports the same simulation tools as this web application.
     </biosimulations-text-page-content-section>

--- a/biosimulations/apps/dispatch/src/app/components/help/help/help.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/help/help.component.html
@@ -1,6 +1,6 @@
 <biosimulations-text-page heading="Tutorial">
   <ng-container id="sideBar">
-    <biosimulations-text-page-side-bar-section heading="Related resources">
+    <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
         <a href="https://biosimulators.org" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -16,10 +16,10 @@
       </div>
     </biosimulations-text-page-side-bar-section>
 
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/dispatch/src/app/components/help/help/help.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/help/help/help.component.ts
@@ -1,17 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './help.component.html',
   styleUrls: ['./help.component.sass'],
 })
-export class HelpComponent implements OnInit {
+export class HelpComponent {
   // TODO: get from app config
   apiUrl = 'https://api.biosimulations.org/'  
   submitAppUrl = 'https://submit.biosimulations.org/'
   submitAppHelpUrl = this.submitAppUrl + 'help'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/dispatch/src/app/components/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/privacy-policy/privacy-policy.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Privacy policy">
+<biosimulations-text-page heading="Privacy policy" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-dispatch-privacy-policy id="content">
+  <biosimulations-dispatch-privacy-policy id="content" #content>
   </biosimulations-dispatch-privacy-policy>
 </biosimulations-text-page>

--- a/biosimulations/apps/dispatch/src/app/components/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/privacy-policy/privacy-policy.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Privacy policy">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/dispatch/src/app/components/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/terms-of-service/terms-of-service.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Terms of service">
+<biosimulations-text-page heading="Terms of service" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-dispatch-terms-of-service id="content">
+  <biosimulations-dispatch-terms-of-service id="content" #content>
   </biosimulations-dispatch-terms-of-service>
 </biosimulations-text-page>

--- a/biosimulations/apps/dispatch/src/app/components/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/help/terms-of-service/terms-of-service.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Terms of service">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/dispatch/src/app/components/home/home.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/home/home.component.html
@@ -187,279 +187,285 @@
 >
   <ng-container id="heading">About <span class="highlight-primary">runBioSimulations</span></ng-container>
   <ng-container id="subsection">
-    <p>
-      runBioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
-    </p>
-    <p>
-      runBioSimulations is implemented using several open-source tools and cloud platforms. The models, simulations, and visualizations are available under the licenses specified for each resource. The code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
-    </p>
-    <p>
-      Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Center for Reproducible Biomedical Modeling"
-        src="assets/images/about/team/crbm.svg"
-        href="https://reproduciblebiomodels.org/"
-      >
-      </biosimulations-home-logo>
+    <div class="about-content">
+      <div class="text">
+        <p>
+          runBioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
+        </p>
+        <p>
+          runBioSimulations is implemented using several open-source tools and cloud platforms. The models, simulations, and visualizations are available under the licenses specified for each resource. The code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
+        </p>
+        <p>
+          Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
+        </p>
+      </div>
+      <div class="logos">        
+        <p>
+          <biosimulations-home-logo
+            title="Center for Reproducible Biomedical Modeling"
+            src="assets/images/about/team/crbm.svg"
+            href="https://reproduciblebiomodels.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Karr Lab"
-        src="assets/images/about/team/karr-lab.svg"
-        href="https://www.karrlab.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Karr Lab"
+            src="assets/images/about/team/karr-lab.svg"
+            href="https://www.karrlab.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Icahn School of Medicine at Mount Sinai"
-        src="assets/images/about/team/sinai.svg"
-        href="https://icahn.mssm.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Icahn School of Medicine at Mount Sinai"
+            src="assets/images/about/team/sinai.svg"
+            href="https://icahn.mssm.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Connecticut Health Center"
-        src="assets/images/about/team/uconn.svg"
-        href="https://health.uconn.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Connecticut Health Center"
+            src="assets/images/about/team/uconn.svg"
+            href="https://health.uconn.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Washington"
-        src="assets/images/about/team/uw.svg"
-        href="https://www.washington.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Washington"
+            src="assets/images/about/team/uw.svg"
+            href="https://www.washington.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIBIB"
-        src="assets/images/about/funding/nibib.svg"
-        href="http://nibib.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIBIB"
+            src="assets/images/about/funding/nibib.svg"
+            href="http://nibib.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIGMS"
-        src="assets/images/about/funding/nigms.svg"
-        href="http://nigms.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIGMS"
+            src="assets/images/about/funding/nigms.svg"
+            href="http://nigms.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIH"
-        src="assets/images/about/funding/nih.svg"
-        href="http://nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIH"
+            src="assets/images/about/funding/nih.svg"
+            href="http://nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NSF"
-        src="assets/images/about/funding/nsf.svg"
-        href="http://nsf.gov/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="BNGL"
-        src="assets/images/about/partners/bionetgen.png"
-        href="https://www.bionetgen.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NSF"
+            src="assets/images/about/funding/nsf.svg"
+            href="http://nsf.gov/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="BNGL"
+            src="assets/images/about/partners/bionetgen.png"
+            href="https://www.bionetgen.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SBML"
-        src="assets/images/about/partners/sbml.svg"
-        href="http://sbml.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SBML"
+            src="assets/images/about/partners/sbml.svg"
+            href="http://sbml.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SED-ML"
-        src="assets/images/about/partners/sed-ml.svg"
-        href="https://sed-ml.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SED-ML"
+            src="assets/images/about/partners/sed-ml.svg"
+            href="https://sed-ml.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COMBINE/OMEX"
-        src="assets/images/about/partners/omex.svg"
-        href="https://combinearchive.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COMBINE/OMEX"
+            src="assets/images/about/partners/omex.svg"
+            href="https://combinearchive.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="BioContainers"
-        src="assets/images/about/partners/biocontainers.png"
-        href="https://biocontainers.pro/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <!--
-      <biosimulations-home-logo
-        title="AMICI"
-        src="assets/images/about/partners/amici.svg"
-        href="http://amici-dev.github.io/AMICI/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="BioContainers"
+            src="assets/images/about/partners/biocontainers.png"
+            href="https://biocontainers.pro/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <!--
+          <biosimulations-home-logo
+            title="AMICI"
+            src="assets/images/about/partners/amici.svg"
+            href="http://amici-dev.github.io/AMICI/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Cayenne"
-        src="assets/images/about/partners/cayenne.png"
-        href="https://cayenne.readthedocs.io/"
-      >
-      </biosimulations-home-logo>
-      -->
+          <biosimulations-home-logo
+            title="Cayenne"
+            src="assets/images/about/partners/cayenne.png"
+            href="https://cayenne.readthedocs.io/"
+          >
+          </biosimulations-home-logo>
+          -->
 
-      <biosimulations-home-logo
-        title="COBRApy"
-        src="assets/images/about/partners/cobrapy.svg"
-        href="https://opencobra.github.io/cobrapy/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COBRApy"
+            src="assets/images/about/partners/cobrapy.svg"
+            href="https://opencobra.github.io/cobrapy/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COPASI"
-        src="assets/images/about/partners/copasi.svg"
-        href="http://copasi.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COPASI"
+            src="assets/images/about/partners/copasi.svg"
+            href="http://copasi.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GillesPy2"
-        src="assets/images/about/partners/gillespy2.svg"
-        href="https://gillespy2.github.io/GillesPy2/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GillesPy2"
+            src="assets/images/about/partners/gillespy2.svg"
+            href="https://gillespy2.github.io/GillesPy2/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="iBioSim"
-        src="assets/images/about/partners/ibiosim.svg"
-        href="https://github.com/MyersResearchGroup/iBioSim"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="iBioSim"
+            src="assets/images/about/partners/ibiosim.svg"
+            href="https://github.com/MyersResearchGroup/iBioSim"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NFsim"
-        src="assets/images/about/partners/nfsim.svg"
-        href="http://michaelsneddon.net/nfsim/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NFsim"
+            src="assets/images/about/partners/nfsim.svg"
+            href="http://michaelsneddon.net/nfsim/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="PySCeS"
-        src="assets/images/about/partners/pysces.svg"
-        href="http://pysces.sourceforge.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="PySCeS"
+            src="assets/images/about/partners/pysces.svg"
+            href="http://pysces.sourceforge.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="tellurium/libRoadRunner"
-        src="assets/images/about/partners/libroadrunner.svg"
-        href="http://tellurium.analogmachine.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="tellurium/libRoadRunner"
+            src="assets/images/about/partners/libroadrunner.svg"
+            href="http://tellurium.analogmachine.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="VCell"
-        src="assets/images/about/partners/vcell.svg"
-        href="https://vcell.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Angular"
-        src="assets/images/about/tech/angular.svg"
-        href="https://angular.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="VCell"
+            src="assets/images/about/partners/vcell.svg"
+            href="https://vcell.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="Angular"
+            src="assets/images/about/tech/angular.svg"
+            href="https://angular.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Bruit.io"
-        src="assets/images/about/tech/bruit-io.svg"
-        href="https://www.bruit.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Bruit.io"
+            src="assets/images/about/tech/bruit-io.svg"
+            href="https://www.bruit.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Docker"
-        src="assets/images/about/tech/docker.svg"
-        href="http://www.docker.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Docker"
+            src="assets/images/about/tech/docker.svg"
+            href="http://www.docker.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Favicon Generator"
-        src="assets/images/about/tech/real-favicon-generator.png"
-        href="http://realfavicongenerator.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Favicon Generator"
+            src="assets/images/about/tech/real-favicon-generator.png"
+            href="http://realfavicongenerator.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Font Awesome"
-        src="assets/images/about/tech/font-awesome.svg"
-        href="https://fontawesome.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Font Awesome"
+            src="assets/images/about/tech/font-awesome.svg"
+            href="https://fontawesome.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GitHub"
-        src="assets/images/about/tech/github.svg"
-        href="https://github.com/open-source"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GitHub"
+            src="assets/images/about/tech/github.svg"
+            href="https://github.com/open-source"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Kubernetes"
-        src="assets/images/about/tech/kubernetes.svg"
-        href="https://kubernetes.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Kubernetes"
+            src="assets/images/about/tech/kubernetes.svg"
+            href="https://kubernetes.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Design"
-        src="assets/images/about/tech/material.svg"
-        href="https://material.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Design"
+            src="assets/images/about/tech/material.svg"
+            href="https://material.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Theme Generator"
-        src="assets/images/about/tech/material-theme-generator.svg"
-        href="https://materialtheme.arcsine.dev/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Theme Generator"
+            src="assets/images/about/tech/material-theme-generator.svg"
+            href="https://materialtheme.arcsine.dev/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="MongoDB"
-        src="assets/images/about/tech/mongodb.svg"
-        href="https://www.mongodb.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="MongoDB"
+            src="assets/images/about/tech/mongodb.svg"
+            href="https://www.mongodb.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NestJS"
-        src="assets/images/about/tech/nestjs.svg"
-        href="https://nestjs.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NestJS"
+            src="assets/images/about/tech/nestjs.svg"
+            href="https://nestjs.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Netlify"
-        src="assets/images/about/tech/netlify.svg"
-        href="https://www.netlify.com"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Netlify"
+            src="assets/images/about/tech/netlify.svg"
+            href="https://www.netlify.com"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="OpenAPI"
-        src="assets/images/about/tech/openapi.svg"
-        href="https://www.openapis.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
+          <biosimulations-home-logo
+            title="OpenAPI"
+            src="assets/images/about/tech/openapi.svg"
+            href="https://www.openapis.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+      </div>
+    </div>
   </ng-container>
 </biosimulations-home-section>

--- a/biosimulations/apps/dispatch/src/app/components/home/home.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/home/home.component.scss
@@ -1,0 +1,19 @@
+.about-content {
+    .text {
+        margin-bottom: 0.75rem;
+    }
+    .logos {
+        text-align: center;
+    }
+}
+
+@media screen and (max-width: 63.99875em) {
+    .about-content {
+        .text {
+            text-align: left;
+        }
+        .logos p {
+            display: inline;
+        }
+    }
+}

--- a/biosimulations/apps/dispatch/src/app/components/home/home.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/home/home.component.scss
@@ -7,7 +7,7 @@
     }
 }
 
-@media screen and (max-width: 63.99875em) {
+@media screen and (max-width: 959px) {
     .about-content {
         .text {
             text-align: left;

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.scss
@@ -5,11 +5,25 @@
 ::ng-deep #mat-tab-content-0-3 {
   .mat-tab-body-content {
     width: calc(100vw - 2 * 2rem);
-    height: calc(100vh - 64px - 32px - 32px - 2 * 2rem);
+    height: calc(100vh - 64px - 28px - 0.5rem - 32px - 2 * 2rem);
     min-width: calc(100vw - 2 * 2rem);
-    min-height: calc(100vh - 64px - 32px - 32px - 2 * 2rem);
+    min-height: calc(100vh - 64px - 28px - 0.5rem - 32px - 2 * 2rem);
     max-width: calc(100vw - 2 * 2rem);
-    max-height: calc(100vh - 64px - 32px - 32px - 2 * 2rem);
+    max-height: calc(100vh - 64px - 28px - 0.5rem - 32px - 2 * 2rem);
     overflow: visible;
+  }
+}
+
+@media screen and (max-width: 959px) {
+  ::ng-deep #mat-tab-content-0-3 {
+    .mat-tab-body-content {
+      width: calc(100vw - 2 * 1rem);
+      height: calc(100vh - 56px - 32px - 2 * 1rem);
+      min-width: calc(100vw - 2 * 1rem);
+      min-height: calc(100vh - 56px - 32px - 2 * 1rem);
+      max-width: calc(100vw - 2 * 1rem);
+      max-height: calc(100vh - 56px - 32px - 2 * 1rem);
+      overflow: visible;
+    }
   }
 }

--- a/biosimulations/apps/platform/src/app/help/about/about.component.html
+++ b/biosimulations/apps/platform/src/app/help/about/about.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="About BioSimulations">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/platform/src/app/help/about/about.component.html
+++ b/biosimulations/apps/platform/src/app/help/about/about.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="About BioSimulations">
+<biosimulations-text-page heading="About BioSimulations" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Motivation and goals of BioSimulations"
-      shortHeading="Motivation and goals"
+      tocSection="Motivation and goals"
     >
       <p>
         More comprehensive and more predictive models have the potential to advance biology, bioengineering, and medicine. Building more predictive models will likely require the collaborative efforts of many investigators. This requires teams to be able to share and reuse model components and simulations. Despite extensive efforts to develop standards such as COMBINE/OMEX <a target="_blank" href="https://combinearchive.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, SBML <a target="_blank" href="http://sbml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, and SED-ML <a target="_blank" href="https://www.sed-ml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a> and repositories such as BioModels, it is still often difficult to share and reuse models and simulations. One challenge to sharing and reusing models is the disparate formats, model repositories, and simulation tools for different types of models. The proliferation of numerous similar formats, repositories, and tools makes it difficult, especially for non-experts, to find models and to find an appropriate simulation tool for each model. In addition, the existing model repositories have limited capabilities for sharing associated resources such as training data, simulation experiments, and visualizations.
@@ -22,7 +22,7 @@
 
     <biosimulations-text-page-content-section
       heading="Supported modeling frameworks, algorithms, formats and software tools"
-      shortHeading="Supported frameworks &amp; formats"
+      tocSection="Supported frameworks &amp; formats"
     >
       <p>
         BioSimulations supports all modeling frameworks and model formats. However, currrently BioSimulations can only simulate logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) models that are described in using the BioNetGen Language (BNGL) <a href="https://bionetgen.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> or the Systems Biology Markup Language (SBML) <a href="http://sbml.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -150,7 +150,7 @@
 
     <biosimulations-text-page-content-section
       heading="Source model repositories"
-      shortHeading="Source model repositories"
+      tocSection="Source model repositories"
     >
       <p>
         In addition to models, simulations, and visualizations contributed by investigators, BioSimulations contains models, simulations, and visualizations imported from BiGG <a href="http://bigg.ucsd.edu/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, BioModels <a href="http://www.ebi.ac.uk/biomodels/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and Cell Collective <a href="https://cellcollective.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>. BioSimulations provides a central place to find and reuse these models.
@@ -187,7 +187,7 @@
 
     <biosimulations-text-page-content-section
       heading="Technological foundation of BioSimulations"
-      shortHeading="Technological foundation"
+      tocSection="Technological foundation"
     >
       <p>
         BioSimulations is implemented using several open-source tools and cloud platforms.
@@ -269,7 +269,7 @@
 
     <biosimulations-text-page-content-section
       heading="Downloading the models, simulations, and visualizations in BioSimulations"
-      shortHeading="Downloading BioSimulations"
+      tocSection="Downloading BioSimulations"
     >
       <p>
         The models, simulations, and visualizations in BioSimulations can be programmatically obtained using our REST API <a target="_blank" [href]="apiUrl"><biosimulations-icon icon="link"></biosimulations-icon></a>. Documentation for the API is available at the same URL.
@@ -279,7 +279,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the containerized simulation tools"
-      shortHeading="Obtaining the simulators"
+      tocSection="Obtaining the simulators"
     >
       <p>
         The containerized simulation software tools are available from BioSimulators <a target="_blank" href="https://biosimulators.org"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -288,7 +288,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the BioSimulations source code"
-      shortHeading="Obtaining the source code"
+      tocSection="Obtaining the source code"
     >
       <p>
         The BioSimulations source code is composed of the following open-source packages:
@@ -305,7 +305,7 @@
 
     <biosimulations-text-page-content-section
       heading="License"
-      shortHeading="License"
+      tocSection="License"
     >
       <p>The models, simulations, and visualizations in BioSimulations are provided under the license specified for each resource. The containerized simulators are provided under the open-source licenses documented for each image. Please see BioSimulators <a target="_blank" href="https://biosimulators.org"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information. The BioSimulations source code is provided under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -317,7 +317,7 @@
 
     <biosimulations-text-page-content-section
       heading="BioSimulations team"
-      shortHeading="BioSimulations team"
+      tocSection="BioSimulations team"
     >
       <p>
         BioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="http://reproduciblebiomodels.org/" target="_blank">
@@ -415,7 +415,7 @@
 
     <biosimulations-text-page-content-section
       heading="Contributing to BioSimulations"
-      shortHeading="Contributing to BioSimulations"
+      tocSection="Contributing to BioSimulations"
     >
       <p>
         We welcome contributions to BioSimulations!
@@ -430,7 +430,7 @@
 
     <biosimulations-text-page-content-section
       heading="Acknowledgements"
-      shortHeading="Acknowledgements"
+      tocSection="Acknowledgements"
     >
       <p>
         BioSimulations was developed with support from the Center for

--- a/biosimulations/apps/platform/src/app/help/about/about.component.sass
+++ b/biosimulations/apps/platform/src/app/help/about/about.component.sass
@@ -11,3 +11,9 @@
 
   img
     height: 2.5rem
+
+@media screen and (max-width: 959px)
+  .logos
+    text-align: center
+  .logos-row
+    display: inline

--- a/biosimulations/apps/platform/src/app/help/about/about.component.ts
+++ b/biosimulations/apps/platform/src/app/help/about/about.component.ts
@@ -1,17 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-about',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.sass'],
 })
-export class AboutComponent implements OnInit {
+export class AboutComponent {
   // TODO: get from app config
   apiUrl = 'https://api.biosimulations.org/'
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/platform/src/app/help/faq/faq.component.html
+++ b/biosimulations/apps/platform/src/app/help/faq/faq.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="FAQ">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/platform/src/app/help/faq/faq.component.html
+++ b/biosimulations/apps/platform/src/app/help/faq/faq.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="FAQ">
+<biosimulations-text-page heading="FAQ" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Models"
-      shortHeading="Models"
+      tocSection="Models"
     >
       <biosimulations-q-a heading="Which modeling frameworks does BioSimulations support?">
         BioSimulations supports all modeling frameworks. However, currently BioSimulations can only simulate the logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) frameworks. This includes rule-based models. BioSimulations uses the BioSimulators collection of simulations tools to simulate models. Please see BioSimulators <a href="https://biosimulators.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information about supported modeling frameworks.
@@ -27,7 +27,7 @@
 
     <biosimulations-text-page-content-section
       heading="Simulations"
-      shortHeading="Simulations"
+      tocSection="Simulations"
     >
       <biosimulations-q-a heading="Which simulation algorithms does BioSimulations support?">
         BioSimulations supports numerous algorithms for simulating logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) models. BioSimulations uses the BioSimulators collection of simulations tools to simulate models. Please see BioSimulators <a href="https://biosimulators.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information about supported simulation algorithms.
@@ -65,7 +65,7 @@
 
     <biosimulations-text-page-content-section
       heading="Simulation software tools"
-      shortHeading="Simulation tools"
+      tocSection="Simulation tools"
     >
       <biosimulations-q-a heading="Which simulation tools does BioSimulations support?">
         BioSimulations uses the BioSimulators collection of containerized simulation software tools. Please see <a href="https://biosimulators.org" target="_blank">https://biosimulators.org</a> for information about the available simulation tools, including the modeling frameworks, simulation algorithms, and model formats supported by each tool.
@@ -78,7 +78,7 @@
 
     <biosimulations-text-page-content-section
       heading="Visualizations"
-      shortHeading="Visualizations"
+      tocSection="Visualizations"
     >
       <biosimulations-q-a heading="Which visualization formats does BioSimulations support?">
         Currently, simulations can only be uploaded in Vega <a href="https://vega.github.io/vega" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> and Vega-Lite <a href="https://vega.github.io/vega-lite" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> formats.
@@ -87,7 +87,7 @@
 
     <biosimulations-text-page-content-section
       heading="General"
-      shortHeading="General"
+      tocSection="General"
     >
       <biosimulations-q-a heading="What licenses can I use to publish models, simulations, and visualizations?">
         Currently, BioSimulations supports the Creative Commons licenses <a href="https://creativecommons.org/choose/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.

--- a/biosimulations/apps/platform/src/app/help/faq/faq.component.ts
+++ b/biosimulations/apps/platform/src/app/help/faq/faq.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './faq.component.html',
   styleUrls: ['./faq.component.sass'],
 })
-export class FaqComponent implements OnInit {
+export class FaqComponent {
   // TODO: get from app config
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
@@ -12,7 +13,10 @@ export class FaqComponent implements OnInit {
   submitAppUrl = 'https://submit.biosimulations.org/'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/platform/src/app/help/help/help.component.html
+++ b/biosimulations/apps/platform/src/app/help/help/help.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Tutorial">
+<biosimulations-text-page heading="Tutorial" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
@@ -22,10 +22,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Guide for users: Finding, simulating, and visualizing published models"
-      shortHeading="Guide for users"
+      tocSection="Guide for users"
     >
       <ul>
         <li>Finding models</li>
@@ -39,7 +39,7 @@
 
     <biosimulations-text-page-content-section
       heading="Guide for authors: Publishing models, simulations, and visualizations"
-      shortHeading="Guide for authors"
+      tocSection="Guide for authors"
     >
       <ul>
         <li>Uploading models</li>
@@ -52,7 +52,7 @@
 
     <biosimulations-text-page-content-section
       heading="Guide for reviewers and editors: Evaluating models, simulations, and visualizations"
-      shortHeading="Guide for reviewers and editors"
+      tocSection="Guide for reviewers and editors"
     >
       <ul>
         <li>Accessing resources</li>
@@ -61,14 +61,14 @@
 
     <biosimulations-text-page-content-section
       heading="Guide for simulation software developers: Contributing an additional simulation tool"
-      shortHeading="Guide for simulator developers"
+      tocSection="Guide for simulator developers"
     >
       BioSimulations uses the BioSimulators collection of simulation tools. Please see BioSimulators <a href="https://biosimulators.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for information about contributing an additional simulation tool.
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
       heading="User accounts"
-      shortHeading="User accounts"
+      tocSection="User accounts"
     >
       <ul>
         <li>Signing up</li>
@@ -79,14 +79,14 @@
 
     <biosimulations-text-page-content-section
       heading="Programmatically working with BioSimulations via the REST API"
-      shortHeading="REST API"
+      tocSection="REST API"
     >
       A comprehensive API is available for submitting and retrieving projects, models, simulations, charts, and visualizations and executing simulations and retrieving their results. Please see the documentation for the REST API <a [href]="apiUrl" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information.
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
       heading="Executing simulations with the standalone simulation web application and REST API"
-      shortHeading="Standalone simulation web service"
+      tocSection="Standalone simulation web service"
     >
       In addition to this full-featured web application, runBioSimulations <a [href]="submitAppUrl" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> provides a simpler web application and REST API for executing simulations. runBioSimulations simply enables users to execute COMBINE archives using a variety of simulation tools and generate time series plots of their results. This application does not require an account.
     </biosimulations-text-page-content-section>

--- a/biosimulations/apps/platform/src/app/help/help/help.component.html
+++ b/biosimulations/apps/platform/src/app/help/help/help.component.html
@@ -1,6 +1,6 @@
 <biosimulations-text-page heading="Tutorial">
   <ng-container id="sideBar">
-    <biosimulations-text-page-side-bar-section heading="Related resources">
+    <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
         <a href="https://biosimulators.org" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -15,10 +15,10 @@
       </div>
     </biosimulations-text-page-side-bar-section>
 
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/platform/src/app/help/help/help.component.ts
+++ b/biosimulations/apps/platform/src/app/help/help/help.component.ts
@@ -1,17 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './help.component.html',
   styleUrls: ['./help.component.sass'],
 })
-export class HelpComponent implements OnInit {
+export class HelpComponent {
   // TODO: get from app config
   apiUrl = 'https://api.biosimulations.org/'  
   submitAppUrl = 'https://submit.biosimulations.org/'
   submitAppHelpUrl = this.submitAppUrl + 'help'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/platform/src/app/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/platform/src/app/help/privacy-policy/privacy-policy.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Privacy policy">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/platform/src/app/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/platform/src/app/help/privacy-policy/privacy-policy.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Privacy policy">
+<biosimulations-text-page heading="Privacy policy" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-platform-privacy-policy id="content">
+  <biosimulations-platform-privacy-policy id="content" #content>
   </biosimulations-platform-privacy-policy>
 </biosimulations-text-page>

--- a/biosimulations/apps/platform/src/app/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/platform/src/app/help/terms-of-service/terms-of-service.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Terms of service">
+<biosimulations-text-page heading="Terms of service" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-platform-terms-of-service id="content">
+  <biosimulations-platform-terms-of-service id="content" #content>
   </biosimulations-platform-terms-of-service>
 </biosimulations-text-page>

--- a/biosimulations/apps/platform/src/app/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/platform/src/app/help/terms-of-service/terms-of-service.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Terms of service">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/platform/src/app/home/home.component.html
+++ b/biosimulations/apps/platform/src/app/home/home.component.html
@@ -194,328 +194,334 @@
 >
   <ng-container id="heading">About <span class="highlight-primary">BioSimulations</span></ng-container>
   <ng-container id="subsection">
-    <p>
-      BioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
-    </p>
-    <p>
-      BioSimulations is implemented using several open-source tools and cloud platforms. The models, simulations, and visualizations are available under the licenses specified for each resource. The code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
-    </p>
-    <p>
-      Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Center for Reproducible Biomedical Modeling"
-        src="assets/images/about/team/crbm.svg"
-        href="https://reproduciblebiomodels.org/"
-      >
-      </biosimulations-home-logo>
+    <div class="about-content">
+      <div class="text">
+        <p>
+          BioSimulations was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
+        </p>
+        <p>
+          BioSimulations is implemented using several open-source tools and cloud platforms. The models, simulations, and visualizations are available under the licenses specified for each resource. The code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
+        </p>
+        <p>
+          Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
+        </p>
+      </div>
+      <div class="logos">
+        <p>
+          <biosimulations-home-logo
+            title="Center for Reproducible Biomedical Modeling"
+            src="assets/images/about/team/crbm.svg"
+            href="https://reproduciblebiomodels.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Karr Lab"
-        src="assets/images/about/team/karr-lab.svg"
-        href="https://www.karrlab.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Karr Lab"
+            src="assets/images/about/team/karr-lab.svg"
+            href="https://www.karrlab.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Icahn School of Medicine at Mount Sinai"
-        src="assets/images/about/team/sinai.svg"
-        href="https://icahn.mssm.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Icahn School of Medicine at Mount Sinai"
+            src="assets/images/about/team/sinai.svg"
+            href="https://icahn.mssm.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Connecticut Health Center"
-        src="assets/images/about/team/uconn.svg"
-        href="https://health.uconn.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Connecticut Health Center"
+            src="assets/images/about/team/uconn.svg"
+            href="https://health.uconn.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Washington"
-        src="assets/images/about/team/uw.svg"
-        href="https://www.washington.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Washington"
+            src="assets/images/about/team/uw.svg"
+            href="https://www.washington.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIBIB"
-        src="assets/images/about/funding/nibib.svg"
-        href="http://nibib.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIBIB"
+            src="assets/images/about/funding/nibib.svg"
+            href="http://nibib.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIGMS"
-        src="assets/images/about/funding/nigms.svg"
-        href="http://nigms.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIGMS"
+            src="assets/images/about/funding/nigms.svg"
+            href="http://nigms.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIH"
-        src="assets/images/about/funding/nih.svg"
-        href="http://nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIH"
+            src="assets/images/about/funding/nih.svg"
+            href="http://nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NSF"
-        src="assets/images/about/funding/nsf.svg"
-        href="http://nsf.gov/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="BNGL"
-        src="assets/images/about/partners/bionetgen.png"
-        href="https://www.bionetgen.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NSF"
+            src="assets/images/about/funding/nsf.svg"
+            href="http://nsf.gov/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="BNGL"
+            src="assets/images/about/partners/bionetgen.png"
+            href="https://www.bionetgen.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SBML"
-        src="assets/images/about/partners/sbml.svg"
-        href="http://sbml.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SBML"
+            src="assets/images/about/partners/sbml.svg"
+            href="http://sbml.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SED-ML"
-        src="assets/images/about/partners/sed-ml.svg"
-        href="https://sed-ml.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SED-ML"
+            src="assets/images/about/partners/sed-ml.svg"
+            href="https://sed-ml.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Vega"
-        src="assets/images/about/partners/vega.svg"
-        href="https://vega.github.io/vega/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Vega"
+            src="assets/images/about/partners/vega.svg"
+            href="https://vega.github.io/vega/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Vega Lite"
-        src="assets/images/about/partners/vegalite.svg"
-        href="https://vega.github.io/vega-lite/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Vega Lite"
+            src="assets/images/about/partners/vegalite.svg"
+            href="https://vega.github.io/vega-lite/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COMBINE/OMEX"
-        src="assets/images/about/partners/omex.svg"
-        href="https://combinearchive.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COMBINE/OMEX"
+            src="assets/images/about/partners/omex.svg"
+            href="https://combinearchive.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="BioContainers"
-        src="assets/images/about/partners/biocontainers.png"
-        href="https://biocontainers.pro/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <!--
-      <biosimulations-home-logo
-        title="AMICI"
-        src="assets/images/about/partners/amici.svg"
-        href="http://amici-dev.github.io/AMICI/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="BioContainers"
+            src="assets/images/about/partners/biocontainers.png"
+            href="https://biocontainers.pro/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <!--
+          <biosimulations-home-logo
+            title="AMICI"
+            src="assets/images/about/partners/amici.svg"
+            href="http://amici-dev.github.io/AMICI/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Cayenne"
-        src="assets/images/about/partners/cayenne.png"
-        href="https://cayenne.readthedocs.io/"
-      >
-      </biosimulations-home-logo>
-      -->
+          <biosimulations-home-logo
+            title="Cayenne"
+            src="assets/images/about/partners/cayenne.png"
+            href="https://cayenne.readthedocs.io/"
+          >
+          </biosimulations-home-logo>
+          -->
 
-      <biosimulations-home-logo
-        title="COBRApy"
-        src="assets/images/about/partners/cobrapy.svg"
-        href="https://opencobra.github.io/cobrapy/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COBRApy"
+            src="assets/images/about/partners/cobrapy.svg"
+            href="https://opencobra.github.io/cobrapy/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COPASI"
-        src="assets/images/about/partners/copasi.svg"
-        href="http://copasi.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COPASI"
+            src="assets/images/about/partners/copasi.svg"
+            href="http://copasi.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GillesPy2"
-        src="assets/images/about/partners/gillespy2.svg"
-        href="https://gillespy2.github.io/GillesPy2/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GillesPy2"
+            src="assets/images/about/partners/gillespy2.svg"
+            href="https://gillespy2.github.io/GillesPy2/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="iBioSim"
-        src="assets/images/about/partners/ibiosim.svg"
-        href="https://github.com/MyersResearchGroup/iBioSim"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="iBioSim"
+            src="assets/images/about/partners/ibiosim.svg"
+            href="https://github.com/MyersResearchGroup/iBioSim"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NFsim"
-        src="assets/images/about/partners/nfsim.svg"
-        href="http://michaelsneddon.net/nfsim/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NFsim"
+            src="assets/images/about/partners/nfsim.svg"
+            href="http://michaelsneddon.net/nfsim/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="PySCeS"
-        src="assets/images/about/partners/pysces.svg"
-        href="http://pysces.sourceforge.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="PySCeS"
+            src="assets/images/about/partners/pysces.svg"
+            href="http://pysces.sourceforge.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="tellurium/libRoadRunner"
-        src="assets/images/about/partners/libroadrunner.svg"
-        href="http://tellurium.analogmachine.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="tellurium/libRoadRunner"
+            src="assets/images/about/partners/libroadrunner.svg"
+            href="http://tellurium.analogmachine.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="VCell"
-        src="assets/images/about/partners/vcell.svg"
-        href="https://vcell.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="VCell"
+            src="assets/images/about/partners/vcell.svg"
+            href="https://vcell.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="BiGG"
-        src="assets/images/about/partners/bigg.png"
-        href="http://bigg.ucsd.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="BiGG"
+            src="assets/images/about/partners/bigg.png"
+            href="http://bigg.ucsd.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="BioModels"
-        src="assets/images/about/partners/biomodels.svg"
-        href="http://biomodels.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="BioModels"
+            src="assets/images/about/partners/biomodels.svg"
+            href="http://biomodels.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Cell Collective"
-        src="assets/images/about/partners/cell-collective.png"
-        href="http://cellcollective.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Angular"
-        src="assets/images/about/tech/angular.svg"
-        href="https://angular.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Cell Collective"
+            src="assets/images/about/partners/cell-collective.png"
+            href="http://cellcollective.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="Angular"
+            src="assets/images/about/tech/angular.svg"
+            href="https://angular.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Auth0"
-        src="assets/images/about/tech/auth0.svg"
-        href="https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Auth0"
+            src="assets/images/about/tech/auth0.svg"
+            href="https://auth0.com/?utm_source=oss&utm_medium=gp&utm_campaign=oss"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Bruit.io"
-        src="assets/images/about/tech/bruit-io.svg"
-        href="https://www.bruit.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Bruit.io"
+            src="assets/images/about/tech/bruit-io.svg"
+            href="https://www.bruit.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Docker"
-        src="assets/images/about/tech/docker.svg"
-        href="http://www.docker.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Docker"
+            src="assets/images/about/tech/docker.svg"
+            href="http://www.docker.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Favicon Generator"
-        src="assets/images/about/tech/real-favicon-generator.png"
-        href="http://realfavicongenerator.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Favicon Generator"
+            src="assets/images/about/tech/real-favicon-generator.png"
+            href="http://realfavicongenerator.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Font Awesome"
-        src="assets/images/about/tech/font-awesome.svg"
-        href="https://fontawesome.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Font Awesome"
+            src="assets/images/about/tech/font-awesome.svg"
+            href="https://fontawesome.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GitHub"
-        src="assets/images/about/tech/github.svg"
-        href="https://github.com/open-source"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GitHub"
+            src="assets/images/about/tech/github.svg"
+            href="https://github.com/open-source"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Gravatar"
-        src="assets/images/about/tech/gravatar.svg"
-        href="https://gravatar.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Gravatar"
+            src="assets/images/about/tech/gravatar.svg"
+            href="https://gravatar.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Kubernetes"
-        src="assets/images/about/tech/kubernetes.svg"
-        href="https://kubernetes.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Kubernetes"
+            src="assets/images/about/tech/kubernetes.svg"
+            href="https://kubernetes.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Design"
-        src="assets/images/about/tech/material.svg"
-        href="https://material.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Design"
+            src="assets/images/about/tech/material.svg"
+            href="https://material.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Theme Generator"
-        src="assets/images/about/tech/material-theme-generator.svg"
-        href="https://materialtheme.arcsine.dev/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Theme Generator"
+            src="assets/images/about/tech/material-theme-generator.svg"
+            href="https://materialtheme.arcsine.dev/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="MongoDB"
-        src="assets/images/about/tech/mongodb.svg"
-        href="https://www.mongodb.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="MongoDB"
+            src="assets/images/about/tech/mongodb.svg"
+            href="https://www.mongodb.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NestJS"
-        src="assets/images/about/tech/nestjs.svg"
-        href="https://nestjs.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NestJS"
+            src="assets/images/about/tech/nestjs.svg"
+            href="https://nestjs.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Netlify"
-        src="assets/images/about/tech/netlify.svg"
-        href="https://www.netlify.com"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Netlify"
+            src="assets/images/about/tech/netlify.svg"
+            href="https://www.netlify.com"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="OpenAPI"
-        src="assets/images/about/tech/openapi.svg"
-        href="https://www.openapis.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
+          <biosimulations-home-logo
+            title="OpenAPI"
+            src="assets/images/about/tech/openapi.svg"
+            href="https://www.openapis.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+      </div>
+    </div>
   </ng-container>
 </biosimulations-home-section>

--- a/biosimulations/apps/platform/src/app/home/home.component.scss
+++ b/biosimulations/apps/platform/src/app/home/home.component.scss
@@ -1,0 +1,19 @@
+.about-content {
+    .text {
+        margin-bottom: 0.75rem;
+    }
+    .logos {
+        text-align: center;
+    }
+}
+
+@media screen and (max-width: 63.99875em) {
+    .about-content {
+        .text {
+            text-align: left;
+        }
+        .logos p {
+            display: inline;
+        }
+    }
+}

--- a/biosimulations/apps/platform/src/app/home/home.component.scss
+++ b/biosimulations/apps/platform/src/app/home/home.component.scss
@@ -7,7 +7,7 @@
     }
 }
 
-@media screen and (max-width: 63.99875em) {
+@media screen and (max-width: 959px) {
     .about-content {
         .text {
             text-align: left;

--- a/biosimulations/apps/simulators/src/app/help/about/about.component.html
+++ b/biosimulations/apps/simulators/src/app/help/about/about.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="About BioSimulators">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/simulators/src/app/help/about/about.component.html
+++ b/biosimulations/apps/simulators/src/app/help/about/about.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="About BioSimulators">
+<biosimulations-text-page heading="About BioSimulators" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Motivation and goals of BioSimulators"
-      shortHeading="Motivation and goals"
+      tocSection="Motivation and goals"
     >
       <p>
         More comprehensive and more predictive models have the potential to advance biology, bioengineering, and medicine. Building more predictive models will likely require the collaborative efforts of many investigators. This requires teams to be able to share and reuse model components and simulations. Despite extensive efforts to develop standards such as COMBINE/OMEX <a target="_blank" href="https://combinearchive.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, SBML <a target="_blank" href="http://sbml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, and SED-ML <a target="_blank" href="https://www.sed-ml.org/"><biosimulations-icon icon="link"></biosimulations-icon></a>, it remains difficult to reuse many models and simulations. One challenge to reusing models and simulations is the diverse array of incompatible modeling formats and simulation tools.
@@ -22,7 +22,7 @@
 
     <biosimulations-text-page-content-section
       heading="Supported modeling frameworks, algorithms, formats and software tools"
-      shortHeading="Supported frameworks &amp; formats"
+      tocSection="Supported frameworks &amp; formats"
     >
       <p>
         The BioSimulators standards, web application, and database support all modeling frameworks, simulation algorithms, and model formats. Currrently, BioSimulators includes tools for logical, Flux Balance Analysis (FBA), continous kinetic (ordinary differential equations (ODE) and differential-algebraic equations (DAE)), and discrete kinetic (e.g., Stochastic Simulation Algorithms (SSA)) simulation of models that are described in using the BioNetGen Language (BNGL) <a href="https://bionetgen.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> or the Systems Biology Markup Language (SBML) <a href="http://sbml.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>. Together, these tools support numerous simulation algorithms.
@@ -147,7 +147,7 @@
 
     <biosimulations-text-page-content-section
       heading="Technological foundation of BioSimulators"
-      shortHeading="Technological foundation"
+      tocSection="Technological foundation"
     >
       <p>
         BioSimulators is implemented using several open-source tools and cloud platforms.
@@ -220,7 +220,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the containerized simulation tools"
-      shortHeading="Obtaining the simulators"
+      tocSection="Obtaining the simulators"
     >
       <p>
         The containerized simulation software tools are available from DockerHub <a target="_blank" href="http://dockerhub.com/u/biosimulators"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -229,7 +229,7 @@
 
     <biosimulations-text-page-content-section
       heading="Obtaining the BioSimulators source code"
-      shortHeading="Obtaining the source code"
+      tocSection="Obtaining the source code"
     >
       <p>
         The BioSimulators source code is composed of the following open-source packages:
@@ -249,7 +249,7 @@
 
     <biosimulations-text-page-content-section
       heading="License"
-      shortHeading="License"
+      tocSection="License"
     >
       <p>The containerized simulators are provided under the open-source licenses documented for each image. The BioSimulators source code is provided under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -261,7 +261,7 @@
 
     <biosimulations-text-page-content-section
       heading="BioSimulators team"
-      shortHeading="BioSimulators team"
+      tocSection="BioSimulators team"
     >
       <p>
         BioSimulators was developed by the Center for Reproducible Biomedical Modeling <a href="http://reproduciblebiomodels.org/" target="_blank">
@@ -359,7 +359,7 @@
 
     <biosimulations-text-page-content-section
       heading="Contributing to BioSimulators"
-      shortHeading="Contributing to BioSimulators"
+      tocSection="Contributing to BioSimulators"
     >
       <p>
         We welcome contributions to BioSimulators!
@@ -373,7 +373,7 @@
 
     <biosimulations-text-page-content-section
       heading="Acknowledgements"
-      shortHeading="Acknowledgements"
+      tocSection="Acknowledgements"
     >
       <p>
         BioSimulators was developed with support from the Center for

--- a/biosimulations/apps/simulators/src/app/help/about/about.component.sass
+++ b/biosimulations/apps/simulators/src/app/help/about/about.component.sass
@@ -11,3 +11,9 @@
 
   img
     height: 2.5rem
+
+@media screen and (max-width: 959px)
+  .logos
+    text-align: center
+  .logos-row
+    display: inline

--- a/biosimulations/apps/simulators/src/app/help/about/about.component.ts
+++ b/biosimulations/apps/simulators/src/app/help/about/about.component.ts
@@ -1,17 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-about',
   templateUrl: './about.component.html',
   styleUrls: ['./about.component.sass'],
 })
-export class AboutComponent implements OnInit {
+export class AboutComponent {
   // TODO: get from app config
   apiUrl = 'https://api.biosimulations.org/'
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/simulators/src/app/help/faq/faq.component.html
+++ b/biosimulations/apps/simulators/src/app/help/faq/faq.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="FAQ">
+<biosimulations-text-page heading="FAQ" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,10 +7,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Docker images/containers"
-      shortHeading="Docker images/containers"
+      tocSection="Docker images/containers"
     >
       <biosimulations-q-a heading="What is a Docker image?">
         A Docker image is a template for creating a Docker container. Typically, Docker images are containers for an operating system and additional programs. Docker images enable developers to encapsulate programs and their dependencies into a format which can be shared through online repositories such as Docker Hub and run on top of any operating system.

--- a/biosimulations/apps/simulators/src/app/help/faq/faq.component.html
+++ b/biosimulations/apps/simulators/src/app/help/faq/faq.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="FAQ">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/simulators/src/app/help/faq/faq.component.ts
+++ b/biosimulations/apps/simulators/src/app/help/faq/faq.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './faq.component.html',
   styleUrls: ['./faq.component.sass'],
 })
-export class FaqComponent implements OnInit {
+export class FaqComponent {
   // TODO: get from app config
   issueUrl = 'https://github.com/biosimulations/Biosimulations/issues/new/choose'
   emailUrl = 'mailto:' + 'info@biosimulations.org'
@@ -12,7 +13,10 @@ export class FaqComponent implements OnInit {
   submitAppUrl = 'https://submit.biosimulations.org/'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/simulators/src/app/help/help/help.component.html
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Tutorial">
+<biosimulations-text-page heading="Tutorial" [tocSections]="tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
@@ -16,10 +16,10 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content">
+  <ng-container id="content" tocSectionsContainer>
      <biosimulations-text-page-content-section
       heading="Creating COMBINE/OMEX files that describe modeling projects"
-      shortHeading="Creating modeling projects"
+      tocSection="Creating modeling projects"
     >
       <p>
         The containerized biosimulation tools in the BioSimulators registry require modeling projects (one or more simulations of one or more models) to be described by an OMEX file and packaged into a COMBINE archive. Please follow these steps to create OMEX and COMBINE files. Alternatively, COMBINE/OMEX files which describe modeling projects can be obtained from the BioSimulations repository of modeling projects <a href="https://biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
@@ -46,14 +46,14 @@
 
     <biosimulations-text-page-content-section
       heading="Finding a simulation tool that is capable of executing a modeling project"
-      shortHeading="Finding simulation tools"
+      tocSection="Finding simulation tools'"
     >
       The simulation tools in the BioSimulators collection support different modeling frameworks, different simulation algorithms, and different model formats. The simulators page <a [routerLink]="['/simulators']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> outlines the modeling frameworks, simulation algorithms, and model formats supported by each tool. After determining the framework and format of your model and the simulation algorithm which you would like to execute, use this page to identify a simulation tool which is capable of executing your modeling project.
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
       heading="Using a containerized simulation tool to execute a simulation"
-      shortHeading="Executing simulations"
+      tocSection="Executing simulations"
     >
       <p>Two web applications are available for using the BioSimulators simulation tools to execute simulations. runBioSimulations <a href="https://submit.biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> is a simple application that uses BioSimulators to execute modeling studies. BioSimulations <a href="https://biosimulations.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> is a platform for publishing modeling studies that also uses BioSimulators to executed published modeling studies.</p>
 
@@ -88,14 +88,14 @@
 
     <biosimulations-text-page-content-section
       heading="Programmatically retrieving information about simulation tools via the REST API"
-      shortHeading="REST API"
+      tocSection="REST API"
     >
       An API is available for retrieving information about the simulation tools in the BioSimulators collection. Please see the documentation for the REST API <a [href]="apiUrl" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> for more information.
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
       heading="Developing BioSimulators-compliant containerized biosimulation tool"
-      shortHeading="Developing simulation tools"
+      tocSection="Developing simulation tools"
     >
       <p>We welcome contributions of additional simulation tools! Please follow the steps below to create a containerized simulation tool that adheres to the BioSimulators standards. Several examples are available from the BioSimulators GitHub organization <a href="https://github.com/biosimulations/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.</p>
       <ol class="vertically-spaced">
@@ -171,7 +171,7 @@ biosimulators-test-suite validate {{ '{' }} dockerhub-user-id {{ '}' }}/{{ '{' }
 
     <biosimulations-text-page-content-section
       heading="Contributing containerized biosimulation tools to BioSimulators"
-      shortHeading="Contributing simulation tools"
+      tocSection="Contributing simulation tools"
     >
       <p>We welcome contributions of additional simulation tools! Please follow these steps to contribute a tool to BioSimulators:</p>
       <ol class="vertically-spaced">

--- a/biosimulations/apps/simulators/src/app/help/help/help.component.html
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.html
@@ -1,6 +1,6 @@
 <biosimulations-text-page heading="Tutorial">
   <ng-container id="sideBar">
-    <biosimulations-text-page-side-bar-section heading="Related resources">
+    <biosimulations-text-page-side-bar-section heading="Related resources" fxShow fxHide.lt-md>
       <div class="hanging-indent">
         <a [href]="apiUrl" target="_blank">
           <biosimulations-icon icon="link"></biosimulations-icon>
@@ -9,10 +9,10 @@
       </div>
     </biosimulations-text-page-side-bar-section>
 
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/simulators/src/app/help/help/help.component.ts
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.ts
@@ -1,17 +1,21 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   templateUrl: './help.component.html',
   styleUrls: ['./help.component.sass'],
 })
-export class HelpComponent implements OnInit {
+export class HelpComponent {
   // TODO: get from app config
-  apiUrl = 'https://api.biosimulations.org/'  
+  apiUrl = 'https://api.biosimulations.org/'
   submitAppUrl = 'https://submit.biosimulations.org/'
   submitAppHelpUrl = this.submitAppUrl + 'help'
   webserviceUrl = 'https://dispatch.biosimulations.org/'
 
-  constructor() { }
+  tocSections!: TocSection[];
 
-  ngOnInit(): void { }
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Privacy policy">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.html
+++ b/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Privacy policy">
+<biosimulations-text-page heading="Privacy policy" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-simulators-privacy-policy id="content">
+  <biosimulations-simulators-privacy-policy id="content" #content>
   </biosimulations-simulators-privacy-policy>
 </biosimulations-text-page>

--- a/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.ts
+++ b/biosimulations/apps/simulators/src/app/help/privacy-policy/privacy-policy.component.ts
@@ -1,11 +1,8 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
   templateUrl: './privacy-policy.component.html',
   styleUrls: ['./privacy-policy.component.sass'],
 })
-export class PrivacyPolicyComponent implements OnInit {
-  constructor() { }
-
-  ngOnInit(): void { }
+export class PrivacyPolicyComponent {
 }

--- a/biosimulations/apps/simulators/src/app/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/simulators/src/app/help/terms-of-service/terms-of-service.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page heading="Terms of service">
+<biosimulations-text-page heading="Terms of service" [tocSections]="content.tocSections">
   <ng-container id="sideBar">
     <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
@@ -7,6 +7,6 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <biosimulations-simulators-terms-of-service id="content">
+  <biosimulations-simulators-terms-of-service id="content" #content>
   </biosimulations-simulators-terms-of-service>
 </biosimulations-text-page>

--- a/biosimulations/apps/simulators/src/app/help/terms-of-service/terms-of-service.component.html
+++ b/biosimulations/apps/simulators/src/app/help/terms-of-service/terms-of-service.component.html
@@ -1,9 +1,9 @@
 <biosimulations-text-page heading="Terms of service">
   <ng-container id="sideBar">
-    <biosimulations-text-page-help-side-bar-section>
+    <biosimulations-text-page-help-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-help-side-bar-section>
 
-    <biosimulations-text-page-feedback-side-bar-section>
+    <biosimulations-text-page-feedback-side-bar-section fxShow fxHide.lt-md>
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 

--- a/biosimulations/apps/simulators/src/app/home/home.component.html
+++ b/biosimulations/apps/simulators/src/app/home/home.component.html
@@ -187,279 +187,285 @@
 >
   <ng-container id="heading">About <span class="highlight-primary">BioSimulators</span></ng-container>
   <ng-container id="subsection">
-    <p>
-      BioSimulators was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
-    </p>
-    <p>
-      BioSimulators is implemented using several open-source tools and cloud platforms. The containerized simulators are available under the licenses specified for each container. The BioSimulators code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
-    </p>
-    <p>
-      Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Center for Reproducible Biomedical Modeling"
-        src="assets/images/about/team/crbm.svg"
-        href="https://reproduciblebiomodels.org/"
-      >
-      </biosimulations-home-logo>
+    <div class="about-content">
+      <div class="text">
+        <p>
+          BioSimulators was developed by the Center for Reproducible Biomedical Modeling <a href="https://reproduciblebiomodels.org/" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, the Karr Lab at the Icahn School of Medicine at Mount Sinai <a href="https://www.karrlab.org" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, and the Moraru Lab at the University of Connecticut Health Center <a href="https://facultydirectory.uchc.edu/profile?profileId=Moraru-Ion" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a> with support from the National Institutes of Health and the National Science Foundation.
+        </p>
+        <p>
+          BioSimulators is implemented using several open-source tools and cloud platforms. The containerized simulators are available under the licenses specified for each container. The BioSimulators code is openly available under the MIT license <a href="https://github.com/biosimulations/Biosimulations/blob/master/LICENSE" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.
+        </p>
+        <p>
+          Please see the About page <a [routerLink]="['/help', 'about']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> for more information.
+        </p>
+      </div>
+      <div class="logos">
+        <p>
+          <biosimulations-home-logo
+            title="Center for Reproducible Biomedical Modeling"
+            src="assets/images/about/team/crbm.svg"
+            href="https://reproduciblebiomodels.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Karr Lab"
-        src="assets/images/about/team/karr-lab.svg"
-        href="https://www.karrlab.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Karr Lab"
+            src="assets/images/about/team/karr-lab.svg"
+            href="https://www.karrlab.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Icahn School of Medicine at Mount Sinai"
-        src="assets/images/about/team/sinai.svg"
-        href="https://icahn.mssm.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Icahn School of Medicine at Mount Sinai"
+            src="assets/images/about/team/sinai.svg"
+            href="https://icahn.mssm.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Connecticut Health Center"
-        src="assets/images/about/team/uconn.svg"
-        href="https://health.uconn.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Connecticut Health Center"
+            src="assets/images/about/team/uconn.svg"
+            href="https://health.uconn.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="University of Washington"
-        src="assets/images/about/team/uw.svg"
-        href="https://www.washington.edu/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="University of Washington"
+            src="assets/images/about/team/uw.svg"
+            href="https://www.washington.edu/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIBIB"
-        src="assets/images/about/funding/nibib.svg"
-        href="http://nibib.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIBIB"
+            src="assets/images/about/funding/nibib.svg"
+            href="http://nibib.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIGMS"
-        src="assets/images/about/funding/nigms.svg"
-        href="http://nigms.nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIGMS"
+            src="assets/images/about/funding/nigms.svg"
+            href="http://nigms.nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NIH"
-        src="assets/images/about/funding/nih.svg"
-        href="http://nih.gov/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NIH"
+            src="assets/images/about/funding/nih.svg"
+            href="http://nih.gov/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NSF"
-        src="assets/images/about/funding/nsf.svg"
-        href="http://nsf.gov/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="BNGL"
-        src="assets/images/about/partners/bionetgen.png"
-        href="https://www.bionetgen.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NSF"
+            src="assets/images/about/funding/nsf.svg"
+            href="http://nsf.gov/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="BNGL"
+            src="assets/images/about/partners/bionetgen.png"
+            href="https://www.bionetgen.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SBML"
-        src="assets/images/about/partners/sbml.svg"
-        href="http://sbml.org"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SBML"
+            src="assets/images/about/partners/sbml.svg"
+            href="http://sbml.org"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="SED-ML"
-        src="assets/images/about/partners/sed-ml.svg"
-        href="https://sed-ml.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="SED-ML"
+            src="assets/images/about/partners/sed-ml.svg"
+            href="https://sed-ml.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COMBINE/OMEX"
-        src="assets/images/about/partners/omex.svg"
-        href="https://combinearchive.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COMBINE/OMEX"
+            src="assets/images/about/partners/omex.svg"
+            href="https://combinearchive.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="BioContainers"
-        src="assets/images/about/partners/biocontainers.png"
-        href="https://biocontainers.pro/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <!--
-      <biosimulations-home-logo
-        title="AMICI"
-        src="assets/images/about/partners/amici.svg"
-        href="http://amici-dev.github.io/AMICI/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="BioContainers"
+            src="assets/images/about/partners/biocontainers.png"
+            href="https://biocontainers.pro/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <!--
+          <biosimulations-home-logo
+            title="AMICI"
+            src="assets/images/about/partners/amici.svg"
+            href="http://amici-dev.github.io/AMICI/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Cayenne"
-        src="assets/images/about/partners/cayenne.png"
-        href="https://cayenne.readthedocs.io/"
-      >
-      </biosimulations-home-logo>
-      -->
+          <biosimulations-home-logo
+            title="Cayenne"
+            src="assets/images/about/partners/cayenne.png"
+            href="https://cayenne.readthedocs.io/"
+          >
+          </biosimulations-home-logo>
+          -->
 
-      <biosimulations-home-logo
-        title="COBRApy"
-        src="assets/images/about/partners/cobrapy.svg"
-        href="https://opencobra.github.io/cobrapy/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COBRApy"
+            src="assets/images/about/partners/cobrapy.svg"
+            href="https://opencobra.github.io/cobrapy/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="COPASI"
-        src="assets/images/about/partners/copasi.svg"
-        href="http://copasi.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="COPASI"
+            src="assets/images/about/partners/copasi.svg"
+            href="http://copasi.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GillesPy2"
-        src="assets/images/about/partners/gillespy2.svg"
-        href="https://gillespy2.github.io/GillesPy2/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GillesPy2"
+            src="assets/images/about/partners/gillespy2.svg"
+            href="https://gillespy2.github.io/GillesPy2/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="iBioSim"
-        src="assets/images/about/partners/ibiosim.svg"
-        href="https://github.com/MyersResearchGroup/iBioSim"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="iBioSim"
+            src="assets/images/about/partners/ibiosim.svg"
+            href="https://github.com/MyersResearchGroup/iBioSim"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NFsim"
-        src="assets/images/about/partners/nfsim.svg"
-        href="http://michaelsneddon.net/nfsim/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NFsim"
+            src="assets/images/about/partners/nfsim.svg"
+            href="http://michaelsneddon.net/nfsim/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="PySCeS"
-        src="assets/images/about/partners/pysces.svg"
-        href="http://pysces.sourceforge.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="PySCeS"
+            src="assets/images/about/partners/pysces.svg"
+            href="http://pysces.sourceforge.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="tellurium/libRoadRunner"
-        src="assets/images/about/partners/libroadrunner.svg"
-        href="http://tellurium.analogmachine.org/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="tellurium/libRoadRunner"
+            src="assets/images/about/partners/libroadrunner.svg"
+            href="http://tellurium.analogmachine.org/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="VCell"
-        src="assets/images/about/partners/vcell.svg"
-        href="https://vcell.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
-    <p>
-      <biosimulations-home-logo
-        title="Angular"
-        src="assets/images/about/tech/angular.svg"
-        href="https://angular.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="VCell"
+            src="assets/images/about/partners/vcell.svg"
+            href="https://vcell.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+        <p>
+          <biosimulations-home-logo
+            title="Angular"
+            src="assets/images/about/tech/angular.svg"
+            href="https://angular.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Bruit.io"
-        src="assets/images/about/tech/bruit-io.svg"
-        href="https://www.bruit.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Bruit.io"
+            src="assets/images/about/tech/bruit-io.svg"
+            href="https://www.bruit.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Docker"
-        src="assets/images/about/tech/docker.svg"
-        href="http://www.docker.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Docker"
+            src="assets/images/about/tech/docker.svg"
+            href="http://www.docker.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Favicon Generator"
-        src="assets/images/about/tech/real-favicon-generator.png"
-        href="http://realfavicongenerator.net/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Favicon Generator"
+            src="assets/images/about/tech/real-favicon-generator.png"
+            href="http://realfavicongenerator.net/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Font Awesome"
-        src="assets/images/about/tech/font-awesome.svg"
-        href="https://fontawesome.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Font Awesome"
+            src="assets/images/about/tech/font-awesome.svg"
+            href="https://fontawesome.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="GitHub"
-        src="assets/images/about/tech/github.svg"
-        href="https://github.com/open-source"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="GitHub"
+            src="assets/images/about/tech/github.svg"
+            href="https://github.com/open-source"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Kubernetes"
-        src="assets/images/about/tech/kubernetes.svg"
-        href="https://kubernetes.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Kubernetes"
+            src="assets/images/about/tech/kubernetes.svg"
+            href="https://kubernetes.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Design"
-        src="assets/images/about/tech/material.svg"
-        href="https://material.io/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Design"
+            src="assets/images/about/tech/material.svg"
+            href="https://material.io/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Material Theme Generator"
-        src="assets/images/about/tech/material-theme-generator.svg"
-        href="https://materialtheme.arcsine.dev/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Material Theme Generator"
+            src="assets/images/about/tech/material-theme-generator.svg"
+            href="https://materialtheme.arcsine.dev/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="MongoDB"
-        src="assets/images/about/tech/mongodb.svg"
-        href="https://www.mongodb.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="MongoDB"
+            src="assets/images/about/tech/mongodb.svg"
+            href="https://www.mongodb.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="NestJS"
-        src="assets/images/about/tech/nestjs.svg"
-        href="https://nestjs.com/"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="NestJS"
+            src="assets/images/about/tech/nestjs.svg"
+            href="https://nestjs.com/"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="Netlify"
-        src="assets/images/about/tech/netlify.svg"
-        href="https://www.netlify.com"
-      >
-      </biosimulations-home-logo>
+          <biosimulations-home-logo
+            title="Netlify"
+            src="assets/images/about/tech/netlify.svg"
+            href="https://www.netlify.com"
+          >
+          </biosimulations-home-logo>
 
-      <biosimulations-home-logo
-        title="OpenAPI"
-        src="assets/images/about/tech/openapi.svg"
-        href="https://www.openapis.org/"
-      >
-      </biosimulations-home-logo>
-    </p>
+          <biosimulations-home-logo
+            title="OpenAPI"
+            src="assets/images/about/tech/openapi.svg"
+            href="https://www.openapis.org/"
+          >
+          </biosimulations-home-logo>
+        </p>
+      </div>
+    </div>
   </ng-container>
 </biosimulations-home-section>

--- a/biosimulations/apps/simulators/src/app/home/home.component.scss
+++ b/biosimulations/apps/simulators/src/app/home/home.component.scss
@@ -1,0 +1,19 @@
+.about-content {
+    .text {
+        margin-bottom: 0.75rem;
+    }
+    .logos {
+        text-align: center;
+    }
+}
+
+@media screen and (max-width: 63.99875em) {
+    .about-content {
+        .text {
+            text-align: left;
+        }
+        .logos p {
+            display: inline;
+        }
+    }
+}

--- a/biosimulations/apps/simulators/src/app/home/home.component.scss
+++ b/biosimulations/apps/simulators/src/app/home/home.component.scss
@@ -7,7 +7,7 @@
     }
 }
 
-@media screen and (max-width: 63.99875em) {
+@media screen and (max-width: 959px) {
     .about-content {
         .text {
             text-align: left;

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -1,6 +1,10 @@
 <biosimulations-tab-page [loading]="loading$ | async">
   <biosimulations-tab-page-tab heading="Overview" icon="overview" [partialWidth]="true">
-    <div class="overview grid">
+    <div class="overview columns-container"
+      gdAuto.gt-sm="column"
+      gdColumns.gt-sm="1fr 25rem"
+      gdGap.gt-sm="2rem"
+    >
       <div>
         <h2>{{ name }} ({{ id }} / {{ version }})</h2>
         <p>
@@ -95,60 +99,62 @@
           </ul>
 
           <p class="subsection-heading no-bottom-margin">Parameters</p>
-          <mat-table [dataSource]="algorithm.parameters" class="algorithm-parameters">
-            <ng-container matColumnDef="id">
-              <mat-header-cell *matHeaderCellDef>Id</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.id }}
-              </div>
-              </mat-cell>
-            </ng-container>
-            <ng-container matColumnDef="name">
-              <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.name }}
-              </div>
-              </mat-cell>
-            </ng-container>
-            <ng-container matColumnDef="type">
-              <mat-header-cell *matHeaderCellDef>Type</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.type }}
-              </div>
-              </mat-cell>
-            </ng-container>
-            <ng-container matColumnDef="value">
-              <mat-header-cell *matHeaderCellDef>Value</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.value }}
-              </div>
-              </mat-cell>
-            </ng-container>
-            <ng-container matColumnDef="range">
-              <mat-header-cell *matHeaderCellDef>Recommended range</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.range }}
-              </div>
-              </mat-cell>
-            </ng-container>
-            <ng-container matColumnDef="kisaoId">
-              <mat-header-cell *matHeaderCellDef>KiSAO id</mat-header-cell>
-              <mat-cell *matCellDef="let parameter">
-                <div class="cell-content-container lines-one">
-                  {{ parameter.kisaoId }}
-                  <a *ngIf="parameter.kisaoUrl" [href]="parameter.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
-              </div>
-              </mat-cell>
-            </ng-container>
+          <div class="table-container">
+            <mat-table [dataSource]="algorithm.parameters" class="algorithm-parameters">
+              <ng-container matColumnDef="id">
+                <mat-header-cell *matHeaderCellDef>Id</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.id }}
+                </div>
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="name">
+                <mat-header-cell *matHeaderCellDef>Name</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.name }}
+                </div>
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="type">
+                <mat-header-cell *matHeaderCellDef>Type</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.type }}
+                </div>
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="value">
+                <mat-header-cell *matHeaderCellDef>Value</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.value }}
+                </div>
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="range">
+                <mat-header-cell *matHeaderCellDef>Recommended range</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.range }}
+                </div>
+                </mat-cell>
+              </ng-container>
+              <ng-container matColumnDef="kisaoId">
+                <mat-header-cell *matHeaderCellDef>KiSAO id</mat-header-cell>
+                <mat-cell *matCellDef="let parameter">
+                  <div class="cell-content-container lines-one">
+                    {{ parameter.kisaoId }}
+                    <a *ngIf="parameter.kisaoUrl" [href]="parameter.url" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>
+                </div>
+                </mat-cell>
+              </ng-container>
 
-            <mat-header-row *matHeaderRowDef="parameterColumns; sticky: true"></mat-header-row>
-            <mat-row *matRowDef="let row; columns: parameterColumns"></mat-row>
-          </mat-table>
+              <mat-header-row *matHeaderRowDef="parameterColumns; sticky: true"></mat-header-row>
+              <mat-row *matRowDef="let row; columns: parameterColumns"></mat-row>
+            </mat-table>
+          </div>
 
           <p class="subsection-heading no-bottom-margin">Citations</p>
           <ul class="icon-list">
@@ -171,8 +177,12 @@
   </biosimulations-tab-page-tab>
 
   <biosimulations-tab-page-tab heading="Versions" icon="version" [partialWidth]="true">
-    <div class="grid">
-      <div>
+    <div class="columns-container"
+      gdAuto.gt-sm="column"
+      gdColumns.gt-sm="1fr 25rem"
+      gdGap.gt-sm="2rem"
+    >
+      <div class="table-container">
         <mat-table [dataSource]="versions" class="versions">
           <ng-container matColumnDef="label">
             <mat-header-cell *matHeaderCellDef>Version</mat-header-cell>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -51,7 +51,7 @@
   <biosimulations-tab-page-tab heading="Algorithms" icon="simulator" class="algorithms">
     <biosimulations-text-page contentsHeading="Algorithms" [padded]="false" alwaysFixed="calc(64px + 32px + 32px + 2rem)">
       <ng-container id="sideBar">
-        <biosimulations-text-page-side-bar-section heading="More info">
+        <biosimulations-text-page-side-bar-section heading="More info" fxShow fxHide.lt-md>
           <div class="hanging-indent">
             <a [href]="url" target="_blank">
               <biosimulations-icon icon="link"></biosimulations-icon>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -1,7 +1,6 @@
 <biosimulations-tab-page [loading]="loading$ | async">
   <biosimulations-tab-page-tab heading="Overview" icon="overview" [partialWidth]="true">
     <div class="overview columns-container"
-      gdAuto.gt-sm="column"
       gdColumns.gt-sm="1fr 25rem"
       gdGap.gt-sm="2rem"
     >
@@ -178,7 +177,6 @@
 
   <biosimulations-tab-page-tab heading="Versions" icon="version" [partialWidth]="true">
     <div class="columns-container"
-      gdAuto.gt-sm="column"
       gdColumns.gt-sm="1fr 25rem"
       gdGap.gt-sm="2rem"
     >

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -52,7 +52,13 @@
   </biosimulations-tab-page-tab>
 
   <biosimulations-tab-page-tab heading="Algorithms" icon="simulator" class="algorithms">
-    <biosimulations-text-page contentsHeading="Algorithms" [padded]="false" alwaysFixed="calc(64px + 32px + 32px + 2rem)">
+    <biosimulations-text-page
+      contentsHeading="Algorithms"
+      [padded]="false"
+      alwaysFixed="calc(64px + 32px + 32px + 2rem)" 
+      [tocSections]="tocSections"
+      [tocScrollSectionScrollOffset]="128"
+    >
       <ng-container id="sideBar">
         <biosimulations-text-page-side-bar-section heading="More info" fxShow fxHide.lt-md>
           <div class="hanging-indent">
@@ -64,10 +70,10 @@
         </biosimulations-text-page-side-bar-section>
       </ng-container>
 
-      <ng-container id="content">
+      <ng-container id="content" tocSectionsContainer>
         <biosimulations-text-page-content-section *ngFor="let algorithm of algorithms"
           [heading]="algorithm.heading"
-          [shortHeading]="algorithm.name"
+          [tocSection]="algorithm.name"
         >
           <p class="subsection-heading no-bottom-margin">Description</p>
           <p>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
@@ -15,19 +15,21 @@
 }
 
 .section:not(:last-child) {
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
 }
 
 .subsection-heading {
     font-weight: bold;
 }
 
-.grid {
-    grid-template-columns: 1fr 25rem;
+.columns-container > *:last-child {
+    padding: 0.5rem 0.5rem 0;
 }
 
-.grid > *:last-child {
-    padding: 0.5rem 0.5rem 0;
+@media screen and (max-width: 959px) {
+    .columns-container > *:last-child {
+        margin-top: 1rem;
+    }
 }
 
 .citations tr:first-child {
@@ -69,6 +71,15 @@
       color: mat-color($theme-primary);
     }
   }
+}
+
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+
+    &:not(:last-child) {
+        margin-bottom: 0.5rem;
+    }    
 }
 
 .code {

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.scss
@@ -2,66 +2,66 @@
 @import 'biosimulations-typography';
 
 ::ng-deep .mat-typography {
-    h2, h3 {
-        margin: 0;
-    }
+  h2, h3 {
+    margin: 0;
+  }
 
-    h3 {
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-        border-radius: 4px;
-        background: $light-background;
-    }
+  h3 {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+    border-radius: 4px;
+    background: $light-background;
+  }
 }
 
 .section:not(:last-child) {
-    margin-bottom: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .subsection-heading {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .columns-container > *:last-child {
-    padding: 0.5rem 0.5rem 0;
+  padding: 0.5rem 0.5rem 0;
 }
 
 @media screen and (max-width: 959px) {
-    .columns-container > *:last-child {
-        margin-top: 1rem;
-    }
+  .columns-container > *:last-child {
+    margin-top: 1rem;
+  }
 }
 
 .citations tr:first-child {
-    th, td {
-        padding-top: 0.5rem;
-    }
+  th, td {
+    padding-top: 0.5rem;
+  }
 }
 
 .algorithm-parameters {
-    .mat-header-cell {
-        white-space: nowrap;
-    }
+  .mat-header-cell {
+    white-space: nowrap;
+  }
 
-    .mat-header-cell:nth-child(1),
-    .mat-header-cell:nth-child(3),
-    .mat-header-cell:nth-child(4),
-    .mat-header-cell:nth-child(6),
-    .mat-cell:nth-child(1),
-    .mat-cell:nth-child(3),
-    .mat-cell:nth-child(4),
-    .mat-cell:nth-child(6) {
-        flex: 0.75;
-    }
+  .mat-header-cell:nth-child(1),
+  .mat-header-cell:nth-child(3),
+  .mat-header-cell:nth-child(4),
+  .mat-header-cell:nth-child(6),
+  .mat-cell:nth-child(1),
+  .mat-cell:nth-child(3),
+  .mat-cell:nth-child(4),
+  .mat-cell:nth-child(6) {
+    flex: 0.75;
+  }
 }
 
 .versions {
-    .mat-header-cell:nth-child(1),
-    .mat-header-cell:nth-child(2),
-    .mat-cell:nth-child(1),
-    .mat-cell:nth-child(2) {
-        flex: 0.3;
-    }
+  .mat-header-cell:nth-child(1),
+  .mat-header-cell:nth-child(2),
+  .mat-cell:nth-child(1),
+  .mat-cell:nth-child(2) {
+    flex: 0.3;
+  }
 }
 
 .icon-list {
@@ -74,12 +74,12 @@
 }
 
 .table-container {
-    width: 100%;
-    overflow-x: auto;
+  width: 100%;
+  overflow-x: auto;
 
-    &:not(:last-child) {
-        margin-bottom: 0.5rem;
-    }    
+  &:not(:last-child) {
+    margin-bottom: 0.5rem;
+  }
 }
 
 .code {

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy, ViewChild } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { pluck, map, mergeAll, tap, catchError } from 'rxjs/operators';
 import { Observable, of, BehaviorSubject } from 'rxjs';
 
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 import { SimulatorService, Simulator } from '../simulator.service';
 import edamJson from '../edam.json';
 import kisaoJson from '../kisao.json';
@@ -275,5 +276,12 @@ export class ViewSimulatorComponent implements OnInit {
       url: citation.identifiers[0].url as string,
       text: text,
     };
+  }
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
   }
 }

--- a/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-feature.component.scss
+++ b/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-feature.component.scss
@@ -5,3 +5,24 @@ h3 {
   font-weight: 500;
   text-align: center;
 }
+
+.grid {
+  display: grid;
+  grid-gap: 2rem;
+}
+
+.grid-2 {
+  grid-template-columns: 1fr 1fr;
+}
+
+.grid-3 {
+  grid-template-columns: 1fr 1fr 1fr;
+}
+
+.grid-4 {
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+}
+
+.grid-5 {
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+}

--- a/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-features.component.html
+++ b/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-features.component.html
@@ -3,12 +3,14 @@
         <h2>{{ heading }}</h2>
         <div class="heading-separator"></div>
     </ng-container>
-    <div class="grid" [ngClass]="{
-        'grid-2': cols === 2,
-        'grid-3': cols === 3,
-        'grid-4': cols === 4,
-        'grid-5': cols === 5
-        }"
+    <div 
+        gdAuto="row"
+
+        [gdColumns]="'repeat(' + cols.toString() + ', 1fr)'"
+        gdGap="2rem"
+
+        gdColumns.lt-md="1fr"
+        gdGap.lt-md="1rem"
       >
       <ng-content select="#content"></ng-content>
     </div>

--- a/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-features.component.spec.ts
+++ b/biosimulations/libs/platform/view/src/lib/resource-home/resource-home-features.component.spec.ts
@@ -1,5 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { ResourceHomeFeaturesComponent } from './resource-home-features.component';
 
 describe('ResourceHomeFeaturesComponent', () => {
@@ -9,6 +10,7 @@ describe('ResourceHomeFeaturesComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [ResourceHomeFeaturesComponent],
+      imports: [FlexLayoutModule],
     }).compileComponents();
   }));
 

--- a/biosimulations/libs/shared/content/src/lib/policies/dispatch-privacy-policy.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/dispatch-privacy-policy.component.html
@@ -1,63 +1,63 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Personal data that we collect"
-    shortHeading="Personal data that we collect"
+    tocSection="Personal data that we collect"
   >
     We collect the email addresses of users. In addition, we collect standard information about user behavior such as the IP addresses, operating systems, and browsers used to access our website and the dates and times that users visit our website.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we use personal data"
-    shortHeading="How we use data"
+    tocSection="How we use data"
   >
     We use the email addresses to notify users when their simulations have completed and are ready for their analysis. We use the user behavior data to help improve the functionality of {{ appName }} for the scientific community. This includes helping us better understand the needs of users.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we collect personal data"
-    shortHeading="How we collect data"
+    tocSection="How we collect data"
   >
     Users optionally provide their email addresses when they submit simulations through the simulation submission form. We use Google Analytics to collect the user behavior data. Google Analytics uses cookies.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we store personal data"
-    shortHeading="How we store data"
+    tocSection="How we store data"
   >
     The email addresses are stored in our MongoDB database. We use Google Analytics to store the user behavior data. Personal data will not be transferred to international organisations.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How long we keep personal data"
-    shortHeading="How long we keep data"
+    tocSection="How long we keep data"
   >
     This personal data will be stored as long as {{ appName }} is live.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Who has access to this personal data"
-    shortHeading="Who has access to the data"
+    tocSection="Who has access to the data"
   >
     The email addresses and user behavior data is only accessible to the leader developers. We may also make information about the total volume of usage of particular simulation tools available to the public and third party organisations who supply the simulation tools without details of any individual's use.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Your rights regarding your personal data"
-    shortHeading="Your rights regarding your data"
+    tocSection="Your rights regarding your data"
   >
     You have the right to request at reasonable intervals and without excessive delay or expense, information about the user behavior data processed about you.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/dispatch-privacy-policy.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/dispatch-privacy-policy.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-dispatch-privacy-policy',
   templateUrl: './dispatch-privacy-policy.component.html',
   styleUrls: ['./dispatch-privacy-policy.component.scss'],
 })
-export class DispatchPrivacyPolicyComponent {  
+export class DispatchPrivacyPolicyComponent {
   // TODO: get from app config
   appName = 'runBioSimulators';
   emailUrl = 'mailto:' + 'info@biosimulators.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/policies/dispatch-terms-of-service.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/dispatch-terms-of-service.component.html
@@ -1,28 +1,28 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Permitted usage"
-    shortHeading="Permitted usage"
+    tocSection="Permitted usage"
   >
     {{ appName }} promotes open science by providing the community a central platform for executing biomodeling studies. The simulation tools available through {{ appName }} are available under the open-source licenses chosen by their owners. These licenses are available from BioSimulators <a href="https://biosimulators.org"><biosimulations-icon icon="link"></biosimulations-icon></a>. {{ appName }} imposes no additional restrictions on the use of these community-contributed tools beyond those imposed by their owners. These licences describe who can use each resource, for which purposes, and what attribution may be required.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Attribution"
-    shortHeading="Attribution"
+    tocSection="Attribution"
   >
     {{ appName }} expects attribution (e.g., in publications, services, or products) for use of its online services in accordance with good scientific practice. Please use the citation indicated on the help page <a [routerLink]="['/help']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a>.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Privacy policy"
-    shortHeading="Privacy policy"
+    tocSection="Privacy policy"
   >
     {{ appName }} collects limited personal data. Our privacy policy <a [routerLink]="['/help', 'privacy']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> describes how we collect, store, and use this data and who has access to this data.
   </biosimulations-text-page-content-section>
- 
+
   <biosimulations-text-page-content-section
     heading="Disclaimers"
-    shortHeading="Disclaimers"
+    tocSection="Disclaimers"
   >
     <p>The simulation tools available through {{ appName }} and simulation results provided by {{ appName }} are provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the {{ appName }} Team be liable for any claim, damages or other liability whatsoever, whether in an action of contract, tort or otherwise, arising from, out of or in connection with these studies or the use or other dealings in these studies.</p>
 
@@ -43,21 +43,21 @@
 
   <biosimulations-text-page-content-section
     heading="Right to update this policy"
-    shortHeading="Right to update this policy"
+    tocSection="Right to update this policy"
   >
     We reserve the right to update this policy at any time. The date of the most recent revision of this policy is at the bottom of this page.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/dispatch-terms-of-service.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/dispatch-terms-of-service.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-dispatch-terms-of-service',
   templateUrl: './dispatch-terms-of-service.component.html',
   styleUrls: ['./dispatch-terms-of-service.component.scss'],
 })
-export class DispatchTermsOfServiceComponent {  
+export class DispatchTermsOfServiceComponent {
   // TODO: get from app config
   appName = 'runBioSimulations';
   emailUrl = 'mailto:' + 'info@biosimulations.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/policies/platform-privacy-policy.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/platform-privacy-policy.component.html
@@ -1,63 +1,63 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Personal data that we collect"
-    shortHeading="Personal data that we collect"
+    tocSection="Personal data that we collect"
   >
     We collect profiles of the authors of each model, simulation, and visualization. This includes their name, institution, website, email, ORCID, and a brief biography. In addition, we collect standard information about user behavior such as the IP addresses, operating systems, and browsers used to access our website and the dates and times that users visit our website.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we use personal data"
-    shortHeading="How we use data"
+    tocSection="How we use data"
   >
     We use the author profiles to publicly credit authors for their models, simulations, and visualizations. We use the user behavior data to help improve the functionality of {{ appName }} for the scientific community. This includes helping us better understand the needs of users.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we collect personal data"
-    shortHeading="How we collect data"
+    tocSection="How we collect data"
   >
     After logging in, authors can edit their profile using our online form. We use Google Analytics to collect the user behavior data. Google Analytics uses cookies.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we store personal data"
-    shortHeading="How we store data"
+    tocSection="How we store data"
   >
     The author profiles are stored in our MongoDB database. We use Google Analytics to store the user behavior data. Personal data will not be transferred to international organisations.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How long we keep personal data"
-    shortHeading="How long we keep data"
+    tocSection="How long we keep data"
   >
     This personal data will be stored as long as {{ appName }} is live.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Who has access to this personal data"
-    shortHeading="Who has access to the data"
+    tocSection="Who has access to the data"
   >
     The author profiles are publicly accessible. The user behavior data is only accessible to the leader developers. We may also make information about the total volume of usage of particular simulation studies and simulation tools available to the public and third party organisations who supply the studies and tools without details of any individual's use.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Your rights regarding your personal data"
-    shortHeading="Your rights regarding your data"
+    tocSection="Your rights regarding your data"
   >
     You have the right to view, edit, or delete your author profile at any time. You also have the right to request at reasonable intervals and without excessive delay or expense, information about the user behavior data processed about you.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/platform-privacy-policy.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/platform-privacy-policy.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-platform-privacy-policy',
   templateUrl: './platform-privacy-policy.component.html',
   styleUrls: ['./platform-privacy-policy.component.scss'],
 })
-export class PlatformPrivacyPolicyComponent {  
+export class PlatformPrivacyPolicyComponent {
   // TODO: get from app config
   appName = 'BioSimulations';
   emailUrl = 'mailto:' + 'info@biosimulations.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/policies/platform-terms-of-service.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/platform-terms-of-service.component.html
@@ -1,28 +1,28 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Permitted usage"
-    shortHeading="Permitted usage"
+    tocSection="Permitted usage"
   >
     {{ appName }} promotes open science by providing the community a central platform for sharing and executing biomodeling studies. The public simulation studies, simulation tools, and simulation results available through {{ appName }} are available under the open-source licenses chosen by their owners. The licenses for the simulation studies and results are noted with each resource. The licenses for the simulation tools are available from BioSimulators <a href="https://biosimulators.org"><biosimulations-icon icon="link"></biosimulations-icon></a>. {{ appName }} imposes no additional restrictions on the use of these community-contributed resources beyond those imposed by their owners. These licences describe who can use each resource, for which purposes, and what attribution may be required.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Attribution"
-    shortHeading="Attribution"
+    tocSection="Attribution"
   >
     {{ appName }} expects attribution (e.g., in publications, services, or products) for use of its simulation studies and online services in accordance with good scientific practice. Please use the citation indicated on the help page <a [routerLink]="['/help']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a>.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Privacy policy"
-    shortHeading="Privacy policy"
+    tocSection="Privacy policy"
   >
     {{ appName }} collects limited personal data. Our privacy policy <a [routerLink]="['/help', 'privacy']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> describes how we collect, store, and use this data and who has access to this data.
   </biosimulations-text-page-content-section>
- 
+
   <biosimulations-text-page-content-section
     heading="Disclaimers"
-    shortHeading="Disclaimers"
+    tocSection="Disclaimers"
   >
     <p>The simulation studies, simulation tools, and simulation results available through {{ appName }} are provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the {{ appName }} Team be liable for any claim, damages or other liability whatsoever, whether in an action of contract, tort or otherwise, arising from, out of or in connection with these studies or the use or other dealings in these studies.</p>
 
@@ -43,21 +43,21 @@
 
   <biosimulations-text-page-content-section
     heading="Right to update this policy"
-    shortHeading="Right to update this policy"
+    tocSection="Right to update this policy"
   >
     We reserve the right to update this policy at any time. The date of the most recent revision of this policy is at the bottom of this page.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/platform-terms-of-service.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/platform-terms-of-service.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-platform-terms-of-service',
   templateUrl: './platform-terms-of-service.component.html',
   styleUrls: ['./platform-terms-of-service.component.scss'],
 })
-export class PlatformTermsOfServiceComponent {  
+export class PlatformTermsOfServiceComponent {
   // TODO: get from app config
   appName = 'BioSimulations';
   emailUrl = 'mailto:' + 'info@biosimulations.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/policies/simulators-privacy-policy.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/simulators-privacy-policy.component.html
@@ -1,63 +1,63 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Personal data that we collect"
-    shortHeading="Personal data that we collect"
+    tocSection="Personal data that we collect"
   >
     We collect standard information about user behavior such as the IP addresses, operating systems, and browsers used to access our website and the dates and times that users visit our website.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we use personal data"
-    shortHeading="How we use data"
+    tocSection="How we use data"
   >
     We use this data to help improve the functionality of {{ appName }} for the scientific community. This includes helping us better understand the needs of users.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we collect personal data"
-    shortHeading="How we collect data"
+    tocSection="How we collect data"
   >
     We use Google Analytics to collect the user behavior data. Google Analytics uses cookies.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How we store personal data"
-    shortHeading="How we store data"
+    tocSection="How we store data"
   >
     We use Google Analytics to store the user behavior data. This data will not be transferred to international organisations.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How long we keep personal data"
-    shortHeading="How long we keep data"
+    tocSection="How long we keep data"
   >
     This data will be stored as long as {{ appName }} is live.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Who has access to this personal data"
-    shortHeading="Who has access to the data"
+    tocSection="Who has access to the data"
   >
     This data is only accessible to the leader developers. We may also make information about the total volume of usage of particular simulation tools available to the public and third party organisations who supply the simulation tools without details of any individual's use.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Your rights regarding your personal data"
-    shortHeading="Your rights regarding your data"
+    tocSection="Your rights regarding your data"
   >
     You have the right to request at reasonable intervals and without excessive delay or expense, information about the user behavior data processed about you.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/simulators-privacy-policy.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/simulators-privacy-policy.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-simulators-privacy-policy',
   templateUrl: './simulators-privacy-policy.component.html',
   styleUrls: ['./simulators-privacy-policy.component.scss'],
 })
-export class SimulatorsPrivacyPolicyComponent {  
+export class SimulatorsPrivacyPolicyComponent {
   // TODO: get from app config
   appName = 'BioSimulators';
   emailUrl = 'mailto:' + 'info@biosimulators.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/policies/simulators-terms-of-service.component.html
+++ b/biosimulations/libs/shared/content/src/lib/policies/simulators-terms-of-service.component.html
@@ -1,28 +1,28 @@
-<ng-container>
+<ng-container tocSectionsContainer>
   <biosimulations-text-page-content-section
     heading="Permitted usage"
-    shortHeading="Permitted usage"
+    tocSection="Permitted usage"
   >
     {{ appName }} promotes open science by providing the community a central platform for sharing biosimulation tools. These tools are available under the open-source licenses chosen by their owners. These licenses are noted with each resource. {{ appName }} imposes no additional restrictions on the use of these community-contributed resources beyond those imposed by their owners. These licences describe who can use each tool, for which purposes, and what attribution may be required.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Attribution"
-    shortHeading="Attribution"
+    tocSection="Attribution"
   >
     {{ appName }} expects attribution (e.g., in publications, services, or products) for use of its simulation tools in accordance with good scientific practice. Please use the citation indicated on the help page <a [routerLink]="['/help']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a>.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Privacy policy"
-    shortHeading="Privacy policy"
+    tocSection="Privacy policy"
   >
     {{ appName }} collects limited personal data. Our privacy policy <a [routerLink]="['/help', 'privacy']"><biosimulations-icon icon="internalLink"></biosimulations-icon></a> describes how we collect, store, and use this data and who has access to this data.
   </biosimulations-text-page-content-section>
- 
+
   <biosimulations-text-page-content-section
     heading="Disclaimers"
-    shortHeading="Disclaimers"
+    tocSection="Disclaimers"
   >
     <p>The simulation tools available through {{ appName }} are provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the {{ appName }} Team be liable for any claim, damages or other liability whatsoever, whether in an action of contract, tort or otherwise, arising from, out of or in connection with these studies or the use or other dealings in these studies.</p>
 
@@ -43,21 +43,21 @@
 
   <biosimulations-text-page-content-section
     heading="Right to update this policy"
-    shortHeading="Right to update this policy"
+    tocSection="Right to update this policy"
   >
     We reserve the right to update this policy at any time. The date of the most recent revision of this policy is at the bottom of this page.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="How to contact us"
-    shortHeading="Contact information"
+    tocSection="Contact information"
   >
     If you have any questions about this policy, please contact Jonathan Karr and Ion Moraru at <a [href]="emailUrl"><biosimulations-icon icon="email"></biosimulations-icon></a> or at 263 Farmington Avenue, Farmington, CT 06030-6406, USA.
   </biosimulations-text-page-content-section>
 
   <biosimulations-text-page-content-section
     heading="Date this policy was last revised"
-    shortHeading="Last revision date"
+    tocSection="Last revision date"
   >
     This policy was last revised on August 29, 2020.
   </biosimulations-text-page-content-section>

--- a/biosimulations/libs/shared/content/src/lib/policies/simulators-terms-of-service.component.ts
+++ b/biosimulations/libs/shared/content/src/lib/policies/simulators-terms-of-service.component.ts
@@ -1,14 +1,20 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 
 @Component({
   selector: 'biosimulations-simulators-terms-of-service',
   templateUrl: './simulators-terms-of-service.component.html',
   styleUrls: ['./simulators-terms-of-service.component.scss'],
 })
-export class SimulatorsTermsOfServiceComponent {  
+export class SimulatorsTermsOfServiceComponent {
   // TODO: get from app config
   appName = 'BioSimulators';
   emailUrl = 'mailto:' + 'info@biosimulators.org'
-  
-  constructor() {}
+
+  tocSections!: TocSection[];
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    setTimeout(() => {this.tocSections = container.sections;});
+  }
 }

--- a/biosimulations/libs/shared/content/src/lib/text-page-side-bar-sections/text-page-citation-side-bar-section.component.html
+++ b/biosimulations/libs/shared/content/src/lib/text-page-side-bar-sections/text-page-citation-side-bar-section.component.html
@@ -1,4 +1,4 @@
-<biosimulations-text-page-side-bar-section heading="Citing BioSimulations">
+<biosimulations-text-page-side-bar-section heading="Citing BioSimulations" fxShow fxHide.lt-md>
   <p>
     We aim to submit a publication in late 2020. Please check back later this year for a pre-print.
   </p>

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -25,8 +25,20 @@ body {
   box-sizing: border-box;
 }
 
+@media screen and (max-width: 959px) {
+  .full-width {
+    height: calc(100vh - 56px);
+  }
+}
+
 .padded {
   padding: 2rem;
+}
+
+@media screen and (max-width: 959px) {
+  .padded {
+    padding: 1rem;
+  }
 }
 
 h1,

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -83,18 +83,6 @@ h2,
   grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
 }
 
-.columns {
-  column-gap: 2rem;
-}
-
-.columns-2 {
-  column-count: 2;
-}
-
-.columns-3 {
-  column-count: 3;
-}
-
 .inline-list {
   display: inline;
   list-style-type: none;

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -61,28 +61,6 @@ h2,
   color: mat-color($theme-primary);
 }
 
-
-.grid {
-  display: grid;
-  grid-gap: 2rem;
-}
-
-.grid-2 {
-  grid-template-columns: 1fr 1fr;
-}
-
-.grid-3 {
-  grid-template-columns: 1fr 1fr 1fr;
-}
-
-.grid-4 {
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-}
-
-.grid-5 {
-  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
-}
-
 .inline-list {
   display: inline;
   list-style-type: none;

--- a/biosimulations/libs/shared/ui/src/index.ts
+++ b/biosimulations/libs/shared/ui/src/index.ts
@@ -1,2 +1,5 @@
 export * from './lib/table/table.component';
+export * from './lib/toc/toc-section';
+export * from './lib/toc/toc-section.directive';
+export * from './lib/toc/toc-sections-container.directive';
 export * from './lib/shared-ui.module';

--- a/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.html
@@ -47,7 +47,7 @@
         </ng-content>
       </biosimulations-topbar>
     </div>
-    <div class="bread-crumbs">
+    <div class="bread-crumbs" fxShow fxHide.lt-md>
       <biosimulations-bread-crumbs
         [pad]="!drawer.opened"
       ></biosimulations-bread-crumbs>

--- a/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
@@ -30,6 +30,12 @@
     overflow-y: auto;
   }
 
+  @media screen and (max-width: 959px) {
+    .sidenav-menu-container {
+      height: calc(100% - 56px);
+    }
+  }
+
   .sidenav-menu ::ng-deep .mat-expansion-panel:first-of-type {
       border-top-right-radius: 0;
       border-top-left-radius: 0;
@@ -85,6 +91,10 @@
 }
 
 @media screen and (max-width: 959px) {
+  .bread-crumbs {
+    top: 56px;
+  }
+
   .content {
     min-height: calc(100vh - 56px); // TODO: substract an additional 52px when the privacy notice is visible
   }

--- a/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
@@ -63,6 +63,12 @@
   position: sticky;
   top: 0;
   z-index: 200;
+
+  @media (max-width: 599px) {
+    ::ng-deep .mat-toolbar-single-row {
+        height: 64px;
+    }
+  }
 }
 
 .topbar-left-button {

--- a/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/biosimulations-navigation/biosimulations-navigation.component.scss
@@ -63,12 +63,6 @@
   position: sticky;
   top: 0;
   z-index: 200;
-
-  @media (max-width: 599px) {
-    ::ng-deep .mat-toolbar-single-row {
-        height: 64px;
-    }
-  }
 }
 
 .topbar-left-button {
@@ -87,7 +81,13 @@
 .content {
   padding: 0;
   background: #fff;
-  min-height: calc(100vh - 64px - 32px); // TODO: substract an additional 52px when the privacy notice is visible
+  min-height: calc(100vh - 64px - 28px - 0.5rem); // TODO: substract an additional 52px when the privacy notice is visible
+}
+
+@media screen and (max-width: 959px) {
+  .content {
+    min-height: calc(100vh - 56px); // TODO: substract an additional 52px when the privacy notice is visible
+  }
 }
 
 .logo-img {

--- a/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.html
@@ -17,6 +17,5 @@
     class="buttons"
     [buttons]="contextButtons"
     fxFlex
-    fxShow fxHide.lt-md
   ></biosimulations-bread-crumb-buttons>
 </mat-toolbar>

--- a/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.html
@@ -17,5 +17,6 @@
     class="buttons"
     [buttons]="contextButtons"
     fxFlex
+    fxShow fxHide.lt-md
   ></biosimulations-bread-crumb-buttons>
 </mat-toolbar>

--- a/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/bread-crumbs/bread-crumbs.component.scss
@@ -15,7 +15,7 @@ mat-toolbar {
 
 .breadcrumb {
   margin: 0;
-  padding-left: calc(20px + 1rem);
+  padding-left: 0;
 
   li {
     list-style: none;

--- a/biosimulations/libs/shared/ui/src/lib/home/home-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-section.component.html
@@ -1,4 +1,4 @@
-<div class="container partial-width">
+<div class="container partial-width padded">
   <div class="heading"><ng-content select="#heading"></ng-content></div>
   <div class="heading-separator"></div>
   <div class="subsections" 

--- a/biosimulations/libs/shared/ui/src/lib/home/home-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-section.component.html
@@ -1,13 +1,12 @@
 <div class="container partial-width">
   <div class="heading"><ng-content select="#heading"></ng-content></div>
   <div class="heading-separator"></div>
-  <div class="subsections" [ngClass]="{
-    'grid': columns > 1,
-    'grid-2': columns === 2,
-    'grid-3': columns === 3,
-    'grid-4': columns === 4,
-    'grid-5': columns === 5
-  }">
+  <div class="subsections" 
+    fxLayout="row"
+    fxLayout.lt-md="column"
+    fxLayoutAlign="space-between"
+    fxLayoutGap="32px"
+  >
     <ng-content select="#subsection"></ng-content>
   </div>
 </div>

--- a/biosimulations/libs/shared/ui/src/lib/home/home-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-section.component.scss
@@ -9,6 +9,8 @@
 .container {
   padding-top: 4rem;
   padding-bottom: 4rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .heading {

--- a/biosimulations/libs/shared/ui/src/lib/home/home-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-section.component.scss
@@ -9,8 +9,6 @@
 .container {
   padding-top: 4rem;
   padding-bottom: 4rem;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
 .heading {

--- a/biosimulations/libs/shared/ui/src/lib/home/home-subsection.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/home/home-subsection.component.scss
@@ -22,7 +22,7 @@ biosimulations-icon {
   line-height: normal;
   font-weight: bold;
   text-align: center;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
 }
 
 .subheading-large {
@@ -43,7 +43,7 @@ biosimulations-icon {
   line-height: normal;
   padding: 0;
   margin: 0;
-  margin-top: 1rem;
+  margin-top: 0.5rem;
   list-style-type: none;
   text-align: center;
 }

--- a/biosimulations/libs/shared/ui/src/lib/page/page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/page/page.component.html
@@ -1,5 +1,5 @@
 <div class="partial-width" [ngClass]="{'padded': padded}">
-  <h1 *ngIf="heading">
+  <h1 *ngIf="heading" fxShow fxHide.lt-md>
     {{ heading }}
     <div class="buttons">
       <ng-content select="#buttons"></ng-content>

--- a/biosimulations/libs/shared/ui/src/lib/shared-ui.module.ts
+++ b/biosimulations/libs/shared/ui/src/lib/shared-ui.module.ts
@@ -34,6 +34,8 @@ import { HomeSectionComponent } from './home/home-section.component';
 import { HomeSubsectionComponent } from './home/home-subsection.component';
 import { HomeTeaserComponent } from './home/home-teaser.component';
 import { HomeLogoComponent } from './home/home-logo.component';
+import { TocSectionDirective } from './toc/toc-section.directive';
+import { TocSectionsContainerDirective } from './toc/toc-sections-container.directive';
 @NgModule({
   imports: [CommonModule, MaterialWrapperModule, RouterModule, BiosimulationsIconsModule, BreadCrumbsModule],
   exports: [MaterialWrapperModule, TopbarComponent, TopbarMenuComponent, TopbarMenuItemComponent,
@@ -47,6 +49,7 @@ import { HomeLogoComponent } from './home/home-logo.component';
     TextPageComponent, TextPageSectionComponent, TextPageSideBarSectionComponent, TextPageContentSectionComponent, TextPageTocItemComponent,
     QAComponent,
     HomeSectionComponent, HomeSubsectionComponent, HomeTeaserComponent, HomeLogoComponent,
+    TocSectionDirective, TocSectionsContainerDirective,
   ],
   declarations: [TopbarComponent, TopbarMenuComponent, TopbarMenuItemComponent,
     HoverOpenMenuComponent, DropdownMenuItemComponent,
@@ -60,6 +63,7 @@ import { HomeLogoComponent } from './home/home-logo.component';
     TextPageComponent, TextPageSectionComponent, TextPageSideBarSectionComponent, TextPageContentSectionComponent, TextPageTocItemComponent,
     QAComponent,
     HomeSectionComponent, HomeSubsectionComponent, HomeTeaserComponent, HomeLogoComponent,
+    TocSectionDirective, TocSectionsContainerDirective,
   ],
 })
 export class SharedUiModule { }

--- a/biosimulations/libs/shared/ui/src/lib/spinner/full-page-spinner.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/spinner/full-page-spinner.component.scss
@@ -1,6 +1,12 @@
 .container {
-  height: calc(100vh - 96px);
+  height: calc(100vh - 64px - 28px - 0.5rem);
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+@media screen and (max-width: 959px) {
+  .container {
+    height: calc(100vh - 56px);
+  }
 }

--- a/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
@@ -38,4 +38,16 @@
     min-height: calc(100vh - 64px - 32px - 32px - 2 * 2rem);
     z-index: 0;
   }
+
+  @media screen and (max-width: 959px) {
+    .mat-tab-header {
+      top: 56px;
+    }
+
+    .mat-tab-body-wrapper {
+      padding: 1rem;
+      min-height: calc(100vh - 56px - 32px - 2 * 1rem);
+      z-index: 0;
+    }
+  }
 }

--- a/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
@@ -10,7 +10,7 @@
   }
 
   .mat-tab-label-container {
-    padding-left: calc(20px + 1rem);
+    padding-left: 0;
   }
 
   .mat-tab-label {

--- a/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/tab-page/tab-page.component.scss
@@ -36,5 +36,6 @@
   .mat-tab-body-wrapper {
     padding: 2rem;
     min-height: calc(100vh - 64px - 32px - 32px - 2 * 2rem);
+    z-index: 0;
   }
 }

--- a/biosimulations/libs/shared/ui/src/lib/table/table.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/table/table.component.html
@@ -2,7 +2,17 @@
   <biosimulations-spinner></biosimulations-spinner>
 </div>
 
-<div class="grid" [ngClass]="{hidden: isLoading | async}">
+<div  
+  gdAuto="column"
+  gdColumns.gt-sm="16rem 1fr"
+  gdGap="2rem"
+
+  gdAuto.lt-md="row"
+  gdRows.lt-md="1fr"
+  gdGap.lt-md="1rem"
+
+  [ngClass]="{hidden: isLoading | async}"
+>
   <mat-accordion class="controls">
     <mat-expansion-panel>
       <mat-expansion-panel-header

--- a/biosimulations/libs/shared/ui/src/lib/table/table.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/table/table.component.html
@@ -3,11 +3,11 @@
 </div>
 
 <div  
-  gdAuto="column"
+  gdAuto="row"
+
   gdColumns.gt-sm="16rem 1fr"
   gdGap="2rem"
 
-  gdAuto.lt-md="row"
   gdRows.lt-md="1fr"
   gdGap.lt-md="1rem"
 

--- a/biosimulations/libs/shared/ui/src/lib/table/table.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/table/table.component.scss
@@ -6,10 +6,6 @@
     justify-content: center;
 }
 
-.grid {
-    grid-template-columns: 16rem 1fr;
-}
-
 ::ng-deep .mat-accordion {
     .mat-expansion-panel {
         border-left: 1px solid $light-bg-darker-5;

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
@@ -1,6 +1,5 @@
 import {
   Component,
-  OnInit,
   Input,
   ChangeDetectionStrategy,
 } from '@angular/core';
@@ -11,16 +10,9 @@ import {
   styleUrls: ['./text-page-content-section.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TextPageContentSectionComponent implements OnInit {
+export class TextPageContentSectionComponent {
   @Input()
   heading = '';
-
-  @Input()
-  shortHeading = '';
-
-  constructor() {}
-
-  ngOnInit(): void {}
 
   scrollToTop(): void {
     const scrollContainer = document.getElementsByTagName('mat-sidenav-content')[0];

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
@@ -2,6 +2,12 @@
   margin-top: 2rem;
 }
 
+@media screen and (max-width: 959px) {
+  .container {
+    margin-top: 1rem;
+  }
+}
+
 h2 {
   padding-left: 0.5rem;
   padding-right: 0.5rem;

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-toc-item.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-toc-item.component.ts
@@ -18,13 +18,16 @@ export class TextPageTocItemComponent implements OnInit {
   @Input()
   scrollTarget!: HTMLElement;
 
+  @Input()
+  scrollOffset = 0;
+
   constructor() {}
 
   ngOnInit(): void {}
 
   scrollToElement(): void {
     const scrollContainer = document.getElementsByTagName('mat-sidenav-content')[0];
-    const y = this.scrollTarget.getBoundingClientRect().top + scrollContainer.scrollTop - 96;
+    const y = this.scrollTarget.getBoundingClientRect().top + scrollContainer.scrollTop - this.scrollOffset;
     scrollContainer.scrollTo({top: y, behavior: 'smooth'});
   }
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
@@ -1,6 +1,5 @@
 <biosimulations-page [heading]="heading" [padded]="padded">
   <div
-    gdAuto.gt-sm="column"
     gdColumns.gt-sm="16rem 1fr"
     gdGap.gt-sm="2rem"
   >

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
@@ -12,7 +12,11 @@
       >
         <biosimulations-text-page-side-bar-section [heading]="contentsHeading">
           <ul>
-            <biosimulations-text-page-toc-item *ngFor="let section of tocSections" [heading]="section.heading" [scrollTarget]="section.target">
+            <biosimulations-text-page-toc-item *ngFor="let section of tocSections"
+              [heading]="section.heading"
+              [scrollTarget]="section.target"
+              [scrollOffset]="tocScrollSectionScrollOffset"
+            >
             </biosimulations-text-page-toc-item>
           </ul>
         </biosimulations-text-page-side-bar-section>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
@@ -1,9 +1,13 @@
 <biosimulations-page [heading]="heading" [padded]="padded">
-  <div class="grid grid-2">
+  <div
+    gdAuto.gt-sm="column"
+    gdColumns.gt-sm="16rem 1fr"
+    gdGap.gt-sm="2rem"
+  >
     <div class="side-bar">
-      <div class="side-bar-inner sections-container"
+      <div class="sections-container side-bar-container"
         [ngStyle]="{
-          position: !heading || alwaysFixed != null || fixed ? 'fixed': null,
+          position: (!heading || alwaysFixed != null || fixed) && !smallLayout ? 'fixed': null,
           top: alwaysFixed == null ? 'calc(64px + 32px + 2rem)' : alwaysFixed
         }"
       >
@@ -18,7 +22,7 @@
       </div>
     </div>
 
-    <div #sectionsContainer class="sections-container">
+    <div #sectionsContainer class="sections-container content-container">
       <ng-content select="#content"></ng-content>
     </div>
   </div>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -1,11 +1,13 @@
-.grid {
-  grid-template-columns: 16rem 1fr;
-}
-
-.side-bar-inner {
-  width: 16rem;
-}
-
 .sections-container {
   margin-top: -2rem;
+}
+
+@media screen and (max-width: 959px) {
+ .side-bar-container {
+   margin-top: -1rem;
+  } 
+
+ .content-container {
+   margin-top: 0;
+  } 
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -5,9 +5,9 @@
 @media screen and (max-width: 959px) {
  .side-bar-container {
    margin-top: -1rem;
-  } 
+  }
 
  .content-container {
    margin-top: 0;
-  } 
+  }
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -4,6 +4,7 @@ import {
   ViewChild,
   ElementRef,
 } from '@angular/core';
+import { MediaMatcher } from '@angular/cdk/layout';
 
 interface TocItem {
   heading: string;
@@ -29,6 +30,7 @@ export class TextPageComponent {
   alwaysFixed: string | null = null;
 
   fixed = false;
+  smallLayout = false;
 
   tocSections: TocItem[] = [];
   tocSectionObservers: MutationObserver[] = [];
@@ -80,8 +82,14 @@ export class TextPageComponent {
     }
   }
 
-  constructor() {
+  constructor(mediaMatcher: MediaMatcher) {
     window.addEventListener('scroll', this.scroll, true);
+
+    const matcher = mediaMatcher.matchMedia('(max-width: 959px)');
+    this.smallLayout = matcher.matches;
+    matcher.addListener((event) => {
+      this.smallLayout = event.matches;
+    });
   }
 
   ngOnDestroy() {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -5,11 +5,7 @@ import {
   ElementRef,
 } from '@angular/core';
 import { MediaMatcher } from '@angular/cdk/layout';
-
-interface TocItem {
-  heading: string;
-  target: HTMLElement;
-}
+import { TocSection } from '../toc/toc-section';
 
 @Component({
   selector: 'biosimulations-text-page',
@@ -32,55 +28,11 @@ export class TextPageComponent {
   fixed = false;
   smallLayout = false;
 
-  tocSections: TocItem[] = [];
-  tocSectionObservers: MutationObserver[] = [];
+  @Input()
+  tocSections!: TocSection[];
 
-  @ViewChild('sectionsContainer', {read: ElementRef})
-  set sectionsContainer(container: ElementRef) {
-    while(this.tocSections.length) {
-      this.tocSections.pop();
-    }
-    while(this.tocSectionObservers.length) {
-      const observer = this.tocSectionObservers.pop();
-      if (observer !== undefined) {
-        observer.disconnect();
-      }
-    }
-    this.getTocSections(container.nativeElement);
-  }
-
-  getTocSections(container: any) {
-    for (const section of container.children) {
-      if (section.localName === 'biosimulations-text-page-content-section') {
-        const heading = section.getAttribute('shortHeading')
-            || section.getAttribute('ng-reflect-short-heading')
-            || section.getAttribute('heading')
-            || section.getAttribute('ng-reflect-heading');
-        const tocSection = {
-          heading: heading,
-          target: section,
-        };
-        this.tocSections.push(tocSection);
-
-        const observer = new MutationObserver((mutations) => {
-          mutations.forEach((mutation) => {
-            const heading = section.getAttribute('shortHeading')
-              || section.getAttribute('ng-reflect-short-heading')
-              || section.getAttribute('heading')
-              || section.getAttribute('ng-reflect-heading');
-            tocSection.heading = heading;
-          });
-        });
-
-        observer.observe(section, {
-          attributeFilter: ['shortHeading', 'ng-reflect-short-heading', 'heading', 'ng-reflect-heading'],
-        });
-        this.tocSectionObservers.push(observer);
-      } else {
-        this.getTocSections(section);
-      }
-    }
-  }
+  @Input()
+  tocScrollSectionScrollOffset = 96;
 
   constructor(mediaMatcher: MediaMatcher) {
     window.addEventListener('scroll', this.scroll, true);
@@ -93,12 +45,6 @@ export class TextPageComponent {
   }
 
   ngOnDestroy() {
-    while(this.tocSectionObservers.length) {
-      const observer = this.tocSectionObservers.pop();
-      if (observer !== undefined) {
-        observer.disconnect();
-      }
-    }
     window.removeEventListener('scroll', this.scroll, true);
   }
 

--- a/biosimulations/libs/shared/ui/src/lib/toc/toc-section.directive.ts
+++ b/biosimulations/libs/shared/ui/src/lib/toc/toc-section.directive.ts
@@ -1,0 +1,25 @@
+import { Directive, ElementRef, Input, Host } from '@angular/core';
+
+import { TocSection } from './toc-section';
+import { TocSectionsContainerDirective } from './toc-sections-container.directive';
+
+@Directive({
+  selector: '[tocSection]',
+  exportAs: 'tocSection',
+})
+export class TocSectionDirective {
+  @Input()
+  set tocSection (heading: string) {
+    this.section.heading = heading;
+  }
+
+  private section: TocSection = {};
+
+  constructor(
+    @Host() sectionsContainer: TocSectionsContainerDirective,
+    elementRef: ElementRef,
+  ) {
+    this.section.target = elementRef.nativeElement;
+    sectionsContainer.sections.push(this.section);
+  }
+}

--- a/biosimulations/libs/shared/ui/src/lib/toc/toc-section.ts
+++ b/biosimulations/libs/shared/ui/src/lib/toc/toc-section.ts
@@ -1,0 +1,6 @@
+import { ElementRef } from '@angular/core';
+
+export interface TocSection {
+  heading?: string;
+  target?: HTMLElement;
+}

--- a/biosimulations/libs/shared/ui/src/lib/toc/toc-sections-container.directive.ts
+++ b/biosimulations/libs/shared/ui/src/lib/toc/toc-sections-container.directive.ts
@@ -1,0 +1,11 @@
+import { Directive, ElementRef } from '@angular/core';
+
+import { TocSection } from './toc-section';
+
+@Directive({
+  selector: '[tocSectionsContainer]',
+  exportAs: 'tocSectionsContainer',
+})
+export class TocSectionsContainerDirective {
+  sections: any[] = [];
+}

--- a/biosimulations/libs/shared/ui/src/lib/topbar/topbar-menu-item.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/topbar/topbar-menu-item.component.html
@@ -1,4 +1,4 @@
-<button mat-flat-button [routerLink]="route || null" [disabled]="disabled">
+<button mat-flat-button [routerLink]="route || null" [disabled]="disabled" fxShow fxHide.lt-md>
   <div class="button-content">
     <biosimulations-icon [icon]="icon"></biosimulations-icon>
     {{ heading }}


### PR DESCRIPTION
- Styled for mobile
  - Supports two layouts: desktop and mobile with breakpoint at 960px width
  - Used @angular/flex-layout to control when multiple columns are used and to hide some content for small browsers
  - Used media queries to make padding tighter for small browsers and change the align and text flow in a few places
  - It's not perfect, but this is close to being good enough for our initial launch
- Built components for table of contents