### PR TITLE
Fix scrolling of non-container components

### DIFF
--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.spec.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.spec.ts
@@ -7,6 +7,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { MatTabsModule } from '@angular/material/tabs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { ScrollService } from '@biosimulations/shared/services';
+
 describe('ViewSimulatorComponent', () => {
   let component: ViewSimulatorComponent;
   let fixture: ComponentFixture<ViewSimulatorComponent>;
@@ -14,7 +16,8 @@ describe('ViewSimulatorComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports:[SharedUiModule, RouterTestingModule, HttpClientTestingModule, BiosimulationsIconsModule, MatTabsModule, NoopAnimationsModule],
-      declarations: [ ViewSimulatorComponent ]
+      declarations: [ ViewSimulatorComponent ],
+      providers: [ScrollService],
     })
     .compileComponents();
   }));

--- a/biosimulations/libs/shared/services/src/lib/scroll/scroll.service.ts
+++ b/biosimulations/libs/shared/services/src/lib/scroll/scroll.service.ts
@@ -5,7 +5,7 @@ import { filter } from 'rxjs/operators';
 @Injectable()
 export class ScrollService {
   static scrollContainerId = 'mat-sidenav-content';
-  private scrollContainer!: Element;
+  public scrollContainer!: Element;
 
   constructor(private router: Router) {}
 

--- a/biosimulations/libs/shared/services/src/lib/scroll/scroll.service.ts
+++ b/biosimulations/libs/shared/services/src/lib/scroll/scroll.service.ts
@@ -5,7 +5,7 @@ import { filter } from 'rxjs/operators';
 @Injectable()
 export class ScrollService {
   static scrollContainerId = 'mat-sidenav-content';
-  public scrollContainer!: Element;
+  private scrollContainer!: Element;
 
   constructor(private router: Router) {}
 
@@ -55,5 +55,22 @@ export class ScrollService {
   scrollToElement(target: Element, offset: number = 0): void {
     const y = target.getBoundingClientRect().top + this.getScrollTop() - offset;
     this.scrollTo({top: y, behavior: 'smooth'});
+  }
+
+  addScrollListener(listener: (event: any) => void): ((event: any) => void) {
+
+    const wrappedListener = (event: any): void => {
+      if (event.target === this.scrollContainer) {
+        listener(event);
+      }
+    }
+
+    window.addEventListener('scroll', wrappedListener, true);
+
+    return wrappedListener;
+  }
+
+  removeScrollListener(wrappedListener: (event: any) => void): void {
+    window.removeEventListener('scroll', wrappedListener, true);
   }
 }

--- a/biosimulations/libs/shared/ui/src/lib/table/stacked-table.component.spec.ts
+++ b/biosimulations/libs/shared/ui/src/lib/table/stacked-table.component.spec.ts
@@ -13,6 +13,7 @@ import { StackedTableComponent } from './stacked-table.component';
 import { TocSectionDirective } from '../toc/toc-section.directive';
 import { TocSectionsContainerDirective } from '../toc/toc-sections-container.directive';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { ScrollService } from '@biosimulations/shared/services';
 
 describe('StackedTableComponent', () => {
   let component: StackedTableComponent;
@@ -36,6 +37,9 @@ describe('StackedTableComponent', () => {
         TextPageTocItemComponent,
         TocSectionDirective,
         TocSectionsContainerDirective,
+      ],
+      providers: [
+        ScrollService,
       ],
     }).compileComponents();
   }));

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.spec.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.spec.ts
@@ -7,6 +7,7 @@ import { TextPageSectionComponent } from './text-page-section.component';
 import { TextPageSideBarSectionComponent } from './text-page-side-bar-section.component';
 import { TextPageTocItemComponent } from './text-page-toc-item.component';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
+import { ScrollService } from '@biosimulations/shared/services';
 
 describe('TextPageComponent', () => {
   let component: TextPageComponent;
@@ -16,6 +17,7 @@ describe('TextPageComponent', () => {
     TestBed.configureTestingModule({
       declarations: [PageComponent, TextPageComponent, TextPageSectionComponent, TextPageSideBarSectionComponent, TextPageTocItemComponent],
       imports: [RouterTestingModule, BiosimulationsIconsModule],
+      providers: [ScrollService],
     }).compileComponents();
   }));
 

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -65,7 +65,7 @@ export class TextPageComponent {
     private changeRef: ChangeDetectorRef,
     private scrollService: ScrollService
   ) {
-    window.addEventListener('scroll', this.boundScroll, true);
+    this.boundScroll = this.scrollService.addScrollListener(this.scroll.bind(this));
 
     this.smallLayout = breakpointObserver.isMatched('(max-width: 959px)');
     breakpointObserver.observe(['(max-width: 959px)']).subscribe((result) => {
@@ -78,16 +78,14 @@ export class TextPageComponent {
     this.changeRef.markForCheck();
   }
   ngOnDestroy() {
-    window.removeEventListener('scroll', this.boundScroll, true);
+    this.scrollService.removeScrollListener(this.boundScroll);
   }
 
   scroll(event: any): void {
-    if (event.target === this.scrollService.scrollContainer) {
-      this.fixed = event.srcElement.scrollTop > 64;
-      this.calcSideBarStyle();
-    }
+    this.fixed = event.srcElement.scrollTop > 64;
+    this.calcSideBarStyle();
   }
-  boundScroll = this.scroll.bind(this);
+  boundScroll: (event: any) => void;
 
   calcSideBarStyle() {
     let position: string | null = null;

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -7,6 +7,7 @@ import {
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { TocSection } from '../toc/toc-section';
 import { Observable, BehaviorSubject } from 'rxjs';
+import { ScrollService } from '@biosimulations/shared/services';
 
 interface SideBarStyle {
   position: string | null;
@@ -61,9 +62,10 @@ export class TextPageComponent {
 
   constructor(
     breakpointObserver: BreakpointObserver,
-    private changeRef: ChangeDetectorRef
+    private changeRef: ChangeDetectorRef,
+    private scrollService: ScrollService
   ) {
-    window.addEventListener('scroll', this.scroll, true);
+    window.addEventListener('scroll', this.boundScroll, true);
 
     this.smallLayout = breakpointObserver.isMatched('(max-width: 959px)');
     breakpointObserver.observe(['(max-width: 959px)']).subscribe((result) => {
@@ -76,13 +78,16 @@ export class TextPageComponent {
     this.changeRef.markForCheck();
   }
   ngOnDestroy() {
-    window.removeEventListener('scroll', this.scroll, true);
+    window.removeEventListener('scroll', this.boundScroll, true);
   }
 
-  scroll = (event: any): void => {
-    this.fixed = event.srcElement.scrollTop > 64;
-    this.calcSideBarStyle();
-  };
+  scroll(event: any): void {
+    if (event.target === this.scrollService.scrollContainer) {
+      this.fixed = event.srcElement.scrollTop > 64;
+      this.calcSideBarStyle();
+    }
+  }
+  boundScroll = this.scroll.bind(this);
 
   calcSideBarStyle() {
     let position: string | null = null;


### PR DESCRIPTION
Currently scrolling of components other than the content container breaks the positioning of the left column (e.g., table of contents).  This pull request fixes this issue.