### PR TITLE
Stricter validation of simulators

### DIFF
--- a/biosimulations/apps/dispatch-api/src/app/app.module.ts
+++ b/biosimulations/apps/dispatch-api/src/app/app.module.ts
@@ -13,6 +13,9 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { ModelsModule } from './resources/models/models.module';
 import { AppService } from './app.service';
 
+import * as mongoose from 'mongoose';
+mongoose.set('strict', 'throw');
+
 @Module({
   imports: [
     BiosimulationsConfigModule,

--- a/biosimulations/apps/dispatch-service/src/app/app.module.ts
+++ b/biosimulations/apps/dispatch-service/src/app/app.module.ts
@@ -17,6 +17,9 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { ModelsModule } from './resources/models/models.module';
 import { SimulationService } from './services/simulation/simulation.service';
 
+import * as mongoose from 'mongoose';
+mongoose.set('strict', 'throw');
+
 @Module({
   imports: [
     BiosimulationsConfigModule,

--- a/biosimulations/apps/platform-api/src/app/app.module.ts
+++ b/biosimulations/apps/platform-api/src/app/app.module.ts
@@ -11,6 +11,9 @@ import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
 import { TypegooseModule } from 'nestjs-typegoose';
 import { MongooseModule } from '@nestjs/mongoose';
 
+import * as mongoose from 'mongoose';
+mongoose.set('strict', 'throw');
+
 @Module({
   imports: [
     BiosimulationsConfigModule,

--- a/biosimulations/apps/platform/src/app/shared/models/algorithm-parameter.ts
+++ b/biosimulations/apps/platform/src/app/shared/models/algorithm-parameter.ts
@@ -1,6 +1,6 @@
 import { AlgorithmParameter as AlgorithmParameterDTO } from '@biosimulations/shared/datamodel';
 import { JsonSerializable } from '@biosimulations/datamodel/utils';
-import { PrimitiveType } from '@biosimulations/shared/datamodel';
+import { AlgorithmParameterType } from '@biosimulations/shared/datamodel';
 
 export class AlgorithmParameter
   implements JsonSerializable<AlgorithmParameterDTO> {
@@ -8,7 +8,7 @@ export class AlgorithmParameter
   id: string;
   value: number | boolean | string;
   kisaoId: string | null;
-  type: PrimitiveType;
+  type: AlgorithmParameterType;
   recommendedRange: (boolean | string | number)[] | null;
   constructor(data: AlgorithmParameterDTO) {
     this.name = data.name;

--- a/biosimulations/apps/simulators-api/src/app/app.module.ts
+++ b/biosimulations/apps/simulators-api/src/app/app.module.ts
@@ -8,6 +8,10 @@ import { ConfigService } from '@nestjs/config';
 import { SimulatorsModule } from '../simulators/simulators.module';
 import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
 import { SharedExceptionsModule } from '@biosimulations/shared/exceptions';
+
+import * as mongoose from 'mongoose';
+mongoose.set('strict', 'throw');
+
 @Module({
   imports: [
     BiosimulationsConfigModule,

--- a/biosimulations/apps/simulators-api/src/simulators/simulators.module.ts
+++ b/biosimulations/apps/simulators-api/src/simulators/simulators.module.ts
@@ -8,6 +8,10 @@ import {
   AuthTestModule,
   BiosimulationsAuthModule,
 } from '@biosimulations/auth/nest';
+
+import * as mongoose from 'mongoose';
+mongoose.set('strict', 'throw');
+
 @Module({
   controllers: [SimulatorsController],
   providers: [SimulatorsService],

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
@@ -24,7 +24,6 @@ import {
   AlgorithmParameterType,
 } from '@biosimulations/shared/datamodel';
 import { UtilsService } from '@biosimulations/shared/services';
-import { AlgorithmParameter } from '@biosimulations/shared/datamodel';
 import { BiosimulationsError } from '@biosimulations/shared/ui';
 
 @Injectable({ providedIn: 'root' })
@@ -139,7 +138,7 @@ export class ViewSimulatorService {
         : [],
     };
   }
-  getParameters(parameter: AlgorithmParameter): ViewParameterObservable {
+  getParameters(parameter: any): ViewParameterObservable {
     const kisaoTerm = this.ontService.getKisaoTerm(parameter.kisaoId.id);
 
     let value;
@@ -152,7 +151,7 @@ export class ViewSimulatorService {
     return {
       id: parameter.id,
       name: kisaoTerm.pipe(pluck('name')),
-      type: AlgorithmParameterType[parameter.type],
+      type: (AlgorithmParameterType as any)[parameter.type as string],
       value,
       range: parameter.recommendedRange
         ? parameter.recommendedRange

--- a/biosimulations/libs/shared/datamodel/src/lib/common/ontology.ts
+++ b/biosimulations/libs/shared/datamodel/src/lib/common/ontology.ts
@@ -7,8 +7,10 @@ export enum Ontologies {
   SPDX = 'SPDX',
   URL = 'URL',
 }
-export const KisaoIdRegEx = /^KISAO_\d+$/; //sourced from identifiers.org
-export const SboIdRegEx = /^SBO_\d+$/;
+export const EdamIdRegEx = /^(data|topic|operation|format)_\d{4}$/;
+export const EdamFormatIdRegEx = /^format_\d{4}$/;
+export const KisaoIdRegEx = /^KISAO_\d{7}$/; //sourced from identifiers.org
+export const SboIdRegEx = /^SBO_\d{7}$/;
 export interface Identifier {
   namespace: string;
   id: string;

--- a/biosimulations/libs/shared/datamodel/src/lib/core/algorithm.ts
+++ b/biosimulations/libs/shared/datamodel/src/lib/core/algorithm.ts
@@ -9,11 +9,11 @@ import {
 } from '../common';
 
 export enum AlgorithmParameterType {
-  boolean = 'boolean',
-  integer = ' integer',
+  boolean = 'Boolean',
+  integer = 'integer',
   float = 'float',
   string = 'string',
-  kisaoId = 'kisaoId',
+  kisaoId = 'KiSAO id',
   list = 'list',
   object = 'object',
   any = 'any',

--- a/biosimulations/libs/shared/datamodel/src/lib/core/algorithm.ts
+++ b/biosimulations/libs/shared/datamodel/src/lib/core/algorithm.ts
@@ -1,4 +1,3 @@
-import { PrimitiveType } from '../common/primitive-type';
 import { IOntologyTerm, Format, Citation } from '../..';
 import { KisaoId } from '../common/alias';
 import {
@@ -9,6 +8,17 @@ import {
   KISAOTerm,
 } from '../common';
 
+export enum AlgorithmParameterType {
+  boolean = 'boolean',
+  integer = ' integer',
+  float = 'float',
+  string = 'string',
+  kisaoId = 'kisaoId',
+  list = 'list',
+  object = 'object',
+  any = 'any',
+}
+
 /**
  * Represents a parameter in a particular simulation algorith or method.
  * id refers to the identifier used by some software package to reference parameter
@@ -18,7 +28,7 @@ import {
 export interface AlgorithmParameter {
   id: string;
   name: string;
-  type: PrimitiveType;
+  type: AlgorithmParameterType;
   value: boolean | number | string;
   // Todo make this a conditional type based on value
   recommendedRange: (boolean | number | string)[] | null;

--- a/biosimulations/libs/shared/datamodel/src/lib/core/simulator.ts
+++ b/biosimulations/libs/shared/datamodel/src/lib/core/simulator.ts
@@ -1,8 +1,8 @@
 import { IAlgorithm } from './algorithm';
 import { SecondaryResourceMetaData } from '../resources';
 
-export simulatorSpecificationsVersions = ['1.0.0'];
-export SimulatorImageVersions = ['1.0.0'];
+export const simulatorSpecificationsVersions: string[] = ['1.0.0'];
+export const SimulatorImageVersions: string[] = ['1.0.0'];
 
 export interface SimulatorAttributes {
   name: string;

--- a/biosimulations/libs/shared/datamodel/src/lib/core/simulator.ts
+++ b/biosimulations/libs/shared/datamodel/src/lib/core/simulator.ts
@@ -1,6 +1,9 @@
 import { IAlgorithm } from './algorithm';
 import { SecondaryResourceMetaData } from '../resources';
 
+export simulatorSpecificationsVersions = ['1.0.0'];
+export SimulatorImageVersions = ['1.0.0'];
+
 export interface SimulatorAttributes {
   name: string;
   version: string;

--- a/biosimulations/libs/simulators/api-models/src/lib/algorithmParameter.ts
+++ b/biosimulations/libs/simulators/api-models/src/lib/algorithmParameter.ts
@@ -1,4 +1,4 @@
-import { PrimitiveType } from '@biosimulations/shared/datamodel';
+import { AlgorithmParameterType } from '@biosimulations/shared/datamodel';
 import { KisaoOntologyId } from './ontologyId';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -13,9 +13,9 @@ export class AlgorithmParameter {
   name!: string;
 
   @ApiProperty({
-    enum: [PrimitiveType],
+    enum: AlgorithmParameterType,
   })
-  type!: PrimitiveType;
+  type!: AlgorithmParameterType;
 
   @ApiProperty({
     type: String,

--- a/biosimulations/libs/simulators/api-models/src/lib/biosimulatorsMeta.ts
+++ b/biosimulations/libs/simulators/api-models/src/lib/biosimulatorsMeta.ts
@@ -1,26 +1,22 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { simulatorSpecificationsVersions, simulatorImageVersions } from '@biosimulations/shared/datamodel';
 
 export class BiosimulatorsMeta {
   @ApiProperty({
-    default: '1.0.0',
+    type: String,
     description:
-      ' The version of the API schema that the properties of the simulators conforms to',
-    examples: ['1.0.0', '1.2.3'],
-    enum: ['1.0.0'],
+      'The version of the BioSimulators simulator specifications format that the simulator specifications conforms to',
+    examples: ['1.0.0'],
+    enum: simulatorSpecificationsVersions,
   })
-  schemaVersion!: string;
+  specificationsVersion!: string;
 
   @ApiProperty({
-    default: '1.0.0',
+    type: String,
     description:
-      ' The version of the docker image interface and features supported by the image',
-    examples: ['1.0.0', '1.2.3'],
-    enum: ['1.0.0'],
+      'The version of the BioSimulators simulator image format (command-line interface and Docker image structure) that the simulator implements',
+    examples: ['1.0.0'],
+    enum: simulatorImageVersions,
   })
   imageVersion!: string;
-
-  @ApiPropertyOptional({
-    description: 'True if the simulator is supported by the BioSimulators team',
-  })
-  internal?: boolean;
 }

--- a/biosimulations/libs/simulators/api-models/src/lib/simulator.ts
+++ b/biosimulations/libs/simulators/api-models/src/lib/simulator.ts
@@ -11,7 +11,9 @@ import { Algorithm } from './algorithm';
 import { BiosimulatorsMeta } from './biosimulatorsMeta';
 
 export class Simulator extends Document {
-  @ApiProperty()
+  @ApiProperty({
+    type: BiosimulatorsMeta,
+  })
   biosimulators!: BiosimulatorsMeta;
 
   @ApiProperty({

--- a/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
@@ -16,7 +16,7 @@ export class AlgorithmParameter implements IAlgorithmParameter {
   name!: string;
   @Prop({
     type: String,
-    enum: Object.keys(AlgorithmParameterType).map((key: AlgorithmParameterType) => AlgorithmParameterType[key]).sort(),
+    enum: Object.keys(AlgorithmParameterType).sort(),
     required: true,
   })
   type!: AlgorithmParameterType;

--- a/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
@@ -14,7 +14,11 @@ export class AlgorithmParameter implements IAlgorithmParameter {
   id!: string;
   @Prop()
   name!: string;
-  @Prop()
+  @Prop({
+    type: String,
+    enum: Object.values(PrimitiveType).sort(),
+    required: true,
+  })
   type!: PrimitiveType;
   @Prop()
   value!: boolean | number | string;

--- a/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/algorithmParameter.ts
@@ -1,5 +1,5 @@
 import {
-  PrimitiveType,
+  AlgorithmParameterType,
   AlgorithmParameter as IAlgorithmParameter,
 } from '@biosimulations/shared/datamodel';
 import { KisaoOntologyIdSchema } from './ontologyId';
@@ -16,10 +16,10 @@ export class AlgorithmParameter implements IAlgorithmParameter {
   name!: string;
   @Prop({
     type: String,
-    enum: Object.values(PrimitiveType).sort(),
+    enum: Object.keys(AlgorithmParameterType).map((key: AlgorithmParameterType) => AlgorithmParameterType[key]).sort(),
     required: true,
   })
-  type!: PrimitiveType;
+  type!: AlgorithmParameterType;
   @Prop()
   value!: boolean | number | string;
   @Prop()

--- a/biosimulations/libs/simulators/database-models/src/lib/biosimulatorsMeta.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/biosimulatorsMeta.ts
@@ -2,14 +2,19 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 
 @Schema({ _id: false, storeSubdocValidationError: false })
 export class BiosimulatorsMeta {
-  @Prop({ required: true, default: '1.0.0' })
-  schemaVersion!: string;
+  @Prop({
+    type: String,
+    required: true,
+    default: '1.0.0',
+  })
+  specificationsVersion!: string;
 
-  @Prop({ default: '1.0.0' })
+  @Prop({
+    type: String,
+    required: true,
+    default: '1.0.0',
+  })
   imageVersion!: string;
-
-  @Prop()
-  internal?: boolean;
 }
 export const BiosimulatorsInfoSchema = SchemaFactory.createForClass(
   BiosimulatorsMeta

--- a/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
@@ -42,7 +42,13 @@ export const OntologyIdSchema = SchemaFactory.createForClass(OntologyId);
 
 @Schema({ _id: false, storeSubdocValidationError: false })
 class EdamOntologyId implements IEdamOntologyId {
-  @Prop({ type: String, required: true })
+  @Prop({ 
+    type: String, 
+    enum: [Ontologies[Ontologies.EDAM]],
+    required: true,
+    uppercase: true,
+    trim: true,
+  })
   namespace!: Ontologies.EDAM;
 
   @Prop({
@@ -70,10 +76,10 @@ export const EdamOntologyIdSchema = SchemaFactory.createForClass(
 class KisaoOntologyId implements IKisaoOntologyId {
   @Prop({
     type: String,
+    enum: [Ontologies[Ontologies.KISAO]],
     required: true,
     uppercase: true,
     trim: true,
-    validate: (val: string) => val === Ontologies.KISAO,
   })
   namespace!: Ontologies.KISAO;
 
@@ -102,7 +108,13 @@ export const KisaoOntologyIdSchema = SchemaFactory.createForClass(
 );
 @Schema({ _id: false, storeSubdocValidationError: false })
 class SboOntologyId implements ISboOntologyId {
-  @Prop({ type: String, required: true })
+  @Prop({ 
+    type: String,
+    enum: [Ontologies[Ontologies.SBO]],
+    required: true,
+    uppercase: true,
+    trim: true,
+  })
   namespace!: Ontologies.SBO;
 
   @Prop({
@@ -127,7 +139,13 @@ export const SboOntologyIdSchema = SchemaFactory.createForClass(SboOntologyId);
 
 @Schema({ _id: false, storeSubdocValidationError: false })
 class SpdxId implements ISpdxId {
-  @Prop({ type: String, required: true })
+  @Prop({
+    type: String,
+    enum: [Ontologies[Ontologies.SPDX]],
+    required: true,
+    uppercase: true,
+    trim: true,
+  })
   namespace!: Ontologies.SPDX;
 
   @Prop({

--- a/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
@@ -31,7 +31,7 @@ class OntologyId implements IOntologyId {
   @Prop({
     type: String,
     required: true,
-    enum: Object.keys(Ontologies).map((k) => Ontologies[k as Ontologies]),
+    enum: Object.keys(Ontologies).map((k: Ontologies) => Ontologies[k]).sort(),
   })
   namespace!: Ontologies;
 

--- a/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
@@ -5,20 +5,24 @@ import {
   IKisaoOntologyId,
   ISboOntologyId,
   ISpdxId,
+  EdamFormatIdRegEx,
   KisaoIdRegEx,
   SboIdRegEx,
   Identifier as IIdentifier,
 } from '@biosimulations/shared/datamodel';
 
+import { edamTerms, kisaoTerms, sboTerms } from '@biosimulations/ontology/sources';
+import spdxLicenseList from 'spdx-license-list/full';
+
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 
 @Schema({ _id: false, storeSubdocValidationError: false })
 class Identifier implements IIdentifier {
-  @Prop({ required: true })
+  @Prop({ type: String, required: true })
   namespace!: string;
-  @Prop({ required: true })
+  @Prop({ type: String, required: true })
   id!: string;
-  @Prop({ required: true })
+  @Prop({ type: String, required: true })
   url!: string;
 }
 export const IdentifierSchema = SchemaFactory.createForClass(Identifier);
@@ -31,7 +35,7 @@ class OntologyId implements IOntologyId {
   })
   namespace!: Ontologies;
 
-  @Prop({ required: true })
+  @Prop({ type: String, required: true })
   id!: string;
 }
 export const OntologyIdSchema = SchemaFactory.createForClass(OntologyId);
@@ -41,7 +45,22 @@ class EdamOntologyId implements IEdamOntologyId {
   @Prop({ type: String, required: true })
   namespace!: Ontologies.EDAM;
 
-  @Prop({ required: true })
+  @Prop({
+    type: String,
+    required: true,
+    validate: [
+      {
+        validator: EdamFormatIdRegEx,
+        message: props => `${props.value} is not an id for a valid EDAM format term.`
+      },
+      {
+        validator: function(id: string): boolean {
+          return id in edamTerms;
+        },
+        message: props => `${props.value} is not an id for a valid EDAM term.`
+      }
+    ],
+  })
   id!: string;
 }
 export const EdamOntologyIdSchema = SchemaFactory.createForClass(
@@ -63,7 +82,18 @@ class KisaoOntologyId implements IKisaoOntologyId {
     required: true,
     uppercase: true,
     trim: true,
-    validate: KisaoIdRegEx,
+    validate: [
+      {
+        validator: KisaoIdRegEx,
+        message: props => `${props.value} is not an id for a valid KiSAO term.`
+      },
+      {
+        validator: function(id: string): boolean {
+          return id in kisaoTerms;
+        },
+        message: props => `${props.value} is not an id for a valid KiSAO term.`
+      }
+    ],
   })
   id!: string;
 }
@@ -75,7 +105,22 @@ class SboOntologyId implements ISboOntologyId {
   @Prop({ type: String, required: true })
   namespace!: Ontologies.SBO;
 
-  @Prop({ required: true, validate: SboIdRegEx })
+  @Prop({
+    type: String,
+    required: true,
+    validate: [
+      {
+        validator: SboIdRegEx,
+        message: props => `${props.value} is not an id for a valid SBO term.`
+      },
+      {
+        validator: function(id: string): boolean {
+          return id in sboTerms;
+        },
+        message: props => `${props.value} is not an id for a valid SBO term.`
+      }
+    ],
+  })
   id!: string;
 }
 export const SboOntologyIdSchema = SchemaFactory.createForClass(SboOntologyId);
@@ -85,7 +130,18 @@ class SpdxId implements ISpdxId {
   @Prop({ type: String, required: true })
   namespace!: Ontologies.SPDX;
 
-  @Prop({ type: String, required: true })
+  @Prop({
+    type: String,
+    required: true,
+    validate: [
+      {
+        validator: function(id: string): boolean {
+          return id in spdxLicenseList;
+        },
+        message: props => `${props.value} is not an id for a valid SPDX license.`
+      }
+    ],
+  })
   id!: string;
 }
 export const SpdxIdSchema = SchemaFactory.createForClass(SpdxId);

--- a/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
+++ b/biosimulations/libs/simulators/database-models/src/lib/ontologyId.ts
@@ -31,7 +31,7 @@ class OntologyId implements IOntologyId {
   @Prop({
     type: String,
     required: true,
-    enum: Object.keys(Ontologies).map((k: Ontologies) => Ontologies[k]).sort(),
+    enum: Object.keys(Ontologies).sort(),
   })
   namespace!: Ontologies;
 

--- a/biosimulations/nx.json
+++ b/biosimulations/nx.json
@@ -151,7 +151,7 @@
       "tags": ["scope:ontology", "type:api", "platform:server"]
     },
     "ontology-sources": {
-      "tags": ["scope:ontology", "type:datamodel", "platform:server"]
+      "tags": ["scope:ontology", "scope:simulators", "type:datamodel", "platform:server"]
     },
     "ontology-ontologies": {
       "tags": ["scope:ontology", "type:service", "platform:server"]


### PR DESCRIPTION
- Adding additional enumerations for AlgorithmParameter.type; closes #1417, closes #1418 
- Renaming `schemaVersion` to `specificationsVersion`; addresses #1401.
- Annotating type of `biosimulators` attribute. I believe this addresses the rest of #1401.
- Validating that EDAM, KiSAO, SBO, SPDX ids exist; closes #1398
  Note, this requires changing the scope of `ontology-sources`. This causes a circular dependency which needs to be resolved.
- Validating enumerations; closes #1400
- Throw errors on extra fields; I think this addresses #1421. @bilalshaikh42 please check. I can't tell from the Mongoose documentation if [`useNestedStrict`](https://mongoosejs.com/docs/guide.html#useNestedStrict) also needs to be set.