### PR TITLE
add controller for image generation

### DIFF
--- a/biosimulations/apps/dispatch-api/src/app/app.module.ts
+++ b/biosimulations/apps/dispatch-api/src/app/app.module.ts
@@ -12,11 +12,13 @@ import {
   AuthTestModule,
   BiosimulationsAuthModule
 } from '@biosimulations/auth/nest';
+import { ImagesModule } from '../images/images.module';
 
 @Module({
   imports: [
     BiosimulationsConfigModule,
     BiosimulationsAuthModule,
+    ImagesModule,
     HttpModule,
     MongooseModule.forRootAsync({
       imports: [BiosimulationsConfigModule,],

--- a/biosimulations/apps/dispatch-api/src/images/image.dto.ts
+++ b/biosimulations/apps/dispatch-api/src/images/image.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class refreshImageBody {
+    @ApiProperty()
+    simulator!: string
+    @ApiProperty()
+    version!: string
+
+}

--- a/biosimulations/apps/dispatch-api/src/images/images.controller.spec.ts
+++ b/biosimulations/apps/dispatch-api/src/images/images.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ImagesController } from './images.controller';
+
+describe('ImagesController', () => {
+  let controller: ImagesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ImagesController],
+    }).compile();
+
+    controller = module.get<ImagesController>(ImagesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/biosimulations/apps/dispatch-api/src/images/images.controller.spec.ts
+++ b/biosimulations/apps/dispatch-api/src/images/images.controller.spec.ts
@@ -1,3 +1,6 @@
+import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
+import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ImagesController } from './images.controller';
 
@@ -7,6 +10,7 @@ describe('ImagesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ImagesController],
+      imports: [BiosimulationsAuthModule, BiosimulationsConfigModule, SharedNatsClientModule],
     }).compile();
 
     controller = module.get<ImagesController>(ImagesController);

--- a/biosimulations/apps/dispatch-api/src/images/images.controller.ts
+++ b/biosimulations/apps/dispatch-api/src/images/images.controller.ts
@@ -1,19 +1,35 @@
 import { permissions } from '@biosimulations/auth/nest';
-import { Body, Controller, Get, Inject, Post } from '@nestjs/common';
-import { Client } from '@nestjs/microservices/external/nats-client.interface';
-import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ImageMessage, ImageMessagePayload, ImageMessageResponse } from '@biosimulations/messages/messages';
+import { Body, Controller, Get, HttpCode, HttpStatus, Inject, Post } from '@nestjs/common';
+import { ClientProxy } from '@nestjs/microservices';
+import { ApiBody, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { map, pluck } from 'rxjs/operators';
 import { refreshImageBody } from './image.dto';
 
 @Controller('images')
+@ApiResponse({})
 @ApiTags('Images', 'Internal')
+
 export class ImagesController {
-    constructor(@Inject("NATS_CLIENT") private client: Client) { }
-    @ApiOperation({})
+    constructor(@Inject("NATS_CLIENT") private client: ClientProxy) { }
+    @ApiOperation({ summary: "Refresh Container Image", description: "Trigger a rebuild of the singulairty image of a particular container" })
     @ApiBody({ type: refreshImageBody })
-    @permissions("refresh:images")
+    @permissions("refresh:Images")
     @Post('refresh')
-    refreshImage(@Body() data: refreshImageBody) {
-        this.client.emit("test")
+    @HttpCode(HttpStatus.NO_CONTENT)
+    async refreshImage(@Body() data: refreshImageBody) {
+        const message = new ImageMessagePayload(data.simulator, data.simulator)
+        // !Replace with wrapper to allow typing 
+        const success = await this.client.send(ImageMessage.refresh, message).pipe<boolean>(
+            map((data: ImageMessageResponse) => data.okay)
+        ).toPromise()
+        if (success) {
+            return
+        } else {
+            throw Error()
+        }
+
+
     }
 
 

--- a/biosimulations/apps/dispatch-api/src/images/images.controller.ts
+++ b/biosimulations/apps/dispatch-api/src/images/images.controller.ts
@@ -1,0 +1,21 @@
+import { permissions } from '@biosimulations/auth/nest';
+import { Body, Controller, Get, Inject, Post } from '@nestjs/common';
+import { Client } from '@nestjs/microservices/external/nats-client.interface';
+import { ApiBody, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { refreshImageBody } from './image.dto';
+
+@Controller('images')
+@ApiTags('Images', 'Internal')
+export class ImagesController {
+    constructor(@Inject("NATS_CLIENT") private client: Client) { }
+    @ApiOperation({})
+    @ApiBody({ type: refreshImageBody })
+    @permissions("refresh:images")
+    @Post('refresh')
+    refreshImage(@Body() data: refreshImageBody) {
+        this.client.emit("test")
+    }
+
+
+
+}

--- a/biosimulations/apps/dispatch-api/src/images/images.module.ts
+++ b/biosimulations/apps/dispatch-api/src/images/images.module.ts
@@ -1,0 +1,11 @@
+import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
+import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
+import { Module } from '@nestjs/common';
+import { ImagesController } from './images.controller';
+
+@Module({
+    imports: [BiosimulationsConfigModule, BiosimulationsAuthModule, SharedNatsClientModule],
+    controllers: [ImagesController]
+})
+export class ImagesModule { }

--- a/biosimulations/apps/dispatch-service/src/app/app.module.ts
+++ b/biosimulations/apps/dispatch-service/src/app/app.module.ts
@@ -16,8 +16,9 @@ import { ResultsService } from './results/results.service';
 import { SharedNatsClientModule } from '@biosimulations/shared/nats-client'
 import { AuthClientModule } from '@biosimulations/auth/client';
 import { DispatchNestClientModule } from '@biosimulations/dispatch/nest-client';
+import { ImagesModule } from '../images/images.module';
 @Module({
-  imports: [HttpModule, BiosimulationsConfigModule, AuthClientModule, SharedNatsClientModule, DispatchNestClientModule, ScheduleModule.forRoot()],
+  imports: [HttpModule, ImagesModule, BiosimulationsConfigModule, AuthClientModule, SharedNatsClientModule, DispatchNestClientModule, ScheduleModule.forRoot()],
   controllers: [SubmissionController, ResultsController],
   providers: [
     HpcService,

--- a/biosimulations/apps/dispatch-service/src/images/images.controller.spec.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ImagesController } from './images.controller';
+
+describe('ImagesController', () => {
+  let controller: ImagesController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ImagesController],
+    }).compile();
+
+    controller = module.get<ImagesController>(ImagesController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/biosimulations/apps/dispatch-service/src/images/images.controller.spec.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.controller.spec.ts
@@ -1,12 +1,26 @@
+import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
+import { SbatchService } from '../app/services/sbatch/sbatch.service';
+import { SshService } from '../app/services/ssh/ssh.service';
 import { ImagesController } from './images.controller';
 
+
+class MockSbatchService {
+  async method() { }
+}
+class MockSshService {
+  async method() { }
+}
+class MockConfigService {
+  async method() { }
+}
 describe('ImagesController', () => {
   let controller: ImagesController;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ImagesController],
+      providers: [{ provide: SbatchService, useClass: MockSbatchService }, { provide: ConfigService, useClass: MockConfigService }, { provide: SshService, useClass: MockSshService }]
     }).compile();
 
     controller = module.get<ImagesController>(ImagesController);

--- a/biosimulations/apps/dispatch-service/src/images/images.controller.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.controller.ts
@@ -1,0 +1,38 @@
+import { ImageMessage, ImageMessagePayload, ImageMessageResponse } from '@biosimulations/messages/messages';
+import { Controller, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { MessagePattern } from '@nestjs/microservices';
+import { SbatchService } from '../app/services/sbatch/sbatch.service';
+import { SshService } from '../app/services/ssh/ssh.service';
+
+@Controller()
+export class ImagesController {
+    constructor(private sshSerivce: SshService, private configService: ConfigService, private sbatchService: SbatchService) {
+
+    }
+    logger = new Logger(ImagesController.name)
+
+    @MessagePattern(ImageMessage.refresh)
+    async refreshImage(data: ImageMessagePayload) {
+        const url = data.url
+        const homeDir = this.configService.get("hpc.homeDir")
+        const force = data.force ? "--force" : ""
+        this.logger.log("sending command to update" + data.url)
+        const sbatch = this.sbatchService.generateImageUpdateSbatch(url, force)
+        const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch updateImage.sbatch`
+        const out = await this.sshSerivce.execStringCommand(command)
+
+
+
+        if (out.stderr != "") {
+            return new ImageMessageResponse(false, out.stderr)
+        }
+        else {
+
+            return new ImageMessageResponse(true, out.stdout)
+
+        }
+
+
+    }
+}

--- a/biosimulations/apps/dispatch-service/src/images/images.module.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { SbatchService } from '../app/services/sbatch/sbatch.service';
+import { SshService } from '../app/services/ssh/ssh.service';
+import { ImagesController } from './images.controller';
+import { ImagesService } from './images.service';
+
+@Module({
+  controllers: [ImagesController],
+  providers: [ImagesService, SshService, SbatchService]
+})
+export class ImagesModule { }

--- a/biosimulations/apps/dispatch-service/src/images/images.service.spec.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ImagesService } from './images.service';
+
+describe('ImagesService', () => {
+  let service: ImagesService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ImagesService],
+    }).compile();
+
+    service = module.get<ImagesService>(ImagesService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/biosimulations/apps/dispatch-service/src/images/images.service.ts
+++ b/biosimulations/apps/dispatch-service/src/images/images.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ImagesService {}

--- a/biosimulations/libs/messages/messages/src/index.ts
+++ b/biosimulations/libs/messages/messages/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/dispatch';
+export * from './lib/images';

--- a/biosimulations/libs/messages/messages/src/lib/images.ts
+++ b/biosimulations/libs/messages/messages/src/lib/images.ts
@@ -1,8 +1,9 @@
 export enum ImageMessage {
-    refresh = 'refresh'
+    refresh = 'image.refresh'
 }
 
 export class ImageMessagePayload {
+    _message: ImageMessage = ImageMessage.refresh
     simulator: string
     version: string
     url: string
@@ -14,5 +15,15 @@ export class ImageMessagePayload {
             this.force = force
             this.url = `docker://ghcr.io/biosimulators/${this.simulator}:${this.version}`
         }
+    }
+}
+
+export class ImageMessageResponse {
+    _message: ImageMessage = ImageMessage.refresh
+    okay: boolean
+    description: string | undefined
+    constructor(okay: boolean, description?: string) {
+        this.okay = okay
+        this.description = description
     }
 }

--- a/biosimulations/libs/messages/messages/src/lib/images.ts
+++ b/biosimulations/libs/messages/messages/src/lib/images.ts
@@ -1,0 +1,18 @@
+export enum ImageMessage {
+    refresh = 'refresh'
+}
+
+export class ImageMessagePayload {
+    simulator: string
+    version: string
+    url: string
+    force: boolean
+    constructor(simulator: string, version: string, force = true) {
+        {
+            this.simulator = simulator
+            this.version = version
+            this.force = force
+            this.url = `docker://ghcr.io/biosimulators/${this.simulator}:${this.version}`
+        }
+    }
+}


### PR DESCRIPTION
Provides an endpoint to trigger a refresh of the cache of the singularity images saved on the HPC.  The jobs can now be run without pulling the images. 