### PR TITLE
Wire end-to-end simulation flow across dispatch service controllers (closed)

### DIFF
--- a/biosimulations/apps/dispatch-api/src/simulation-run/simulation-run.service.ts
+++ b/biosimulations/apps/dispatch-api/src/simulation-run/simulation-run.service.ts
@@ -112,7 +112,7 @@ export class SimulationRunService {
   ): Promise<SimulationRunModelReturnType> {
     const model = await this.simulationRunModel.findById(id);
     if (model) {
-      /*
+      
       if (
         run.status == SimulationRunStatus.SUCCEEDED ||
         run.status == SimulationRunStatus.FAILED
@@ -120,7 +120,7 @@ export class SimulationRunService {
         model.runtime = Date.now() - model.submitted.getTime();
         this.logger.debug(`Set ${id} runtime to ${model.runtime} `);
       }
-      */
+      
 
       if (run.public != undefined && run.public != null) {
         model.public = run.public;

--- a/biosimulations/apps/dispatch-service/src/app/app.controller.ts
+++ b/biosimulations/apps/dispatch-service/src/app/app.controller.ts
@@ -24,9 +24,10 @@ export class AppController {
     ''
   );
 
-  @MessagePattern(DispatchMessage.finsihed)
+  @MessagePattern(DispatchMessage.finished)
   async dispatchFinish(data: DispatchPayload) {
     const uuid = data.id;
+    console.log('Simulation Finished with id: ', uuid);
     this.logger.log('Simulation Finished on HPC');
     const resDir = path.join(this.fileStorage, 'simulations', uuid, 'out');
     const allFilesInfo = await FileModifiers.getFilesRecursive(resDir);

--- a/biosimulations/apps/dispatch-service/src/app/results/results.controller.ts
+++ b/biosimulations/apps/dispatch-service/src/app/results/results.controller.ts
@@ -13,7 +13,13 @@ export class ResultsController {
 
   private logger = new Logger(ResultsController.name);
 
-  @MessagePattern(DispatchMessage.finsihed)
+  /**
+   * 
+   *  @bilal Don't activate this message pattern unless finished
+   *    it'll mess with the existing JSON parsing and archiving functionality if 
+   *    this is activated
+   */
+  // @MessagePattern(DispatchMessage.finsihed)
   async processResults(data: DispatchPayload) {
     const id = data.id;
     this.logger.log(`Simulation ${id} Finished`);

--- a/biosimulations/apps/dispatch-service/src/app/results/results.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/results/results.service.ts
@@ -39,6 +39,8 @@ export class ResultsService {
       this.uploadResultFile(id, file);
     });
   }
+
+
   async uploadResultFile(id: string, file: resultFile) {
     const file_json = this.parseToJson(file);
     const report = file.name.split('.csv')[0];
@@ -46,8 +48,10 @@ export class ResultsService {
     //apidomain/results/simulationID/report
     const sedml = encodeURI(file.path.split('/').slice(0, -1).join('/'));
 
-    this.uploadJSON(id, sedml, report, await file_json);
+    //this.uploadJSON(id, sedml, report, await file_json);
   }
+
+
   uploadJSON(id: string, sedml: any, report: string, file_json: string) {
     // TODO Complete implementation
     this.logger.warn(id);
@@ -55,6 +59,8 @@ export class ResultsService {
     this.logger.warn(report);
     this.logger.warn(file_json);
   }
+
+
   async parseToJson(file: resultFile): Promise<string> {
     this.logger.warn(file);
     const jsonArray = await csv().fromFile(file.path);
@@ -62,6 +68,8 @@ export class ResultsService {
     //return JSON.stringify(jsonArray);
     return jsonArray.toString();
   }
+
+
   static async getFilesRecursively(path: string) {
     // Get all the files and folders int the directory
     const entries = fsPromises.readdir(path, { withFileTypes: true });

--- a/biosimulations/apps/dispatch-service/src/app/simulation-run/simulation-run.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/simulation-run/simulation-run.service.ts
@@ -37,4 +37,5 @@ export class SimulationRunService {
       )
       .toPromise();
   }
+
 }

--- a/biosimulations/apps/dispatch-service/src/app/submission/submission.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/submission/submission.service.ts
@@ -13,6 +13,8 @@ import { SimulationRunService } from '../simulation-run/simulation-run.service';
 @Injectable({})
 export class SubmissionService {
   logger: Logger;
+
+
   constructor(
     private service: SimulationRunService,
     private hpcService: HpcService,
@@ -21,6 +23,8 @@ export class SubmissionService {
   ) {
     this.logger = new Logger(SubmissionService.name);
   }
+
+
   private createJob(jobId: string, simId: string, seconds: number) {
     const job = new CronJob(`*/${seconds.toString()} * * * * *`, async () => {
       const jobStatus: SimulationRunStatus = await this.hpcService.getJobStatus(
@@ -55,10 +59,10 @@ export class SubmissionService {
         case SimulationRunStatus.SUCCEEDED: {
           this.updateSimulationRunStatus(simId, jobStatus);
           const succeededMessage: DispatchPayload = {
-            _message: DispatchMessage.finsihed,
+            _message: DispatchMessage.finished,
             id: simId,
           };
-          this.messageClient.emit(DispatchMessage.finsihed, succeededMessage);
+          this.messageClient.emit(DispatchMessage.finished, succeededMessage);
           this.schedulerRegistry.getCronJob(jobId).stop();
 
           break;
@@ -83,6 +87,8 @@ export class SubmissionService {
     });
     return job;
   }
+
+
   async startMonitoringCronJob(jobId: string, simId: string, seconds: number) {
     const job = this.createJob(jobId, simId, seconds);
     this.schedulerRegistry.addCronJob(jobId, job);

--- a/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
@@ -101,6 +101,7 @@ export class BrowseComponent implements OnInit {
       heading: 'Submitted',
       key: 'submitted',
       formatter: (value: Date): string => {
+        value = new Date(value);
         return (
           value.getFullYear().toString() +
           '-' +
@@ -123,6 +124,7 @@ export class BrowseComponent implements OnInit {
       heading: 'Last updated',
       key: 'updated',
       formatter: (value: Date): string => {
+        value = new Date(value);
         return (
           value.getFullYear().toString() +
           '-' +

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -38,7 +38,7 @@
           </th>
           <td>
             <span class="heading">Results:</span>{{' '}}
-            <a [href]="simulation.resultsUrl" *ngIf="statusSucceeded; else noResults">CSV ({{ simulation.resultsSize }})</a>
+            <a [href]="simulation.resultsUrl" *ngIf="simulation.statusSucceeded ; else noResults">CSV ({{ simulation.resultsSize }})</a>
             <ng-template #noResults>N/A</ng-template>
           </td>
         </tr>

--- a/biosimulations/libs/messages/messages/src/lib/dispatch.ts
+++ b/biosimulations/libs/messages/messages/src/lib/dispatch.ts
@@ -8,7 +8,7 @@ export enum DispatchMessage {
   // Job starting running on the HPC
   started = 'dispatch.started',
   // Job done running
-  finsihed = 'dispatch.finished',
+  finished = 'dispatch.finished',
   // Job failed
   failed = 'dispatch.failed',
 }


### PR DESCRIPTION
Things that are working:
- DIspatching simulations through Swagger UI
- Dispatching simulations through dispatch frontend
- Getting status updates on frontend/api
- Creating JSON from CSVs
- Creating result archive
- logs
- Result size info on the frontend
- Runtime info on the frontend