### PR TITLE
Minor improvements so dispatch

### DIFF
--- a/biosimulations/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -39,7 +39,6 @@ export class HpcService {
     const sbatchString = this.sbatchService.generateSbatch(
       simDirBase,
       simulatorString,
-      fileName,
       endpoint,
       id
     );

--- a/biosimulations/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -29,7 +29,7 @@ module load singularity/3.1.1
 export XDG_RUNTIME_DIR=${homeDir}/singularityXDG/
 date
 \`wget ${apiDomain}run/${simId}/download -O "${tempSimDir}/in/project.omex" 1>"${tempSimDir}/out/job.output" 2>&1\`
-command=\\" singularity pull ${simulator} && singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out ${simulator} -i '/root/in/project.omex' -o /root/out\\"
+command=\\" singularity pull --force ${simulator} && singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out ${simulator} -i '/root/in/project.omex' -o /root/out\\"
 eval \\$command;`;
     console.log(template)
     return template;

--- a/biosimulations/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -9,13 +9,11 @@ export class SbatchService {
   generateSbatch(
     tempSimDir: string,
     simulator: string,
-    omexName: string,
     apiDomain: string,
     simId: string
   ): string {
 
     const homeDir = this.configService.get("hpc.homeDir")
-    const cleanedOmexName = omexName.replace(" ", "")
     const template = `#!/bin/bash    
 #SBATCH --job-name=BioSimulations_${simId}
 #SBATCH --time=20:00
@@ -30,8 +28,8 @@ source /usr/share/Modules/init/bash
 module load singularity/3.1.1
 export XDG_RUNTIME_DIR=${homeDir}/singularityXDG/
 date
-\`wget ${apiDomain}run/${simId}/download -O "${tempSimDir}/in/${omexName}" 1>"${tempSimDir}/out/job.output" 2>&1\`
-command=\\" singularity pull ${simulator} && singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out ${simulator} -i '/root/in/${omexName}' -o /root/out\\"
+\`wget ${apiDomain}run/${simId}/download -O "${tempSimDir}/in/project.omex" 1>"${tempSimDir}/out/job.output" 2>&1\`
+command=\\" singularity pull ${simulator} && singularity run -B ${tempSimDir}/in:/root/in -B ${tempSimDir}/out:/root/out ${simulator} -i '/root/in/project.omex' -o /root/out\\"
 eval \\$command;`;
     console.log(template)
     return template;

--- a/biosimulations/apps/dispatch/src/assets/config.json
+++ b/biosimulations/apps/dispatch/src/assets/config.json
@@ -25,7 +25,7 @@
         "simulationStatusRefreshIntervalSec": 5,
         "exampleCombineArchives": {
             "repoOwnerName": "biosimulators/Biosimulators_test_suite",
-            "repoRef": "ad221ff6c1d741815b5554c46f0a7d92555373df",
+            "repoRef": "deploy",
             "repoPath": "examples/",
             "examplePath": "sbml-core/Vilar-PNAS-2002-minimal-circardian-clock.omex"
         }


### PR DESCRIPTION
- Changed links to example combine archives in simulation submission form to use deploy branch of the biosimulators test suite -- closes #1902
- Removed `omexName` from sbatch service. This isn't needed, and it seems to be causing issues with filenames that include non-alphanumeric characters.