### PR TITLE
adding Dockerfile best practices from Syslabs

### DIFF
--- a/biosimulations/apps/simulators/src/app/help/help/help.component.html
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.html
@@ -152,9 +152,11 @@
         <li><b>Create a Dockerfile which describes how to build an image for your simulation tool.</b>
           <ul>
             <li>Use the <code>FROM</code> directive to choose a base operating system such as Ubuntu.</li>
-            <li>Use the <code>RUN</code> directive to describe how to install your tool and any dependencies.</li>
+            <li>Use the <code>RUN</code> directive to describe how to install your tool and any dependencies. Because Docker images are typically run as root, reserve <code>/root</code> for the home directory of the user which executes the image. Similarly, reserve <code>/tmp</code> for temporary files that must be created during the execution of the image. Install your simulation tool into a different directory than <code>/root</code> and <code>/tmp</code> such as <code>/usr/local/bin</code>.</li>
             <li>Set the <code>ENTRYPOINT</code> directive to the path to your command-line interface.</li>
             <li>Set the <code>CMD</code> directive to <code>[]</code>.</li>
+            <li>Use the <code>ENV</code> directive to declare all environment variables that your simulation tool supports.</li>
+            <li>Do not use the <code>USER</code> directive to set the user which will execute the image so that the user can be set at execution time.</li>
             <li>
               <p class="no-bottom-margin">Use the <code>LABEL</code> directive to provide the metadata about your simulation tool described below. This metadata is also necessary to submit your image to BioContainers <a href="https://biocontainers.pro" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>, a broad registry of images for biological research.</p>
               <ul>

--- a/biosimulations/apps/simulators/src/app/help/help/help.component.html
+++ b/biosimulations/apps/simulators/src/app/help/help/help.component.html
@@ -153,6 +153,7 @@
           <ul>
             <li>Use the <code>FROM</code> directive to choose a base operating system such as Ubuntu.</li>
             <li>Use the <code>RUN</code> directive to describe how to install your tool and any dependencies. Because Docker images are typically run as root, reserve <code>/root</code> for the home directory of the user which executes the image. Similarly, reserve <code>/tmp</code> for temporary files that must be created during the execution of the image. Install your simulation tool into a different directory than <code>/root</code> and <code>/tmp</code> such as <code>/usr/local/bin</code>.</li>
+            <li>Ideally, the simulation tools inside images should be installed from internet sources so that the construction of an image is completely specified by its Dockerfile and, therefor, reproducible and portable. Additional files needed during the building of the image, such as licenses to commerical software, can be copied from a local directory such as <code>assets/</code>. These files can then be deleted and squashed out of the final image and injected again when the image is executed.</li>
             <li>Set the <code>ENTRYPOINT</code> directive to the path to your command-line interface.</li>
             <li>Set the <code>CMD</code> directive to <code>[]</code>.</li>
             <li>Use the <code>ENV</code> directive to declare all environment variables that your simulation tool supports.</li>

--- a/biosimulations/apps/simulators/src/app/standards/simulator-images/simulator-images.component.html
+++ b/biosimulations/apps/simulators/src/app/standards/simulator-images/simulator-images.component.html
@@ -84,6 +84,19 @@
     </biosimulations-text-page-content-section>
 
     <biosimulations-text-page-content-section
+      heading="Additional recommended best practices for Docker images"
+      tocSection="Recommended best practices"
+    >
+      <p>To ensure that containerized simulation tools can be executed inside high-performance computing clusters where root access is typically not allowed and conversion to Singularity images is necessary, we recommend that developers also follow the best practices below for Dockerfiles. For more discusion, we recommend Syslab's best practice guide for Singularity images <a href="https://sylabs.io/guides/3.7/user-guide/singularity_and_docker.html#best-practices" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.</p>
+
+      <ul>
+        <li><b>Installation locations of containerized simulation tools and their dependencies:</b> Because Docker images are typically run as root, <code>/root</code> should be be reserved for the home directory of the user which executes the image. Similarly, <code>/tmp</code> should be reserved for temporary files that must be created during the execution of the image. Consequently, the simulation tools inside containers and their dependencies should be installed to different directories other than <code>/root</code> and <code>/tmp</code>.</li>
+        <li><b>Environment variables:</b> All environment variables that the containerized simulation tool supports should be explicitly defined using the <code>ENV</code> directive.</li>
+        <li><b>User priviledges:</b> Do not use the <code>USER</code> directive.</li>
+      </ul>
+    </biosimulations-text-page-content-section>
+
+    <biosimulations-text-page-content-section
       heading="Example Dockerfile for a simulator"
       tocSection="Example Dockerfile"
     >

--- a/biosimulations/apps/simulators/src/app/standards/simulator-images/simulator-images.component.html
+++ b/biosimulations/apps/simulators/src/app/standards/simulator-images/simulator-images.component.html
@@ -22,11 +22,11 @@
     </biosimulations-text-page-feedback-side-bar-section>
   </ng-container>
 
-  <ng-container id="content" tocSectionsContainer>   
+  <ng-container id="content" tocSectionsContainer>
     <biosimulations-text-page-content-section
       heading="Overview"
       tocSection="Overview"
-    >      
+    >
       The BioSimulators standard for Docker images of biosimulation software tools outlines the syntax and semantics of the entry points of Docker images of biosimulators. This standard ensures that containerized simulation tools can be consistently executed with the same input arguments (a path to a COMBINE/OMEX archive that defines models and simulations and a path to save the outputs of the simulaton experiments defined in the archive) and that simulation tools produce consistent outputs (reports and plots at consistent paths in consistent formats). The standard also specifies how images of biosimulation software tools should use Docker labels to capture metadata about themselves.
     </biosimulations-text-page-content-section>
 
@@ -90,6 +90,7 @@
       <p>To ensure that containerized simulation tools can be executed inside high-performance computing clusters where root access is typically not allowed and conversion to Singularity images is necessary, we recommend that developers also follow the best practices below for Dockerfiles. For more discusion, we recommend Syslab's best practice guide for Singularity images <a href="https://sylabs.io/guides/3.7/user-guide/singularity_and_docker.html#best-practices" target="_blank"><biosimulations-icon icon="link"></biosimulations-icon></a>.</p>
 
       <ul>
+        <li><b>Sources of containerized simulation tools and their dependencies:</b> To ensure that the construction of Docker images is reproducible and portable, the simulation tools inside images should be installed from internet sources rather than the local file system. One exception is licenses that are needed to install commerical software. These can be copied from a local directory such as <code>assets/</code>, deleted and squashed out of the final image, and injected again when the image is executed.</li>
         <li><b>Installation locations of containerized simulation tools and their dependencies:</b> Because Docker images are typically run as root, <code>/root</code> should be be reserved for the home directory of the user which executes the image. Similarly, <code>/tmp</code> should be reserved for temporary files that must be created during the execution of the image. Consequently, the simulation tools inside containers and their dependencies should be installed to different directories other than <code>/root</code> and <code>/tmp</code>.</li>
         <li><b>Environment variables:</b> All environment variables that the containerized simulation tool supports should be explicitly defined using the <code>ENV</code> directive.</li>
         <li><b>User priviledges:</b> Do not use the <code>USER</code> directive.</li>


### PR DESCRIPTION
As suggested by Bilal, incorporated best practices for Dockerfiles from Syslabs. These are best practices for ensuring (a) reproducible image construction and (b) running images as root.