### PR TITLE
starting UI component for more granular simulation logs

### DIFF
--- a/biosimulations/apps/dispatch/src/app/components/simulations/simulations.module.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/simulations.module.ts
@@ -13,6 +13,7 @@ import { SimulationsRoutingModule } from './simulations-routing.module';
 import { BrowseComponent } from './browse/browse.component';
 import { ViewComponent } from './view/view.component';
 import { VisualizationComponent } from './view/visualization/visualization.component';
+import { SimulationLogModule } from './view/simulation-log/simulation-log.module';
 
 @NgModule({
   declarations: [
@@ -30,6 +31,7 @@ import { VisualizationComponent } from './view/visualization/visualization.compo
     SharedUiModule,
     BiosimulationsIconsModule,
     PlotlyViaWindowModule,
-  ]
+    SimulationLogModule,
+  ],
 })
 export class SimulationsModule { }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
@@ -7,7 +7,7 @@
     'failed': status === SimulationRunStatus.FAILED
   }"
 >
-  <pre *ngIf="formattedLog; else noOutput"><code [innerHTML]="formattedLog"></code></pre>
+  <pre *ngIf="formattedLog; else noOutput" class="stdout"><code [innerHTML]="formattedLog"></code></pre>
   <ng-template #noOutput>
     <p class="info-message">No output was produced.</p>
   </ng-template>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
@@ -1,13 +1,8 @@
 <biosimulations-text-page-content-section
   [heading]="heading"
-  [ngClass]="{
-    'queued': status === SimulationRunStatus.CREATED || status === SimulationRunStatus.QUEUED,
-    'running': status === SimulationRunStatus.RUNNING || status === SimulationRunStatus.PROCESSING,
-    'succeeded': status === SimulationRunStatus.SUCCEEDED,
-    'failed': status === SimulationRunStatus.FAILED
-  }"
+  [class]="['status-section', status]"
 >
-  <pre *ngIf="formattedLog; else noOutput" class="stdout"><code [innerHTML]="formattedLog"></code></pre>
+  <pre *ngIf="formattedLog; else noOutput" class="stdout dark"><code [innerHTML]="formattedLog"></code></pre>
   <ng-template #noOutput>
     <p class="info-message">No output was produced.</p>
   </ng-template>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
@@ -1,6 +1,6 @@
 <biosimulations-text-page-content-section
   [heading]="heading"
-  [ngClass]="{    
+  [ngClass]="{
     'queued': status === SimulationRunStatus.CREATED || status === SimulationRunStatus.QUEUED,
     'running': status === SimulationRunStatus.RUNNING || status === SimulationRunStatus.PROCESSING,
     'succeeded': status === SimulationRunStatus.SUCCEEDED,

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.html
@@ -1,0 +1,14 @@
+<biosimulations-text-page-content-section
+  [heading]="heading"
+  [ngClass]="{    
+    'queued': status === SimulationRunStatus.CREATED || status === SimulationRunStatus.QUEUED,
+    'running': status === SimulationRunStatus.RUNNING || status === SimulationRunStatus.PROCESSING,
+    'succeeded': status === SimulationRunStatus.SUCCEEDED,
+    'failed': status === SimulationRunStatus.FAILED
+  }"
+>
+  <pre *ngIf="formattedLog; else noOutput"><code [innerHTML]="formattedLog"></code></pre>
+  <ng-template #noOutput>
+    <p class="info-message">No output was produced.</p>
+  </ng-template>
+</biosimulations-text-page-content-section>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.spec.ts
@@ -1,0 +1,36 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RawSimulationLogComponent } from './raw-simulation-log.component';
+import { SharedUiModule } from '@biosimulations/shared/ui';
+import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
+import { ScrollService } from '@biosimulations/shared/services';
+import { RouterTestingModule } from '@angular/router/testing';
+describe('RawSimulationLogComponent', () => {
+  let component: RawSimulationLogComponent;
+  let fixture: ComponentFixture<RawSimulationLogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        RawSimulationLogComponent,
+      ],
+      imports: [
+        SharedUiModule,
+        BiosimulationsIconsModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        ScrollService,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RawSimulationLogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input } from '@angular/core';
+import { RawSimulationLog } from '../../../../simulation-logs-datamodel';
+import { SimulationRunStatus } from '@biosimulations/datamodel/common'
+import * as Convert from 'ansi-to-html';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Component({
+  selector: 'biosimulations-raw-simulation-log',
+  templateUrl: './raw-simulation-log.component.html',
+  styleUrls: ['./raw-simulation-log.component.scss'],
+})
+export class RawSimulationLogComponent {
+  SimulationRunStatus = SimulationRunStatus;
+
+  constructor(private sanitizer: DomSanitizer){}
+
+  heading!: string;
+
+  private _status!: SimulationRunStatus;
+
+  @Input()
+  set status(value: SimulationRunStatus) {
+    this.heading = 'Raw standard output and error for the entire job (' + value.toLowerCase() + ')';
+    this._status = value;
+  }
+
+  get status(): SimulationRunStatus {
+    return this._status;
+  }
+
+  formattedLog!: SafeHtml | null;
+
+  @Input()
+  set log(value: RawSimulationLog) {
+    const convert = new Convert();
+    this.formattedLog = value ? this.sanitizer.bypassSecurityTrustHtml(convert.toHtml(value)) : null;
+  }
+}

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/raw-simulation-log.component.ts
@@ -10,8 +10,6 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
   styleUrls: ['./raw-simulation-log.component.scss'],
 })
 export class RawSimulationLogComponent {
-  SimulationRunStatus = SimulationRunStatus;
-
   constructor(private sanitizer: DomSanitizer){}
 
   heading!: string;

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -3,6 +3,7 @@
   [padded]="false"
   alwaysFixed="calc(64px + 32px + 32px + 2rem)"
   [tocScrollSectionScrollOffset]="128"
+  *ngIf="structuredLogLevel !== undefined"
 >
   <ng-container id="sideBar" [ngSwitch]="structuredLogLevel">
     <ng-container *ngSwitchCase="StructuredLogLevel.None">

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -247,33 +247,37 @@
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
-        *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc"
+        *ngFor="let docLog of structuredLog.sedDocuments"
         [elementId]="docLog.id"
         elementType="Simulation experiment"
         [log]="docLog"
         [id]="'log=' + docLog.id"
         [compact]="true"
         iconActionType="toggle"
+        [first]="docLog === firstStructuredLogElement"
+        [last]="docLog === lastStructuredLogElement"
       >
       </biosimulations-structured-simulation-log-element>
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
         <biosimulations-structured-simulation-log-element
-          *ngFor="let taskLog of docLog.tasks; index as iTask"
+          *ngFor="let taskLog of docLog.tasks"
           [elementId]="docLog.id + ' :: ' + taskLog.id"
           elementType="Task"
           [log]="taskLog"
           [id]="'log=task-' + docLog.id + '/' + taskLog.id"
           [compact]="true"
           iconActionType="toggle"
+          [first]="taskLog === firstStructuredLogElement"
+          [last]="taskLog === lastStructuredLogElement"
         >
         </biosimulations-structured-simulation-log-element>
       </ng-container>
 
-      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
-        <ng-container *ngFor="let outputLog of docLog.outputs; index as iReport">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
+        <ng-container *ngFor="let outputLog of docLog.outputs">
           <biosimulations-structured-simulation-log-element
             *ngIf="outputLog?.dataSets"
             [elementId]="docLog.id + ' :: ' + outputLog.id"
@@ -282,13 +286,15 @@
             [id]="'log=output-' + docLog.id + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
+            [first]="outputLog === firstStructuredLogElement"
+            [last]="outputLog === lastStructuredLogElement"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>
       </ng-container>
 
-      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
-        <ng-container *ngFor="let outputLog of docLog.outputs; index as iPlot">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
+        <ng-container *ngFor="let outputLog of docLog.outputs">
           <biosimulations-structured-simulation-log-element
             *ngIf="!outputLog?.dataSets"
             [elementId]="docLog.id + ' :: ' + outputLog.id"
@@ -297,6 +303,8 @@
             [id]="'log=output-' + docLog.id + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
+            [first]="outputLog === firstStructuredLogElement"
+            [last]="outputLog === lastStructuredLogElement"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -51,12 +51,12 @@
 
       <biosimulations-text-page-side-bar-section heading="Experiments" fxShow fxHide.lt-md>
         <ul>
-          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+          <li *ngFor="let docLog of structuredLog.sedDocuments">
             <a
-              [class]="['status-label', docIdLog.value.status]"
-              (click)="scrollToElement('log=' + docIdLog.key)"
+              [class]="['status-label', docLog.status]"
+              (click)="scrollToElement('log=' + docLog.id)"
             >
-              {{ docIdLog.key }} ({{ docIdLog.value.status | slice : 0 : 1 }})
+              {{ docLog.id }} ({{ docLog.status | slice : 0 : 1 }})
             </a>
           </li>
         </ul>
@@ -130,13 +130,13 @@
             >
               ({{ numTasks }})
               <ul>
-                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                  <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">
+                <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
+                  <li *ngFor="let taskLog of docLog.tasks">
                     <a
-                      [class]="['status-label', taskIdLog.value.status]"
-                      (click)="scrollToElement('log=task-' + docIdLog.key + '/' + taskIdLog.key)"
+                      [class]="['status-label', taskLog.status]"
+                      (click)="scrollToElement('log=task-' + docLog.id + '/' + taskLog.id)"
                     >
-                      {{ docIdLog.key }} :: {{ taskIdLog.key }} ({{ taskIdLog.value.status | slice : 0 : 1 }})
+                      {{ docLog.id }} :: {{ taskLog.id }} ({{ taskLog.status | slice : 0 : 1 }})
                     </a>
                   </li>
                 </ng-container>
@@ -151,14 +151,14 @@
             >
               ({{ numReports }})
               <ul>
-                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                  <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
-                    <li *ngIf="outputIdLog.value?.dataSets">
+                <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
+                  <ng-container *ngFor="let outputLog of docLog.outputs">
+                    <li *ngIf="outputLog?.dataSets">
                       <a
-                        [class]="['status-label', outputIdLog.value.status]"
-                        (click)="scrollToElement('log=output-' + docIdLog.key + '/' + outputIdLog.key)"
+                        [class]="['status-label', outputLog.status]"
+                        (click)="scrollToElement('log=output-' + docLog.id + '/' + outputLog.id)"
                       >
-                        {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
+                        {{ docLog.id }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
                       </a>
                     </li>
                   </ng-container>
@@ -174,14 +174,14 @@
             >
               ({{ numPlots }})
               <ul>
-                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                  <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
-                    <li *ngIf="!outputIdLog.value?.dataSets">
+                <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
+                  <ng-container *ngFor="let outputLog of docLog.outputs">
+                    <li *ngIf="!outputLog?.dataSets">
                       <a
-                        [class]="['status-label', outputIdLog.value.status]"
-                        (click)="scrollToElement('log=output-' + docIdLog.key + '/' + outputIdLog.key)"
+                        [class]="['status-label', outputLog.status]"
+                        (click)="scrollToElement('log=output-' + docLog.id + '/' + outputLog.id)"
                       >
-                        {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
+                        {{ docLog.id }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
                       </a>
                     </li>
                   </ng-container>
@@ -247,11 +247,11 @@
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
-        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc"
-        [elementId]="docIdLog.key"
+        *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc"
+        [elementId]="docLog.id"
         elementType="Simulation experiment"
-        [log]="docIdLog.value"
-        [id]="'log=' + docIdLog.key"
+        [log]="docLog"
+        [id]="'log=' + docLog.id"
         [compact]="true"
         iconActionType="toggle"
       >
@@ -259,27 +259,27 @@
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
         <biosimulations-structured-simulation-log-element
-          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator; index as iTask"
-          [elementId]="docIdLog.key + ' :: ' + taskIdLog.key"
+          *ngFor="let taskLog of docLog.tasks; index as iTask"
+          [elementId]="docLog.id + ' :: ' + taskLog.id"
           elementType="Task"
-          [log]="taskIdLog.value"
-          [id]="'log=task-' + docIdLog.key + '/' + taskIdLog.key"
+          [log]="taskLog"
+          [id]="'log=task-' + docLog.id + '/' + taskLog.id"
           [compact]="true"
           iconActionType="toggle"
         >
         </biosimulations-structured-simulation-log-element>
       </ng-container>
 
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
-        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator; index as iReport">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
+        <ng-container *ngFor="let outputLog of docLog.outputs; index as iReport">
           <biosimulations-structured-simulation-log-element
-            *ngIf="outputIdLog.value?.dataSets"
-            [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
+            *ngIf="outputLog?.dataSets"
+            [elementId]="docLog.id + ' :: ' + outputLog.id"
             elementType="Report"
-            [log]="outputIdLog.value"
-            [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
+            [log]="outputLog"
+            [id]="'log=output-' + docLog.id + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
           >
@@ -287,14 +287,14 @@
         </ng-container>
       </ng-container>
 
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
-        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator; index as iPlot">
+      <ng-container *ngFor="let docLog of structuredLog.sedDocuments; index as iDoc">
+        <ng-container *ngFor="let outputLog of docLog.outputs; index as iPlot">
           <biosimulations-structured-simulation-log-element
-            *ngIf="!outputIdLog.value?.dataSets"
-            [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
+            *ngIf="!outputLog?.dataSets"
+            [elementId]="docLog.id + ' :: ' + outputLog.id"
             elementType="Plot"
-            [log]="outputIdLog.value"
-            [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
+            [log]="outputLog"
+            [id]="'log=output-' + docLog.id + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
           >

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -54,9 +54,9 @@
           <li *ngFor="let docLog of structuredLog.sedDocuments">
             <a
               [class]="['status-label', docLog.status]"
-              (click)="scrollToElement('log=' + docLog.id)"
+              (click)="scrollToElement('log=' + docLog.location)"
             >
-              {{ docLog.id }} ({{ docLog.status | slice : 0 : 1 }})
+              {{ docLog.location }} ({{ docLog.status | slice : 0 : 1 }})
             </a>
           </li>
         </ul>
@@ -134,9 +134,9 @@
                   <li *ngFor="let taskLog of docLog.tasks">
                     <a
                       [class]="['status-label', taskLog.status]"
-                      (click)="scrollToElement('log=task-' + docLog.id + '/' + taskLog.id)"
+                      (click)="scrollToElement('log=task-' + docLog.location + '/' + taskLog.id)"
                     >
-                      {{ docLog.id }} :: {{ taskLog.id }} ({{ taskLog.status | slice : 0 : 1 }})
+                      {{ docLog.location }} :: {{ taskLog.id }} ({{ taskLog.status | slice : 0 : 1 }})
                     </a>
                   </li>
                 </ng-container>
@@ -156,9 +156,9 @@
                     <li *ngIf="outputLog?.dataSets">
                       <a
                         [class]="['status-label', outputLog.status]"
-                        (click)="scrollToElement('log=output-' + docLog.id + '/' + outputLog.id)"
+                        (click)="scrollToElement('log=output-' + docLog.location + '/' + outputLog.id)"
                       >
-                        {{ docLog.id }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
+                        {{ docLog.location }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
                       </a>
                     </li>
                   </ng-container>
@@ -179,9 +179,9 @@
                     <li *ngIf="!outputLog?.dataSets">
                       <a
                         [class]="['status-label', outputLog.status]"
-                        (click)="scrollToElement('log=output-' + docLog.id + '/' + outputLog.id)"
+                        (click)="scrollToElement('log=output-' + docLog.location + '/' + outputLog.id)"
                       >
-                        {{ docLog.id }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
+                        {{ docLog.location }} :: {{ outputLog.id }} ({{ outputLog.status | slice : 0 : 1 }})
                       </a>
                     </li>
                   </ng-container>
@@ -248,10 +248,10 @@
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
         *ngFor="let docLog of structuredLog.sedDocuments"
-        [elementId]="docLog.id"
+        [elementId]="docLog.location"
         elementType="Simulation experiment"
         [log]="docLog"
-        [id]="'log=' + docLog.id"
+        [id]="'log=' + docLog.location"
         [compact]="true"
         iconActionType="toggle"
         [first]="docLog === firstStructuredLogElement"
@@ -264,10 +264,10 @@
       <ng-container *ngFor="let docLog of structuredLog.sedDocuments">
         <biosimulations-structured-simulation-log-element
           *ngFor="let taskLog of docLog.tasks"
-          [elementId]="docLog.id + ' :: ' + taskLog.id"
+          [elementId]="docLog.location + ' :: ' + taskLog.id"
           elementType="Task"
           [log]="taskLog"
-          [id]="'log=task-' + docLog.id + '/' + taskLog.id"
+          [id]="'log=task-' + docLog.location + '/' + taskLog.id"
           [compact]="true"
           iconActionType="toggle"
           [first]="taskLog === firstStructuredLogElement"
@@ -280,10 +280,10 @@
         <ng-container *ngFor="let outputLog of docLog.outputs">
           <biosimulations-structured-simulation-log-element
             *ngIf="outputLog?.dataSets"
-            [elementId]="docLog.id + ' :: ' + outputLog.id"
+            [elementId]="docLog.location + ' :: ' + outputLog.id"
             elementType="Report"
             [log]="outputLog"
-            [id]="'log=output-' + docLog.id + '/' + outputLog.id"
+            [id]="'log=output-' + docLog.location + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
             [first]="outputLog === firstStructuredLogElement"
@@ -297,10 +297,10 @@
         <ng-container *ngFor="let outputLog of docLog.outputs">
           <biosimulations-structured-simulation-log-element
             *ngIf="!outputLog?.dataSets"
-            [elementId]="docLog.id + ' :: ' + outputLog.id"
+            [elementId]="docLog.location + ' :: ' + outputLog.id"
             elementType="Plot"
             [log]="outputLog"
-            [id]="'log=output-' + docLog.id + '/' + outputLog.id"
+            [id]="'log=output-' + docLog.location + '/' + outputLog.id"
             [compact]="true"
             iconActionType="toggle"
             [first]="outputLog === firstStructuredLogElement"

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -1,0 +1,138 @@
+<biosimulations-text-page
+  contentsHeading=""
+  [padded]="false"
+  alwaysFixed="calc(64px + 32px + 32px + 2rem)"
+  [tocScrollSectionScrollOffset]="128"
+>
+  <ng-container id="sideBar" [ngSwitch]="structuredLogLevel">
+    <ng-container *ngSwitchCase="StructuredLogLevel.None">
+      <biosimulations-text-page-side-bar-section heading="Raw Log" fxShow fxHide.lt-md>
+        <ul class="vertically-spaced">
+          <li>Raw standard output and error for the entire job</li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="StructuredLogLevel.CombineArchive">
+      <biosimulations-text-page-side-bar-section heading="Combined log" fxShow fxHide.lt-md>
+        <ul class="vertically-spaced">
+          <li>Combined log of the entire job</li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
+      <biosimulations-text-page-side-bar-section heading="SED document logs" fxShow fxHide.lt-md>
+        <ul class="vertically-spaced">
+          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">{{ docIdLog.key }}</li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+    </ng-container>
+
+    <ng-container *ngSwitchDefault>
+      <biosimulations-text-page-side-bar-section heading="SED task &amp; output logs" fxShow fxHide.lt-md>
+        <ul class="vertically-spaced">
+          <li>Tasks<ul
+            *ngIf="logHasTasks; else noTaskLogs">
+              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
+                <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue">{{ docIdLog.key }} :: {{ taskIdLog.key }}</li>
+              </ng-container>
+            </ul
+            ><ng-template #noTaskLogs>: 
+              <span *ngIf="!archiveHasTasks" class="info-message">None</span>
+              <span *ngIf="archiveHasTasks" class="info-message">N/A</span>
+            </ng-template>
+          </li>
+          <li>Outputs<ul
+           *ngIf="logHasOutputs; else noOutputLogs">
+              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
+                <li *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+              </ng-container>
+            </ul
+            ><ng-template #noOutputLogs>: 
+              <span *ngIf="!archiveHasOutputs" class="info-message">None</span>
+              <span *ngIf="archiveHasOutputs" class="info-message">N/A</span>
+            </ng-template>
+          </li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+    </ng-container>
+
+    <biosimulations-text-page-side-bar-section heading="Download logs" fxShow fxHide.lt-md>
+      <ul class="icon-list">
+        <li>
+          <button
+            mat-icon-button
+            class="biosimulations-icon-button"
+            title="Download raw log"
+            (click)="downloadStructuredLog()"
+            [disabled]="structuredLog === undefined"
+          >
+            <biosimulations-icon icon="download"></biosimulations-icon>
+            Structured log of the entire run
+          </button>
+        </li>
+        <li>
+          <button
+            mat-icon-button
+            class="biosimulations-icon-button"
+            title="Download raw log"
+            (click)="downloadRawLog()"
+          >
+            <biosimulations-icon icon="download"></biosimulations-icon>
+            Raw standard output and error log of the entire run
+          </button>
+        </li>
+      </ul>
+    </biosimulations-text-page-side-bar-section>
+  </ng-container>
+
+  <ng-container id="content" [ngSwitch]="structuredLogLevel">
+    <ng-container *ngSwitchCase="StructuredLogLevel.None">
+      <biosimulations-raw-simulation-log
+        [status]="status"
+        [log]="rawLog"
+      >
+      </biosimulations-raw-simulation-log>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="StructuredLogLevel.CombineArchive">
+      <biosimulations-structured-simulation-log-element
+        [log]="structuredLog"
+        elementId="entire job"
+        elementType="Combined log of the"
+      >
+      </biosimulations-structured-simulation-log-element>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
+      <biosimulations-structured-simulation-log-element
+        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue"        
+        [elementId]="docIdLog.key"
+        elementType="Simulation experiment"
+        [log]="docIdLog.value"
+      >
+      </biosimulations-structured-simulation-log-element>
+    </ng-container>
+
+    <ng-container *ngSwitchDefault>
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
+        <biosimulations-structured-simulation-log-element
+          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue"
+          [elementId]="docIdLog.key + ' :: ' + taskIdLog.key"
+          elementType="Task"
+          [log]="taskIdLog.value"
+        >
+        </biosimulations-structured-simulation-log-element>
+
+        <biosimulations-structured-simulation-log-element
+          *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue"
+          [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
+          elementType="Output"
+          [log]="outputIdLog.value"
+        >
+        </biosimulations-structured-simulation-log-element>
+      </ng-container>
+    </ng-container>
+  </ng-container>
+</biosimulations-text-page>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -24,7 +24,7 @@
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-text-page-side-bar-section heading="SED document logs" fxShow fxHide.lt-md>
         <ul class="vertically-spaced">
-          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">{{ docIdLog.key }}</li>
+          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">{{ docIdLog.key }}</li>
         </ul>
       </biosimulations-text-page-side-bar-section>
     </ng-container>
@@ -34,8 +34,8 @@
         <ul class="vertically-spaced">
           <li>Tasks<ul
             *ngIf="logHasTasks; else noTaskLogs">
-              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
-                <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue">{{ docIdLog.key }} :: {{ taskIdLog.key }}</li>
+              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">{{ docIdLog.key }} :: {{ taskIdLog.key }}</li>
               </ng-container>
             </ul
             ><ng-template #noTaskLogs>: 
@@ -45,8 +45,8 @@
           </li>
           <li>Outputs<ul
            *ngIf="logHasOutputs; else noOutputLogs">
-              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
-                <li *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                <li *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
               </ng-container>
             </ul
             ><ng-template #noOutputLogs>: 
@@ -107,7 +107,7 @@
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
-        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue"        
+        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator"        
         [elementId]="docIdLog.key"
         elementType="Simulation experiment"
         [log]="docIdLog.value"
@@ -116,9 +116,9 @@
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue">
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
         <biosimulations-structured-simulation-log-element
-          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue"
+          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator"
           [elementId]="docIdLog.key + ' :: ' + taskIdLog.key"
           elementType="Task"
           [log]="taskIdLog.value"
@@ -126,7 +126,7 @@
         </biosimulations-structured-simulation-log-element>
 
         <biosimulations-structured-simulation-log-element
-          *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue"
+          *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator"
           [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
           elementType="Output"
           [log]="outputIdLog.value"

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -14,7 +14,7 @@
 
       <biosimulations-text-page-side-bar-section heading="Raw Log" fxShow fxHide.lt-md>
         <ul class="vertically-spaced">
-          <li>Raw standard output and error for the entire job</li>
+          <li><a (click)="scrollToElement('log')">Raw standard output and error for the entire job</a></li>
         </ul>
       </biosimulations-text-page-side-bar-section>
     </ng-container>
@@ -28,7 +28,7 @@
 
       <biosimulations-text-page-side-bar-section heading="Combined log" fxShow fxHide.lt-md>
         <ul>
-          <li>Combined log of the entire job</li>
+          <li><a (click)="scrollToElement('log')">Combined log of the entire job</a></li>
         </ul>
       </biosimulations-text-page-side-bar-section>
     </ng-container>
@@ -50,7 +50,12 @@
       <biosimulations-text-page-side-bar-section heading="Experiments" fxShow fxHide.lt-md>
         <ul>
           <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-            <span [class]="['status-label', docIdLog.value.status]">{{ docIdLog.key }} ({{ docIdLog.value.status | slice : 0 : 1 }})</span>
+            <a
+              [class]="['status-label', docIdLog.value.status]"
+              (click)="scrollToElement('log=' + docIdLog.key)"
+            >
+              {{ docIdLog.key }} ({{ docIdLog.value.status | slice : 0 : 1 }})
+            </a>
           </li>
         </ul>
       </biosimulations-text-page-side-bar-section>
@@ -125,9 +130,12 @@
               <ul>
                 <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
                   <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">
-                    <span [class]="['status-label', taskIdLog.value.status]">
+                    <a
+                      [class]="['status-label', taskIdLog.value.status]"
+                      (click)="scrollToElement('log=task-' + docIdLog.key + '/' + taskIdLog.key)"
+                    >
                       {{ docIdLog.key }} :: {{ taskIdLog.key }} ({{ taskIdLog.value.status | slice : 0 : 1 }})
-                    </span>
+                    </a>
                   </li>
                 </ng-container>
               </ul>
@@ -144,9 +152,12 @@
                 <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
                   <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
                     <li *ngIf="outputIdLog.value?.dataSets">
-                      <span [class]="['status-label', outputIdLog.value.status]">
+                      <a
+                        [class]="['status-label', outputIdLog.value.status]"
+                        (click)="scrollToElement('log=output-' + docIdLog.key + '/' + outputIdLog.key)"
+                      >
                         {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
-                      </span>
+                      </a>
                     </li>
                   </ng-container>
                 </ng-container>
@@ -164,9 +175,12 @@
                 <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
                   <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
                     <li *ngIf="!outputIdLog.value?.dataSets">
-                      <span [class]="['status-label', outputIdLog.value.status]">
+                      <a
+                        [class]="['status-label', outputIdLog.value.status]"
+                        (click)="scrollToElement('log=output-' + docIdLog.key + '/' + outputIdLog.key)"
+                      >
                         {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
-                      </span>
+                      </a>
                     </li>
                   </ng-container>
                 </ng-container>
@@ -214,6 +228,7 @@
       <biosimulations-raw-simulation-log
         [status]="status"
         [log]="rawLog"
+        id="log"
       >
       </biosimulations-raw-simulation-log>
     </ng-container>
@@ -223,6 +238,7 @@
         [log]="structuredLog"
         elementId="entire job"
         elementType="Combined log of the"
+        id="log"
       >
       </biosimulations-structured-simulation-log-element>
     </ng-container>
@@ -233,6 +249,7 @@
         [elementId]="docIdLog.key"
         elementType="Simulation experiment"
         [log]="docIdLog.value"
+        [id]="'log=' + docIdLog.key"
       >
       </biosimulations-structured-simulation-log-element>
     </ng-container>
@@ -244,6 +261,7 @@
           [elementId]="docIdLog.key + ' :: ' + taskIdLog.key"
           elementType="Task"
           [log]="taskIdLog.value"
+          [id]="'log=task-' + docIdLog.key + '/' + taskIdLog.key"
         >
         </biosimulations-structured-simulation-log-element>
       </ng-container>
@@ -255,6 +273,7 @@
             [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
             elementType="Report"
             [log]="outputIdLog.value"
+            [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>
@@ -267,6 +286,7 @@
             [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
             elementType="Plot"
             [log]="outputIdLog.value"
+            [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -38,20 +38,35 @@
                 <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">{{ docIdLog.key }} :: {{ taskIdLog.key }}</li>
               </ng-container>
             </ul
-            ><ng-template #noTaskLogs>: 
+            ><ng-template #noTaskLogs>:
               <span *ngIf="!archiveHasTasks" class="info-message">None</span>
               <span *ngIf="archiveHasTasks" class="info-message">N/A</span>
             </ng-template>
           </li>
-          <li>Outputs<ul
-           *ngIf="logHasOutputs; else noOutputLogs">
+          <li>Reports<ul
+           *ngIf="logHasReports; else noReportLogs">
               <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                <li *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+                <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+                  <li *ngIf="outputIdLog.value?.dataSets">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+                </ng-container>
               </ng-container>
             </ul
-            ><ng-template #noOutputLogs>: 
-              <span *ngIf="!archiveHasOutputs" class="info-message">None</span>
-              <span *ngIf="archiveHasOutputs" class="info-message">N/A</span>
+            ><ng-template #noReportLogs>:
+              <span *ngIf="!archiveHasReports" class="info-message">None</span>
+              <span *ngIf="archiveHasReports" class="info-message">N/A</span>
+            </ng-template>
+          </li>
+          <li>Plots<ul
+           *ngIf="logHasPlots; else noPlotLogs">
+              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+                  <li *ngIf="!outputIdLog.value?.dataSets">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+                </ng-container>
+              </ng-container>
+            </ul
+            ><ng-template #noPlotLogs>:
+              <span *ngIf="!archiveHasPlots" class="info-message">None</span>
+              <span *ngIf="archiveHasPlots" class="info-message">N/A</span>
             </ng-template>
           </li>
         </ul>
@@ -107,7 +122,7 @@
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
-        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator"        
+        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator"
         [elementId]="docIdLog.key"
         elementType="Simulation experiment"
         [log]="docIdLog.value"
@@ -124,14 +139,30 @@
           [log]="taskIdLog.value"
         >
         </biosimulations-structured-simulation-log-element>
+      </ng-container>
 
-        <biosimulations-structured-simulation-log-element
-          *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator"
-          [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
-          elementType="Output"
-          [log]="outputIdLog.value"
-        >
-        </biosimulations-structured-simulation-log-element>
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+          <biosimulations-structured-simulation-log-element
+            *ngIf="outputIdLog.value?.dataSets"
+            [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
+            elementType="Report"
+            [log]="outputIdLog.value"
+          >
+          </biosimulations-structured-simulation-log-element>
+        </ng-container>
+      </ng-container>
+
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+          <biosimulations-structured-simulation-log-element
+            *ngIf="!outputIdLog.value?.dataSets"
+            [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
+            elementType="Plot"
+            [log]="outputIdLog.value"
+          >
+          </biosimulations-structured-simulation-log-element>
+        </ng-container>
       </ng-container>
     </ng-container>
   </ng-container>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -4,6 +4,7 @@
   alwaysFixed="calc(64px + 32px + 32px + 2rem)"
   [tocScrollSectionScrollOffset]="128"
   *ngIf="structuredLogLevel !== undefined"
+  [compact]="structuredLogLevel && structuredLogLevel >= StructuredLogLevel.SedDocument"
 >
   <ng-container id="sideBar" [ngSwitch]="structuredLogLevel">
     <ng-container *ngSwitchCase="StructuredLogLevel.None">
@@ -246,48 +247,56 @@
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
       <biosimulations-structured-simulation-log-element
-        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator"
+        *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc"
         [elementId]="docIdLog.key"
         elementType="Simulation experiment"
         [log]="docIdLog.value"
         [id]="'log=' + docIdLog.key"
+        [compact]="true"
+        iconActionType="toggle"
       >
       </biosimulations-structured-simulation-log-element>
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
         <biosimulations-structured-simulation-log-element
-          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator"
+          *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator; index as iTask"
           [elementId]="docIdLog.key + ' :: ' + taskIdLog.key"
           elementType="Task"
           [log]="taskIdLog.value"
           [id]="'log=task-' + docIdLog.key + '/' + taskIdLog.key"
+          [compact]="true"
+          iconActionType="toggle"
         >
         </biosimulations-structured-simulation-log-element>
       </ng-container>
 
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
+        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator; index as iReport">
           <biosimulations-structured-simulation-log-element
             *ngIf="outputIdLog.value?.dataSets"
             [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
             elementType="Report"
             [log]="outputIdLog.value"
             [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
+            [compact]="true"
+            iconActionType="toggle"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>
       </ng-container>
 
-      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+      <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator; index as iDoc">
+        <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator; index as iPlot">
           <biosimulations-structured-simulation-log-element
             *ngIf="!outputIdLog.value?.dataSets"
             [elementId]="docIdLog.key + ' :: ' + outputIdLog.key"
             elementType="Plot"
             [log]="outputIdLog.value"
             [id]="'log=output-' + docIdLog.key + '/' + outputIdLog.key"
+            [compact]="true"
+            iconActionType="toggle"
           >
           </biosimulations-structured-simulation-log-element>
         </ng-container>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.html
@@ -6,6 +6,12 @@
 >
   <ng-container id="sideBar" [ngSwitch]="structuredLogLevel">
     <ng-container *ngSwitchCase="StructuredLogLevel.None">
+      <biosimulations-text-page-side-bar-section heading="Summary" fxShow fxHide.lt-md>
+        <ul>
+          <li>Status: <span [class]="['status-label', status]">{{ status | titlecase }}</span></li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+
       <biosimulations-text-page-side-bar-section heading="Raw Log" fxShow fxHide.lt-md>
         <ul class="vertically-spaced">
           <li>Raw standard output and error for the entire job</li>
@@ -14,59 +20,160 @@
     </ng-container>
 
     <ng-container *ngSwitchCase="StructuredLogLevel.CombineArchive">
+      <biosimulations-text-page-side-bar-section heading="Summary" fxShow fxHide.lt-md>
+        <ul>
+          <li>Status: <span [class]="['status-label', status]">{{ status | titlecase }}</span></li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+
       <biosimulations-text-page-side-bar-section heading="Combined log" fxShow fxHide.lt-md>
-        <ul class="vertically-spaced">
+        <ul>
           <li>Combined log of the entire job</li>
         </ul>
       </biosimulations-text-page-side-bar-section>
     </ng-container>
 
     <ng-container *ngSwitchCase="StructuredLogLevel.SedDocument">
-      <biosimulations-text-page-side-bar-section heading="SED document logs" fxShow fxHide.lt-md>
+      <biosimulations-text-page-side-bar-section heading="Summary" fxShow fxHide.lt-md>
         <ul class="vertically-spaced">
-          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">{{ docIdLog.key }}</li>
+          <li>Status: <span [class]="['status-label', status]">{{ status | titlecase }}</span></li>
+          <li>Simulation experiments ({{ numSedDocuments }})
+            <ul>
+              <li *ngFor="let statusCount of sedDocumentStatusCounts">
+                <span [class]="['status-label', statusCount.color ]">{{ statusCount.label }}: {{  statusCount.count }}</span>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+
+      <biosimulations-text-page-side-bar-section heading="Experiments" fxShow fxHide.lt-md>
+        <ul>
+          <li *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+            <span [class]="['status-label', docIdLog.value.status]">{{ docIdLog.key }} ({{ docIdLog.value.status | slice : 0 : 1 }})</span>
+          </li>
         </ul>
       </biosimulations-text-page-side-bar-section>
     </ng-container>
 
     <ng-container *ngSwitchDefault>
-      <biosimulations-text-page-side-bar-section heading="SED task &amp; output logs" fxShow fxHide.lt-md>
+      <biosimulations-text-page-side-bar-section heading="Summary" fxShow fxHide.lt-md>
         <ul class="vertically-spaced">
-          <li>Tasks<ul
-            *ngIf="logHasTasks; else noTaskLogs">
-              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">{{ docIdLog.key }} :: {{ taskIdLog.key }}</li>
-              </ng-container>
-            </ul
-            ><ng-template #noTaskLogs>:
-              <span *ngIf="!archiveHasTasks" class="info-message">None</span>
-              <span *ngIf="archiveHasTasks" class="info-message">N/A</span>
+          <li>Status: <span [class]="['status-label', status]">{{ status | titlecase }}</span></li>
+
+          <li>Simulation experiments ({{ numSedDocuments }})
+            <ul>
+              <li *ngFor="let statusCount of sedDocumentStatusCounts">
+                <span [class]="['status-label', statusCount.color ]">{{ statusCount.label }}: {{  statusCount.count }}</span>
+              </li>
+            </ul>
+          </li>
+
+          <li>Tasks<ng-container
+            *ngIf="logHasTasks; else logNotAvailable"
+            >
+              ({{ numTasks }})
+              <ul>
+                <li *ngFor="let statusCount of taskStatusCounts">
+                  <span [class]="['status-label', statusCount.color ]">{{ statusCount.label }}: {{  statusCount.count }}</span>
+                </li>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
             </ng-template>
           </li>
-          <li>Reports<ul
-           *ngIf="logHasReports; else noReportLogs">
-              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
-                  <li *ngIf="outputIdLog.value?.dataSets">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
-                </ng-container>
-              </ng-container>
-            </ul
-            ><ng-template #noReportLogs>:
-              <span *ngIf="!archiveHasReports" class="info-message">None</span>
-              <span *ngIf="archiveHasReports" class="info-message">N/A</span>
+
+          <li>Reports<ng-container
+            *ngIf="logHasReports; else logNotAvailable"
+            >
+              ({{ numReports }})
+              <ul>
+                <li *ngFor="let statusCount of reportStatusCounts">
+                  <span [class]="['status-label', statusCount.color ]">{{ statusCount.label }}: {{  statusCount.count }}</span>
+                </li>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
             </ng-template>
           </li>
-          <li>Plots<ul
-           *ngIf="logHasPlots; else noPlotLogs">
-              <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
-                <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
-                  <li *ngIf="!outputIdLog.value?.dataSets">{{ docIdLog.key }} :: {{ outputIdLog.key }}</li>
+
+          <li>Plots<ng-container
+            *ngIf="logHasPlots; else logNotAvailable"
+            >
+              ({{ numPlots }})
+              <ul>
+                <li *ngFor="let statusCount of plotStatusCounts">
+                  <span [class]="['status-label', statusCount.color ]">{{ statusCount.label }}: {{  statusCount.count }}</span>
+                </li>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
+            </ng-template>
+          </li>
+        </ul>
+      </biosimulations-text-page-side-bar-section>
+
+      <biosimulations-text-page-side-bar-section heading="Tasks, reports &amp; plots" fxShow fxHide.lt-md>
+        <ul class="vertically-spaced">
+          <li>Tasks<ng-container
+            *ngIf="logHasTasks; else logNotAvailable"
+            >
+              ({{ numTasks }})
+              <ul>
+                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                  <li *ngFor="let taskIdLog of docIdLog.value.tasks | keyvalue : naturalComparator">
+                    <span [class]="['status-label', taskIdLog.value.status]">
+                      {{ docIdLog.key }} :: {{ taskIdLog.key }} ({{ taskIdLog.value.status | slice : 0 : 1 }})
+                    </span>
+                  </li>
                 </ng-container>
-              </ng-container>
-            </ul
-            ><ng-template #noPlotLogs>:
-              <span *ngIf="!archiveHasPlots" class="info-message">None</span>
-              <span *ngIf="archiveHasPlots" class="info-message">N/A</span>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
+            </ng-template>
+          </li>
+          <li>Reports<ng-container
+              *ngIf="logHasReports; else logNotAvailable"
+            >
+              ({{ numReports }})
+              <ul>
+                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                  <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+                    <li *ngIf="outputIdLog.value?.dataSets">
+                      <span [class]="['status-label', outputIdLog.value.status]">
+                        {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
+                      </span>
+                    </li>
+                  </ng-container>
+                </ng-container>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
+            </ng-template>
+          </li>
+          <li>Plots<ng-container
+            *ngIf="logHasPlots; else logNotAvailable"
+            >
+              ({{ numPlots }})
+              <ul>
+                <ng-container *ngFor="let docIdLog of structuredLog.sedDocuments | keyvalue : naturalComparator">
+                  <ng-container *ngFor="let outputIdLog of docIdLog.value.outputs | keyvalue : naturalComparator">
+                    <li *ngIf="!outputIdLog.value?.dataSets">
+                      <span [class]="['status-label', outputIdLog.value.status]">
+                        {{ docIdLog.key }} :: {{ outputIdLog.key }} ({{ outputIdLog.value.status | slice : 0 : 1 }})
+                      </span>
+                    </li>
+                  </ng-container>
+                </ng-container>
+              </ul>
+            </ng-container>
+            <ng-template #logNotAvailable>
+              <span class="info-message">: N/A</span>
             </ng-template>
           </li>
         </ul>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
@@ -30,42 +30,8 @@ biosimulations-text-page-side-bar-section ::ng-deep {
 biosimulations-raw-simulation-log,
 biosimulations-structured-simulation-log-element {
   ::ng-deep {
-    .queued h2 {
-      color: mat-color($theme-accent);
-      background: $theme-accent-lightest;
-    }
-
-    .running h2 {
-      color: mat-color($theme-tertiary);
-      background: $theme-tertiary-lightest;
-    }
-
-    .succeeded h2 {
-      color: mat-color($theme-primary);
-      background: $theme-primary-lightest;
-    }
-
-    .skipped h2 {
-      color: mat-color($theme-quartenary);
-      background: $theme-quartenary-lightest;
-    }
-
-    .failed h2 {
-      color: mat-color($theme-warn);
-      background: $theme-warn-lightest;
-    }
-  }
-}
-
-biosimulations-raw-simulation-log,
-biosimulations-structured-simulation-log-element {
-  ::ng-deep {
     pre.stdout {
-      &, & > code {
-        max-height: 600px;
-        background: $dark-background;
-        color: $light-text;
-      }
+      max-height: 600px;
     }
   }
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
@@ -1,0 +1,62 @@
+@import 'biosimulations-colors';
+
+biosimulations-text-page-side-bar-section ::ng-deep {
+  .mat-icon-button {
+    white-space: normal;
+    font-weight: normal; 
+    text-align: left;
+    text-indent: -1.25rem;
+    margin-left: 1.25rem;
+    
+    biosimulations-icon {
+      position: relative;
+      top: -3px;
+    }
+
+    &:hover {
+      color: mat-color($theme-primary);
+    }
+
+    &:active {
+      color: mat-color($theme-primary, darker);
+    }
+
+    &.mat-button-disabled {
+      pointer-events: none;
+    }
+  }
+}
+
+biosimulations-raw-simulation-log,
+biosimulations-structured-simulation-log-element {
+  ::ng-deep {
+    .queued h2 {
+      color: mat-color($theme-accent);
+      background: $theme-accent-lightest;
+    }
+
+    .running h2 {
+      color: mat-color($theme-tertiary);
+      background: $theme-tertiary-lightest;
+    }
+
+    .succeeded h2 {
+      color: mat-color($theme-primary);
+      background: $theme-primary-lightest;
+    }
+
+    .skipped h2 {
+      color: mat-color($theme-quartenary);
+      background: $theme-quartenary-lightest;
+    }
+
+    .failed h2 {
+      color: mat-color($theme-warn);
+      background: $theme-warn-lightest;
+    }
+  }
+}
+
+#content ::ng-deep pre {
+  max-height: 600px;
+}

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
@@ -3,11 +3,11 @@
 biosimulations-text-page-side-bar-section ::ng-deep {
   .mat-icon-button {
     white-space: normal;
-    font-weight: normal; 
+    font-weight: normal;
     text-align: left;
     text-indent: -1.25rem;
     margin-left: 1.25rem;
-    
+
     biosimulations-icon {
       position: relative;
       top: -3px;
@@ -59,7 +59,7 @@ biosimulations-structured-simulation-log-element {
 
 biosimulations-raw-simulation-log,
 biosimulations-structured-simulation-log-element {
-  ::ng-deep { 
+  ::ng-deep {
     pre.stdout {
       &, & > code {
         max-height: 600px;

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.scss
@@ -57,6 +57,15 @@ biosimulations-structured-simulation-log-element {
   }
 }
 
-#content ::ng-deep pre {
-  max-height: 600px;
+biosimulations-raw-simulation-log,
+biosimulations-structured-simulation-log-element {
+  ::ng-deep { 
+    pre.stdout {
+      &, & > code {
+        max-height: 600px;
+        background: $dark-background;
+        color: $light-text;
+      }
+    }
+  }
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.spec.ts
@@ -1,0 +1,42 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SimulationLogComponent } from './simulation-log.component';
+import { RawSimulationLogComponent } from './raw-simulation-log.component';
+import { StructuredSimulationLogElementComponent } from './structured-simulation-log-element.component';
+import { SharedUiModule } from '@biosimulations/shared/ui';
+import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
+import { ScrollService } from '@biosimulations/shared/services';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+describe('SimulationLogComponent', () => {
+  let component: SimulationLogComponent;
+  let fixture: ComponentFixture<SimulationLogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        SimulationLogComponent,
+        RawSimulationLogComponent,
+        StructuredSimulationLogElementComponent,
+      ],
+      imports: [
+        HttpClientTestingModule,
+        SharedUiModule,
+        BiosimulationsIconsModule,
+        RouterTestingModule
+      ],
+      providers: [
+        ScrollService,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SimulationLogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -1,0 +1,147 @@
+import { Component, Input, ViewChild } from '@angular/core';
+import {
+  RawSimulationLog,
+  CombineArchiveLog,
+  SedReportLog,
+  SedPlot2DLog,
+  SedPlot3DLog,
+  DataSetLogs,
+  CurveLogs,
+  SurfaceLogs,
+  StructuredLogLevel,
+} from '../../../../simulation-logs-datamodel';
+import { SimulationRunStatus } from '@biosimulations/datamodel/common'
+import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'biosimulations-simulation-log',
+  templateUrl: './simulation-log.component.html',
+  styleUrls: ['./simulation-log.component.scss'],
+})
+export class SimulationLogComponent {
+  @Input()
+  status!: SimulationRunStatus;
+
+  @Input()
+  rawLog!: RawSimulationLog;
+
+  StructuredLogLevel = StructuredLogLevel;
+  private _structuredLog: CombineArchiveLog | undefined = undefined;
+  structuredLogLevel: StructuredLogLevel | undefined = undefined;
+  archiveHasTasks = false;
+  archiveHasOutputs = false;
+  logHasTasks = false;
+  logHasOutputs = false;
+
+  @Input()
+  set structuredLog(value: CombineArchiveLog | undefined) {
+    this._structuredLog = value;
+    this.structuredLogLevel = this.getStructuredLogLevel(value);
+  }
+
+  get structuredLog(): CombineArchiveLog | undefined {
+    return this._structuredLog;
+  }
+
+  getStructuredLogLevel(log: CombineArchiveLog | undefined): StructuredLogLevel {
+    let level: StructuredLogLevel = StructuredLogLevel.None;
+    this.archiveHasTasks = false;
+    this.archiveHasOutputs = false;
+    this.logHasTasks = false;
+    this.logHasOutputs = false;
+
+    if (log !== undefined) {
+      level = Math.max(level, StructuredLogLevel.CombineArchive);
+
+      if (level < StructuredLogLevel.SedDocument && log?.sedDocuments) {
+        for (const docLog of Object.values(log.sedDocuments)) {
+          level = StructuredLogLevel.SedDocument;
+
+          if (level < StructuredLogLevel.SedTaskOutput && docLog?.tasks) {
+            this.logHasTasks = true;
+            for (const taskLog of Object.values(docLog.tasks)) {
+              level = StructuredLogLevel.SedTaskOutput;
+              this.archiveHasTasks = true;
+              break;
+            }
+          }
+
+          if (level < StructuredLogLevel.SedTaskOutput && docLog?.outputs) {
+            this.logHasOutputs = true;
+
+            for (const outputLog of Object.values(docLog.outputs)) {
+              level = StructuredLogLevel.SedTaskOutput;
+              this.archiveHasOutputs = true;
+
+              if (level < StructuredLogLevel.SedDataSetCurveSurface
+                && outputLog
+                && 'dataSets' in outputLog
+                && (outputLog as SedReportLog).dataSets
+              ) {
+                const dataSetLogs = (outputLog as SedReportLog).dataSets as DataSetLogs;
+                for (const dataSetLog of Object.values(dataSetLogs)) {
+                  level = StructuredLogLevel.SedDataSetCurveSurface;                  
+                  break;
+                }
+              }
+
+              if (level < StructuredLogLevel.SedDataSetCurveSurface
+                && outputLog
+                && 'curves' in outputLog
+                && (outputLog as SedPlot2DLog).curves
+              ) {
+                const curveLogs = (outputLog as SedPlot2DLog).curves as CurveLogs;
+                for (const curveLog of Object.values(curveLogs)) {
+                  level = StructuredLogLevel.SedDataSetCurveSurface;
+                  break;
+                }
+              }
+
+              if (level < StructuredLogLevel.SedDataSetCurveSurface
+                && outputLog
+                && 'surfaces' in outputLog
+                && (outputLog as SedPlot3DLog).surfaces
+              ) {
+                const surfaceLogs = (outputLog as SedPlot3DLog).surfaces as SurfaceLogs;
+                for (const surfaceLog of Object.values(surfaceLogs)) {
+                  level = StructuredLogLevel.SedDataSetCurveSurface;
+                  break;
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    return level;
+  }
+
+  tocSections!: Observable<TocSection[]>;
+
+  @ViewChild(TocSectionsContainerDirective)
+  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+    if (container) {
+      setTimeout(() => {
+        this.tocSections = container.sections$;
+      });
+    }
+  }
+
+  downloadRawLog(): void {
+    this.downloadLog(this.rawLog, 'log.txt', 'text/plain');
+  }
+
+  downloadStructuredLog(): void {
+    this.downloadLog(JSON.stringify(this.structuredLog, null, 2), 'log.json', 'application/json');
+  }
+
+  private downloadLog(log: string, fileName: string, mimeType: string): void {
+    const blob = new Blob([log], { type: mimeType });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = fileName;
+    a.click();
+  }
+}

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -2,17 +2,28 @@ import { Component, Input, ViewChild } from '@angular/core';
 import {
   RawSimulationLog,
   CombineArchiveLog,
+  SedDocumentLog,
+  SedTaskLog,
   SedReportLog,
   SedPlot2DLog,
   SedPlot3DLog,
   DataSetLogs,
   CurveLogs,
   SurfaceLogs,
+  SimulationStatus,
   StructuredLogLevel,
 } from '../../../../simulation-logs-datamodel';
 import { SimulationRunStatus } from '@biosimulations/datamodel/common'
 import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
 import { Observable } from 'rxjs';
+
+interface StatusCount {
+  color: string;
+  label: string;
+  count: number;
+}
+
+type StatusCountsMap = Map<SimulationStatus | null, StatusCount>;
 
 @Component({
   selector: 'biosimulations-simulation-log',
@@ -29,9 +40,15 @@ export class SimulationLogComponent {
   StructuredLogLevel = StructuredLogLevel;
   private _structuredLog: CombineArchiveLog | undefined = undefined;
   structuredLogLevel: StructuredLogLevel | undefined = undefined;
-  archiveHasTasks = false;
-  archiveHasReports = false;
-  archiveHasPlots = false;
+  numSedDocuments = 0;
+  numTasks = 0;
+  numReports = 0;
+  numPlots = 0;
+  sedDocumentStatusCounts!: StatusCount[];
+  taskStatusCounts!: StatusCount[];
+  reportStatusCounts!: StatusCount[];
+  plotStatusCounts!: StatusCount[];
+  logHasSedDocuments = false;
   logHasTasks = false;
   logHasReports = false;
   logHasPlots = false;
@@ -39,78 +56,94 @@ export class SimulationLogComponent {
   @Input()
   set structuredLog(value: CombineArchiveLog | undefined) {
     this._structuredLog = value;
-    this.structuredLogLevel = this.getStructuredLogLevel(value);
+    this.getStructuredLogLevel(value);
   }
 
   get structuredLog(): CombineArchiveLog | undefined {
     return this._structuredLog;
   }
 
-  getStructuredLogLevel(log: CombineArchiveLog | undefined): StructuredLogLevel {
+  private getStructuredLogLevel(log: CombineArchiveLog | undefined) {
     let level: StructuredLogLevel = StructuredLogLevel.None;
-    this.archiveHasTasks = false;
-    this.archiveHasOutputs = false;
+    this.numSedDocuments = 0;
+    this.numTasks = 0;
+    this.numReports = 0;
+    this.numPlots = 0;
+
+    const sedDocumentStatusCountsMap = this.initStatusCountsMap();
+    const taskStatusCountsMap = this.initStatusCountsMap();
+    const reportStatusCountsMap = this.initStatusCountsMap();
+    const plotStatusCountsMap = this.initStatusCountsMap();
+
+    this.logHasSedDocuments = false;
     this.logHasTasks = false;
-    this.logHasOutputs = false;
+    this.logHasReports = false;
+    this.logHasPlots = false;
 
     if (log !== undefined) {
       level = Math.max(level, StructuredLogLevel.CombineArchive);
 
-      if (level < StructuredLogLevel.SedDocument && log?.sedDocuments) {
+      if (log?.sedDocuments) {
+        this.logHasSedDocuments = true;
+
         for (const docLog of Object.values(log.sedDocuments)) {
-          level = StructuredLogLevel.SedDocument;
+          level = Math.max(level, StructuredLogLevel.SedDocument);
+          this.numSedDocuments++;
+          (sedDocumentStatusCountsMap.get((docLog as SedDocumentLog).status) as StatusCount).count++;
 
-          if (level < StructuredLogLevel.SedTaskOutput) {
-            if (docLog?.tasks) {
-              this.logHasTasks = true;
-              for (const taskLog of Object.values(docLog.tasks)) {
-                level = StructuredLogLevel.SedTaskOutput;
-                this.archiveHasTasks = true;
-                break;
-              }
+          if (docLog?.tasks) {
+            this.logHasTasks = true;
+            for (const taskLog of Object.values(docLog.tasks)) {
+              level = Math.max(level, StructuredLogLevel.SedTaskOutput);
+              this.numTasks++;
+              (taskStatusCountsMap.get((taskLog as SedTaskLog).status) as StatusCount).count++;
+              break;
             }
+          }
 
-            if (docLog?.outputs) {
-              this.logHasReports = true;
-              this.logHasPlots = true;
+          if (docLog?.outputs) {
+            this.logHasReports = true;
+            this.logHasPlots = true;
 
-              for (const outputLog of Object.values(docLog.outputs)) {
-                level = StructuredLogLevel.SedTaskOutput;
+            for (const outputLog of Object.values(docLog.outputs)) {
+              level = Math.max(level, StructuredLogLevel.SedTaskOutput);
 
-                if (outputLog
-                  && 'dataSets' in outputLog
-                  && (outputLog as SedReportLog).dataSets
-                ) {
-                  this.archiveHasReports = true;
-                  const dataSetLogs = (outputLog as SedReportLog).dataSets as DataSetLogs;
-                  for (const dataSetLog of Object.values(dataSetLogs)) {
-                    level = StructuredLogLevel.SedDataSetCurveSurface;
-                    break;
-                  }
+              if (outputLog
+                && 'dataSets' in outputLog
+                && (outputLog as SedReportLog).dataSets
+              ) {
+                this.numReports++;
+                (reportStatusCountsMap.get((outputLog as SedReportLog).status) as StatusCount).count++;
+                const dataSetLogs = (outputLog as SedReportLog).dataSets as DataSetLogs;
+                for (const dataSetLog of Object.values(dataSetLogs)) {
+                  level = Math.max(level, StructuredLogLevel.SedDataSetCurveSurface);
+                  break;
                 }
+              }
 
-                if (outputLog
-                  && 'curves' in outputLog
-                  && (outputLog as SedPlot2DLog).curves
-                ) {
-                  this.archiveHasPlots = true;
-                  const curveLogs = (outputLog as SedPlot2DLog).curves as CurveLogs;
-                  for (const curveLog of Object.values(curveLogs)) {
-                    level = StructuredLogLevel.SedDataSetCurveSurface;
-                    break;
-                  }
+              if (outputLog
+                && 'curves' in outputLog
+                && (outputLog as SedPlot2DLog).curves
+              ) {
+                this.numPlots++;
+                (plotStatusCountsMap.get((outputLog as SedPlot2DLog).status) as StatusCount).count++;
+                const curveLogs = (outputLog as SedPlot2DLog).curves as CurveLogs;
+                for (const curveLog of Object.values(curveLogs)) {
+                  level = Math.max(level, StructuredLogLevel.SedDataSetCurveSurface);
+                  break;
                 }
+              }
 
-                if (outputLog
-                  && 'surfaces' in outputLog
-                  && (outputLog as SedPlot3DLog).surfaces
-                ) {
-                  this.archiveHasPlots = true;
-                  const surfaceLogs = (outputLog as SedPlot3DLog).surfaces as SurfaceLogs;
-                  for (const surfaceLog of Object.values(surfaceLogs)) {
-                    level = StructuredLogLevel.SedDataSetCurveSurface;
-                    break;
-                  }
+              if (outputLog
+                && 'surfaces' in outputLog
+                && (outputLog as SedPlot3DLog).surfaces
+              ) {
+                this.numPlots++;
+                (plotStatusCountsMap.get((outputLog as SedPlot3DLog).status) as StatusCount).count++;
+                const surfaceLogs = (outputLog as SedPlot3DLog).surfaces as SurfaceLogs;
+                for (const surfaceLog of Object.values(surfaceLogs)) {
+                  level = Math.max(level, StructuredLogLevel.SedDataSetCurveSurface);
+                  break;
                 }
               }
             }
@@ -119,10 +152,74 @@ export class SimulationLogComponent {
       }
     }
 
-    return level;
+    this.sedDocumentStatusCounts = this.convertStatusCountsMapToArray(sedDocumentStatusCountsMap);
+    this.taskStatusCounts = this.convertStatusCountsMapToArray(taskStatusCountsMap);
+    this.reportStatusCounts = this.convertStatusCountsMapToArray(reportStatusCountsMap);
+    this.plotStatusCounts = this.convertStatusCountsMapToArray(plotStatusCountsMap);
+
+    this.structuredLogLevel = level;
   }
 
-  naturalComparator(a: string, b: string): number {
+  private initStatusCountsMap(): StatusCountsMap {
+    const statusCounts: StatusCountsMap = new Map<SimulationStatus | null, StatusCount>();
+    statusCounts.set(SimulationStatus.QUEUED, {
+      color: SimulationStatus.QUEUED,
+      label: 'Queued',
+      count: 0,
+    });
+    statusCounts.set(SimulationStatus.RUNNING, {
+      color: SimulationStatus.RUNNING,
+      label: 'Running',
+      count: 0,
+    });
+    statusCounts.set(SimulationStatus.SUCCEEDED, {
+      color: SimulationStatus.SUCCEEDED,
+      label: 'Succeeded',
+      count: 0,
+    });
+    statusCounts.set(SimulationStatus.SKIPPED, {
+      color: SimulationStatus.SKIPPED,
+      label: 'Skipped',
+      count: 0,
+    });
+    statusCounts.set(SimulationStatus.FAILED, {
+      color: SimulationStatus.FAILED,
+      label: 'Failed',
+      count: 0,
+    });
+    statusCounts.set(null, {
+      color: SimulationStatus.SUCCEEDED,
+      label: 'Unknown',
+      count: 0,
+    });
+    return statusCounts;
+  }
+
+  private convertStatusCountsMapToArray(map: StatusCountsMap): StatusCount[] {
+    const order = [
+      SimulationStatus.QUEUED,
+      SimulationStatus.RUNNING,
+      SimulationStatus.SUCCEEDED,
+      SimulationStatus.SKIPPED,
+      SimulationStatus.FAILED,
+      null,
+    ];
+
+    const array: StatusCount[] = [];
+
+    order.forEach((key: SimulationStatus | null): void => {
+      const statusCount = map.get(key) as StatusCount;
+      if (statusCount.count === 0) {
+        statusCount.color = SimulationStatus.SUCCEEDED;
+      } else {
+        array.push(statusCount);
+      }
+    });
+
+    return array;
+  }
+
+  naturalComparator(a: {key: string, value: any}, b: {key: string, value: any}): number {
     return a.key.localeCompare(b.key, undefined, { numeric: true });
   }
 

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -90,7 +90,7 @@ export class SimulationLogComponent {
       if (log?.sedDocuments) {
         this.logHasSedDocuments = true;
         this.numSedDocuments = log.sedDocuments.length;
-        log.sedDocuments.sort(this.naturalComparator);
+        log.sedDocuments.sort(this.locationComparator);
 
         for (const docLog of log.sedDocuments) {
           level = Math.max(level, StructuredLogLevel.SedDocument);
@@ -99,7 +99,7 @@ export class SimulationLogComponent {
           if (docLog?.tasks) {
             this.logHasTasks = true;
             this.numTasks += docLog.tasks.length;
-            docLog.tasks.sort(this.naturalComparator);
+            docLog.tasks.sort(this.idComparator);
 
             for (const taskLog of docLog.tasks) {
               level = Math.max(level, StructuredLogLevel.SedTaskOutput);
@@ -111,7 +111,7 @@ export class SimulationLogComponent {
           if (docLog?.outputs) {
             this.logHasReports = true;
             this.logHasPlots = true;
-            docLog.outputs.sort(this.naturalComparator);
+            docLog.outputs.sort(this.idComparator);
 
             for (const outputLog of docLog.outputs) {
               level = Math.max(level, StructuredLogLevel.SedTaskOutput);
@@ -260,7 +260,11 @@ export class SimulationLogComponent {
     return array;
   }
 
-  naturalComparator(a: any, b: any): number {
+  locationComparator(a: any, b: any): number {
+    return a.location.localeCompare(b.location, undefined, { numeric: true });
+  }
+
+  idComparator(a: any, b: any): number {
     return a.id.localeCompare(b.id, undefined, { numeric: true });
   }
 

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -30,9 +30,11 @@ export class SimulationLogComponent {
   private _structuredLog: CombineArchiveLog | undefined = undefined;
   structuredLogLevel: StructuredLogLevel | undefined = undefined;
   archiveHasTasks = false;
-  archiveHasOutputs = false;
+  archiveHasReports = false;
+  archiveHasPlots = false;
   logHasTasks = false;
-  logHasOutputs = false;
+  logHasReports = false;
+  logHasPlots = false;
 
   @Input()
   set structuredLog(value: CombineArchiveLog | undefined) {
@@ -58,55 +60,57 @@ export class SimulationLogComponent {
         for (const docLog of Object.values(log.sedDocuments)) {
           level = StructuredLogLevel.SedDocument;
 
-          if (level < StructuredLogLevel.SedTaskOutput && docLog?.tasks) {
-            this.logHasTasks = true;
-            for (const taskLog of Object.values(docLog.tasks)) {
-              level = StructuredLogLevel.SedTaskOutput;
-              this.archiveHasTasks = true;
-              break;
+          if (level < StructuredLogLevel.SedTaskOutput) {
+            if (docLog?.tasks) {
+              this.logHasTasks = true;
+              for (const taskLog of Object.values(docLog.tasks)) {
+                level = StructuredLogLevel.SedTaskOutput;
+                this.archiveHasTasks = true;
+                break;
+              }
             }
-          }
 
-          if (level < StructuredLogLevel.SedTaskOutput && docLog?.outputs) {
-            this.logHasOutputs = true;
+            if (docLog?.outputs) {
+              this.logHasReports = true;
+              this.logHasPlots = true;
 
-            for (const outputLog of Object.values(docLog.outputs)) {
-              level = StructuredLogLevel.SedTaskOutput;
-              this.archiveHasOutputs = true;
+              for (const outputLog of Object.values(docLog.outputs)) {
+                level = StructuredLogLevel.SedTaskOutput;
 
-              if (level < StructuredLogLevel.SedDataSetCurveSurface
-                && outputLog
-                && 'dataSets' in outputLog
-                && (outputLog as SedReportLog).dataSets
-              ) {
-                const dataSetLogs = (outputLog as SedReportLog).dataSets as DataSetLogs;
-                for (const dataSetLog of Object.values(dataSetLogs)) {
-                  level = StructuredLogLevel.SedDataSetCurveSurface;                  
-                  break;
+                if (outputLog
+                  && 'dataSets' in outputLog
+                  && (outputLog as SedReportLog).dataSets
+                ) {
+                  this.archiveHasReports = true;
+                  const dataSetLogs = (outputLog as SedReportLog).dataSets as DataSetLogs;
+                  for (const dataSetLog of Object.values(dataSetLogs)) {
+                    level = StructuredLogLevel.SedDataSetCurveSurface;
+                    break;
+                  }
                 }
-              }
 
-              if (level < StructuredLogLevel.SedDataSetCurveSurface
-                && outputLog
-                && 'curves' in outputLog
-                && (outputLog as SedPlot2DLog).curves
-              ) {
-                const curveLogs = (outputLog as SedPlot2DLog).curves as CurveLogs;
-                for (const curveLog of Object.values(curveLogs)) {
-                  level = StructuredLogLevel.SedDataSetCurveSurface;
-                  break;
+                if (outputLog
+                  && 'curves' in outputLog
+                  && (outputLog as SedPlot2DLog).curves
+                ) {
+                  this.archiveHasPlots = true;
+                  const curveLogs = (outputLog as SedPlot2DLog).curves as CurveLogs;
+                  for (const curveLog of Object.values(curveLogs)) {
+                    level = StructuredLogLevel.SedDataSetCurveSurface;
+                    break;
+                  }
                 }
-              }
 
-              if (level < StructuredLogLevel.SedDataSetCurveSurface
-                && outputLog
-                && 'surfaces' in outputLog
-                && (outputLog as SedPlot3DLog).surfaces
-              ) {
-                const surfaceLogs = (outputLog as SedPlot3DLog).surfaces as SurfaceLogs;
-                for (const surfaceLog of Object.values(surfaceLogs)) {
-                  level = StructuredLogLevel.SedDataSetCurveSurface;
-                  break;
+                if (outputLog
+                  && 'surfaces' in outputLog
+                  && (outputLog as SedPlot3DLog).surfaces
+                ) {
+                  this.archiveHasPlots = true;
+                  const surfaceLogs = (outputLog as SedPlot3DLog).surfaces as SurfaceLogs;
+                  for (const surfaceLog of Object.values(surfaceLogs)) {
+                    level = StructuredLogLevel.SedDataSetCurveSurface;
+                    break;
+                  }
                 }
               }
             }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../simulation-logs-datamodel';
 import { SimulationRunStatus } from '@biosimulations/datamodel/common'
 import { TocSection, TocSectionsContainerDirective } from '@biosimulations/shared/ui';
+import { ScrollService } from '@biosimulations/shared/services';
 import { Observable } from 'rxjs';
 
 interface StatusCount {
@@ -31,6 +32,8 @@ type StatusCountsMap = Map<SimulationStatus | null, StatusCount>;
   styleUrls: ['./simulation-log.component.scss'],
 })
 export class SimulationLogComponent {
+  constructor(private scrollService: ScrollService) { }
+
   @Input()
   status!: SimulationRunStatus;
 
@@ -232,6 +235,13 @@ export class SimulationLogComponent {
         this.tocSections = container.sections$;
       });
     }
+  }
+
+  private scrollOffset = 64 + 32 + 32;
+
+  scrollToElement(id: string): void {
+    const scrollTarget = document.getElementById(id) as HTMLElement;
+    this.scrollService.scrollToElement(scrollTarget, this.scrollOffset);
   }
 
   downloadRawLog(): void {

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -118,6 +118,10 @@ export class SimulationLogComponent {
     return level;
   }
 
+  naturalComparator(a: string, b: string): number {
+    return a.key.localeCompare(b.key, undefined, { numeric: true });
+  }
+
   tocSections!: Observable<TocSection[]>;
 
   @ViewChild(TocSectionsContainerDirective)

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.module.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { SharedUiModule } from '@biosimulations/shared/ui';
+import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
+
+import { SimulationLogComponent } from './simulation-log.component';
+import { RawSimulationLogComponent } from './raw-simulation-log.component';
+import { StructuredSimulationLogElementComponent } from './structured-simulation-log-element.component';
+
+@NgModule({
+  declarations: [
+    SimulationLogComponent,
+    RawSimulationLogComponent,
+    StructuredSimulationLogElementComponent,
+  ],
+  exports: [
+    SimulationLogComponent,
+  ],
+  imports: [
+    CommonModule,
+    SharedUiModule,
+    BiosimulationsIconsModule,
+  ]
+})
+export class SimulationLogModule { }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -8,16 +8,31 @@
     'failed': log.status === SimulationStatus.FAILED
   }"
 >
-  <!--
-  <ng-container *ngIf="log?.simulatorDetails as simulatorDetails">
+  <ng-container *ngIf="algorithmKisaoTerm | async as algorithm">
+    <h3>Executed algorithm: {{ algorithm.name }} (<a [href]="algorithm.url" target="_blank">{{ algorithm.id }}</a>)</h3>
+    <p *ngIf="algorithmKisaoTermDescription && (algorithmKisaoTermDescription | async)">
+      <ng-template ngFor let-fragment [ngForOf]="algorithmKisaoTermDescription | async">
+        <span *ngIf="fragment.type == 'text'; else descriptionLink">
+          {{ fragment.value }}
+        </span>
+        <ng-template #descriptionLink>
+          <a [href]="fragment.value" target="_blank"
+            ><biosimulations-icon icon="link"></biosimulations-icon
+          ></a>
+        </ng-template>
+      </ng-template>
+    </p>
+  </ng-container>
+
+  <ng-container *ngIf="formattedSimulatorDetails">
     <h3>Simulator details</h3>
-    <ul class="vertically-spaced">
-      <li *ngFor="let keyValue of simulatorDetails | keyvalue">
-        <b>{{ keyValue.key }}:</b> {{ keyValue.value }}
+    <ul class="vertically-spaced key-value">
+      <li *ngFor="let detail of formattedSimulatorDetails">
+        <p class="key">{{ detail.key }}</p>
+        <pre><code>{{ detail.value }}</code></pre>
       </li>
     </ul>
   </ng-container>
--->
 
   <ng-container *ngIf="log?.skipReason as skipReason">
     <h3>Reason why it was skipped: {{ skipReason.category }}</h3>
@@ -36,7 +51,7 @@
   </ng-container>
 
   <h3>Standard output and standard error</h3>
-  <pre *ngIf="formattedOutput; else noOutput"><code [innerHTML]="formattedOutput"></code></pre>
+  <pre *ngIf="formattedOutput; else noOutput" class="stdout"><code [innerHTML]="formattedOutput"></code></pre>
   <ng-template #noOutput>
     <p class="info-message">No output was produced.</p>
   </ng-template>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -4,6 +4,8 @@
   [class]="['status-section', log.status]"
   [compact]="compact"
   [iconActionType]="iconActionType"
+  [first]="first"
+  [last]="last"
 >
   <ng-container *ngIf="algorithmKisaoTerm | async as algorithm">
     <h3>Executed algorithm: {{ algorithm.name }} (<a [href]="algorithm.url" target="_blank">{{ algorithm.id }}</a>)</h3>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -1,0 +1,43 @@
+<biosimulations-text-page-content-section
+  [heading]="heading"
+  [ngClass]="{
+    'queued': log.status === SimulationStatus.QUEUED,
+    'running': log.status === SimulationStatus.RUNNING,
+    'succeeded': log.status === SimulationStatus.SUCCEEDED,
+    'skipped': log.status === SimulationStatus.SKIPPED,
+    'failed': log.status === SimulationStatus.FAILED
+  }"
+>
+  <!--
+  <ng-container *ngIf="log?.simulatorDetails as simulatorDetails">
+    <h3>Simulator details</h3>
+    <ul class="vertically-spaced">
+      <li *ngFor="let keyValue of simulatorDetails | keyvalue">
+        <b>{{ keyValue.key }}:</b> {{ keyValue.value }}
+      </li>
+    </ul>
+  </ng-container>
+-->
+
+  <ng-container *ngIf="log?.skipReason as skipReason">
+    <h3>Reason why it was skipped: {{ skipReason.category }}</h3>
+    <pre *ngIf="skipReason.message; else noSkipMessage"><code>{{ skipReason.message }}</code></pre>
+    <ng-template #noSkipMessage>
+      <p class="info-message">No details were provided.</p>
+    </ng-template>
+  </ng-container>
+  
+  <ng-container *ngIf="log?.exception as exception">
+    <h3>Exception: {{ exception.category }}</h3>
+    <pre *ngIf="exception.message; else noExceptionMessage"><code>{{ exception.message }}</code></pre>
+    <ng-template #noExceptionMessage>
+      <p class="info-message">No details were provided.</p>
+    </ng-template>
+  </ng-container>
+
+  <h3>Standard output and standard error</h3>
+  <pre *ngIf="formattedOutput; else noOutput"><code [innerHTML]="formattedOutput"></code></pre>
+  <ng-template #noOutput>
+    <p class="info-message">No output was produced.</p>
+  </ng-template>
+</biosimulations-text-page-content-section>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -1,4 +1,5 @@
 <biosimulations-text-page-content-section
+  *ngIf="log"
   [heading]="heading"
   [class]="['status-section', log.status]"
 >

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -1,12 +1,6 @@
 <biosimulations-text-page-content-section
   [heading]="heading"
-  [ngClass]="{
-    'queued': log.status === SimulationStatus.QUEUED,
-    'running': log.status === SimulationStatus.RUNNING,
-    'succeeded': log.status === SimulationStatus.SUCCEEDED,
-    'skipped': log.status === SimulationStatus.SKIPPED,
-    'failed': log.status === SimulationStatus.FAILED
-  }"
+  [class]="['status-section', log.status]"
 >
   <ng-container *ngIf="algorithmKisaoTerm | async as algorithm">
     <h3>Executed algorithm: {{ algorithm.name }} (<a [href]="algorithm.url" target="_blank">{{ algorithm.id }}</a>)</h3>
@@ -50,9 +44,11 @@
     </ng-template>
   </ng-container>
 
-  <h3>Standard output and standard error</h3>
-  <pre *ngIf="formattedOutput; else noOutput" class="stdout"><code [innerHTML]="formattedOutput"></code></pre>
-  <ng-template #noOutput>
-    <p class="info-message">No output was produced.</p>
-  </ng-template>
+  <ng-container *ngIf="!queued">
+    <h3>Standard output and standard error</h3>
+    <pre *ngIf="formattedOutput; else noOutput" class="stdout dark"><code [innerHTML]="formattedOutput"></code></pre>
+    <ng-template #noOutput>
+      <p class="info-message">{{ noOutputMessage }}</p>
+    </ng-template>
+  </ng-container>
 </biosimulations-text-page-content-section>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -2,6 +2,8 @@
   *ngIf="log"
   [heading]="heading"
   [class]="['status-section', log.status]"
+  [compact]="compact"
+  [iconActionType]="iconActionType"
 >
   <ng-container *ngIf="algorithmKisaoTerm | async as algorithm">
     <h3>Executed algorithm: {{ algorithm.name }} (<a [href]="algorithm.url" target="_blank">{{ algorithm.id }}</a>)</h3>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.html
@@ -41,7 +41,7 @@
       <p class="info-message">No details were provided.</p>
     </ng-template>
   </ng-container>
-  
+
   <ng-container *ngIf="log?.exception as exception">
     <h3>Exception: {{ exception.category }}</h3>
     <pre *ngIf="exception.message; else noExceptionMessage"><code>{{ exception.message }}</code></pre>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.scss
@@ -1,0 +1,9 @@
+.key-value ::ng-deep {
+  list-style-type: none;
+  padding-inline-start: 0;
+
+  .key {
+    margin-bottom: 0.125rem;
+    font-weight: 500;
+  }
+}

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.spec.ts
@@ -1,0 +1,38 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { StructuredSimulationLogElementComponent } from './structured-simulation-log-element.component';
+import { SharedUiModule } from '@biosimulations/shared/ui';
+import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
+import { ScrollService } from '@biosimulations/shared/services';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+describe('StructuredSimulationLogElementComponent', () => {
+  let component: StructuredSimulationLogElementComponent;
+  let fixture: ComponentFixture<StructuredSimulationLogElementComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [
+        StructuredSimulationLogElementComponent,
+      ],
+      imports: [
+        HttpClientTestingModule,
+        SharedUiModule,
+        BiosimulationsIconsModule,
+        RouterTestingModule
+      ],
+      providers: [
+        ScrollService,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StructuredSimulationLogElementComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -6,6 +6,7 @@ import {
   SedPlot2DLog,
   SedPlot3DLog,
   SimulationStatus,
+  SimulatorDetail,
   AlgorithmKisaoDescriptionFragment,
 } from '../../../../simulation-logs-datamodel';
 import * as Convert from 'ansi-to-html';
@@ -17,7 +18,7 @@ import { KisaoTerm } from '@biosimulations/datamodel/common';
 
 type logTypes = SedDocumentLog | SedTaskLog | SedReportLog | SedPlot2DLog | SedPlot3DLog;
 
-interface SimulatorDetail {
+interface FormattedSimulatorDetail {
   key: string;
   value: string;
 }
@@ -46,7 +47,7 @@ export class StructuredSimulationLogElementComponent {
 
   algorithmKisaoTerm: Observable<KisaoTerm> | undefined;
   algorithmKisaoTermDescription: Observable<AlgorithmKisaoDescriptionFragment[] | undefined> | undefined;
-  formattedSimulatorDetails: SimulatorDetail[] | undefined;
+  formattedSimulatorDetails: FormattedSimulatorDetail[] | undefined;
 
   @Input()
   set log(value: logTypes) {
@@ -82,13 +83,13 @@ export class StructuredSimulationLogElementComponent {
       this.algorithmKisaoTermDescription = undefined;
     }
 
-    if ('simulatorDetails' in value && value.simulatorDetails && Object.keys(value.simulatorDetails).length) {
-      this.formattedSimulatorDetails = Object.entries(value.simulatorDetails).map(
-        (keyValue: [string, any]): SimulatorDetail => {
-          const key = keyValue[0];
-          const value = keyValue[1];
+    if ('simulatorDetails' in value && value?.simulatorDetails?.length) {
+      this.formattedSimulatorDetails = value.simulatorDetails.map(
+        (keyValue: SimulatorDetail): FormattedSimulatorDetail => {
+          const key = keyValue.key;
+          const value = keyValue.value;
           return {
-            key: keyValue[0],
+            key: key,
             value: typeof value === 'object' ? JSON.stringify(value, null, 2) : value.toString(),
           }
         }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -37,7 +37,7 @@ export class StructuredSimulationLogElementComponent {
 
   @Input()
   elementType!: string;
-  
+
   heading!: string;
 
   private _log!: logTypes;
@@ -89,11 +89,11 @@ export class StructuredSimulationLogElementComponent {
     const duration = this.log?.duration;
 
     return (
-      this.elementType 
+      this.elementType
       + ' '
       + this.elementId
       + ' '
-      + '(' 
+      + '('
       + this.log.status.toLowerCase()
       + (typeof duration === 'number' ? ', ' + duration.toFixed(1) + ' s' : '')
       + ')'

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -74,7 +74,7 @@ export class StructuredSimulationLogElementComponent {
           const value = keyValue[1];
           return {
             key: keyValue[0],
-            value: typeof value === "object" ? JSON.stringify(value, null, 2) : value.toString(),
+            value: typeof value === 'object' ? JSON.stringify(value, null, 2) : value.toString(),
           }
         }
       );

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -1,0 +1,55 @@
+import { Component, Input } from '@angular/core';
+import { StructuredSimulationLog, SimulationStatus } from '../../../../simulation-logs-datamodel';
+import * as Convert from 'ansi-to-html';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+
+@Component({
+  selector: 'biosimulations-structured-simulation-log-element',
+  templateUrl: './structured-simulation-log-element.component.html',
+  styleUrls: ['./structured-simulation-log-element.component.scss'],
+})
+export class StructuredSimulationLogElementComponent {
+  SimulationStatus = SimulationStatus;
+
+  constructor(private sanitizer: DomSanitizer){}
+
+  @Input()
+  elementId!: string;
+
+  @Input()
+  elementType!: string;
+  
+  heading!: string;
+
+  private _log!: StructuredSimulationLog;
+
+  formattedOutput!: SafeHtml | null;
+
+  @Input()
+  set log(value: StructuredSimulationLog) {
+    this._log = value;
+    this.heading = this.getHeading();
+
+    const convert = new Convert();
+    this.formattedOutput = value?.output ? this.sanitizer.bypassSecurityTrustHtml(convert.toHtml(value.output)) : null;
+  }
+
+  get log(): StructuredSimulationLog {
+    return this._log;
+  }
+
+  getHeading(): string {
+    const duration = this.log?.duration;
+
+    return (
+      this.elementType 
+      + ' '
+      + this.elementId
+      + ' '
+      + '(' 
+      + this.log.status.toLowerCase()
+      + (typeof duration === 'number' ? ', ' + duration.toFixed(1) + ' s' : '')
+      + ')'
+    );
+  }
+}

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -28,8 +28,6 @@ interface SimulatorDetail {
   styleUrls: ['./structured-simulation-log-element.component.scss'],
 })
 export class StructuredSimulationLogElementComponent {
-  SimulationStatus = SimulationStatus;
-
   constructor(private sanitizer: DomSanitizer, private ontologyService: OntologyService){}
 
   @Input()
@@ -42,6 +40,8 @@ export class StructuredSimulationLogElementComponent {
 
   private _log!: logTypes;
 
+  queued = true;
+  noOutputMessage = '';
   formattedOutput!: SafeHtml | undefined;
 
   algorithmKisaoTerm: Observable<KisaoTerm> | undefined;
@@ -52,6 +52,21 @@ export class StructuredSimulationLogElementComponent {
   set log(value: logTypes) {
     this._log = value;
     this.heading = this.getHeading();
+
+    switch (value.status) {
+      case SimulationStatus.QUEUED:
+        this.queued = true;
+        this.noOutputMessage = '';
+        break;
+      case SimulationStatus.RUNNING:
+        this.queued = false;
+        this.noOutputMessage = 'Output is not yet available.';
+        break;
+      default:
+        this.queued = false;
+        this.noOutputMessage = 'No output was produced.';
+        break;
+    }
 
     const convert = new Convert();
     this.formattedOutput = value?.output ? this.sanitizer.bypassSecurityTrustHtml(convert.toHtml(value.output)) : undefined;

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -121,4 +121,10 @@ export class StructuredSimulationLogElementComponent {
 
   @Input()
   iconActionType = 'scrollToTop';
+
+  @Input()
+  first = false;
+
+  @Input()
+  last = false;
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -114,4 +114,10 @@ export class StructuredSimulationLogElementComponent {
       + ')'
     );
   }
+
+  @Input()
+  compact = false;
+
+  @Input()
+  iconActionType = 'scrollToTop';
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -75,18 +75,6 @@
     </ng-container>
   </biosimulations-tab-page-tab>
 
-  <biosimulations-tab-page-tab heading="Log" icon="logs" urlHashFragment="log" [fullHeight]="true" [disabled]="statusRunning$ | async" *ngIf="(logs$ | async) as logs">
-    <div class="subsection stdout">
-      <b>Standard output</b>
-      <pre><code>{{ logs.out }}</code></pre>
-    </div>
-
-    <div class="subsection stderr">
-      <b>Standard error</b>
-      <pre><code>{{ logs.err }}</code></pre>
-    </div>
-  </biosimulations-tab-page-tab>
-
   <biosimulations-tab-page-tab heading="Design chart" icon="write" urlHashFragment="design-viz" [disabled]="!((sedmlLocations$ | async)?.length > 0)">
     <form [formGroup]="formGroup" class="design-visualization" *ngIf="(sedmlLocations$ | async) !== undefined">
       <mat-form-field appearance="fill">
@@ -216,5 +204,20 @@
   >
     <biosimulations-visualization #visualization [dataLayout]="vizDataLayout$ | async">
     </biosimulations-visualization >
+  </biosimulations-tab-page-tab>
+
+  <biosimulations-tab-page-tab
+    heading="Log"
+    icon="logs"
+    urlHashFragment="log"
+    [disabled]="(statusRunning$ | async) || ((logs$ | async) === null)"
+  >
+    <biosimulations-simulation-log
+      *ngIf="logs$ | async as logs"
+      [status]="(formattedSimulation$ | async)?.status"
+      [rawLog]="logs.raw"
+      [structuredLog]="logs.structured"
+    >
+    </biosimulations-simulation-log>
   </biosimulations-tab-page-tab>
 </biosimulations-tab-page>

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.scss
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.scss
@@ -11,26 +11,6 @@
   }
 }
 
-.stdout {
-  margin-bottom: 1rem;
-}
-.stderr {
-  margin-top: 1rem;
-}
-
-.stdout, .stderr {
-  height: calc((100% - 1.25rem) / 2);
-  pre {
-    height: calc(100% - 16px - 2 * 0.5rem);
-  }
-}
-
-/*
-.stderr code {
-  color: red;
-}
-*/
-
 .design-visualization {
   max-width: 600px;
 }

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
@@ -13,6 +13,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { IonicStorageModule } from '@ionic/storage';
+import { ConfigService, ScrollService } from '@biosimulations/shared/services';
 describe('ViewComponent', () => {
   let component: ViewComponent;
   let fixture: ComponentFixture<ViewComponent>;
@@ -35,17 +36,21 @@ describe('ViewComponent', () => {
         }),
         SimulationLogModule,
       ],
+      providers: [
+        ConfigService,
+        ScrollService,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
   }));
 
   beforeEach(() => {
-    //fixture = TestBed.createComponent(ViewComponent);
-    //component = fixture.componentInstance;
-    //fixture.detectChanges();
+    fixture = TestBed.createComponent(ViewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it('should create', () => {
-    // expect(component).toBeTruthy();
+    expect(component).toBeTruthy();
   });
 });

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
@@ -23,7 +23,7 @@ describe('ViewComponent', () => {
         ViewComponent,
         VisualizationComponent,
       ],
-      imports: [RouterTestingModule, HttpClientTestingModule, 
+      imports: [RouterTestingModule, HttpClientTestingModule,
         FormsModule,
         ReactiveFormsModule,
         MatFormFieldModule,

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ViewComponent } from './view.component';
 import { VisualizationComponent } from './visualization/visualization.component';
+import { SimulationLogModule } from './simulation-log/simulation-log.module';
 
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -32,6 +33,7 @@ describe('ViewComponent', () => {
         IonicStorageModule.forRoot({
           driverOrder: ['indexeddb', 'websql', 'localstorage']
         }),
+        SimulationLogModule,
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
@@ -225,7 +225,7 @@ export class ViewComponent implements OnInit {
         if (!statusRunning) {
           this.dispatchService
             .getSimulationLogs(this.uuid)
-            .subscribe((logs: SimulationLogs) => {              
+            .subscribe((logs: SimulationLogs) => {
               this.logs.next(logs);
               setTimeout(() => this.changeDetectorRef.detectChanges());
             });
@@ -236,7 +236,7 @@ export class ViewComponent implements OnInit {
             .getResultStructure(this.uuid)
 
             .subscribe((response: any): void => {
-              
+
 
               this.setProjectOutputs(response as CombineArchive);
             });

--- a/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
+++ b/biosimulations/apps/dispatch/src/app/components/simulations/view/view.component.ts
@@ -28,6 +28,8 @@ import {
 } from './visualization/visualization.component';
 import { DispatchService } from '../../../services/dispatch/dispatch.service';
 import { Simulation } from '../../../datamodel';
+import { SimulationLogs } from '../../../simulation-logs-datamodel';
+import { SimulationRunStatus } from '@biosimulations/datamodel/common'
 import { urls } from '@biosimulations/config/common';
 import { ConfigService } from '@biosimulations/shared/services';
 import { BehaviorSubject } from 'rxjs';
@@ -39,6 +41,7 @@ interface FormattedSimulation {
   simulator: string;
   simulatorVersion: string;
   simulatorUrl: string;
+  status: SimulationRunStatus;
   statusRunning: boolean;
   statusSucceeded: boolean;
   statusLabel: string;
@@ -58,11 +61,6 @@ interface VizApiResponse {
 
 interface CombineArchive {
   [id: string]: string[];
-}
-
-interface Logs {
-  out: string;
-  err: string;
 }
 
 interface AxisLabelType {
@@ -122,7 +120,7 @@ export class ViewComponent implements OnInit {
   private statusRunning = new BehaviorSubject<boolean>(true);
   statusRunning$ = this.statusRunning.asObservable();
 
-  private logs = new BehaviorSubject<Logs>({ out: '', err: '' });
+  private logs = new BehaviorSubject<SimulationLogs | null>(null);
   logs$ = this.logs.asObservable();
 
   formGroup: FormGroup;
@@ -197,6 +195,7 @@ export class ViewComponent implements OnInit {
           name: simulation.name,
           simulator: simulation.simulator,
           simulatorVersion: simulation.simulatorVersion,
+          status: simulation.status,
           statusRunning: statusRunning,
           statusSucceeded: statusSucceeded,
           statusLabel: SimulationStatusService.getSimulationStatusMessage(
@@ -226,19 +225,8 @@ export class ViewComponent implements OnInit {
         if (!statusRunning) {
           this.dispatchService
             .getSimulationLogs(this.uuid)
-            .subscribe((data: any) => {
-              if (data.data === undefined) {
-                // TODO: should this be interpreted as an error message?
-                this.logs.next({
-                  out: data.message,
-                  err: ''
-                });
-              } else {
-                this.logs.next({
-                  out: data.data.output,
-                  err: data.data.error
-                });
-              }
+            .subscribe((logs: SimulationLogs) => {              
+              this.logs.next(logs);
               setTimeout(() => this.changeDetectorRef.detectChanges());
             });
         }
@@ -409,7 +397,7 @@ export class ViewComponent implements OnInit {
   }
 
   selectedTabChange($event: MatTabChangeEvent): void {
-    if ($event.index == 3) {
+    if ($event.index == 2) {
       this.visualization.setLayout();
       this.changeDetectorRef.detectChanges();
     }

--- a/biosimulations/apps/dispatch/src/app/datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/datamodel.ts
@@ -1,6 +1,5 @@
 import { SimulationRunStatus } from '@biosimulations/datamodel/common';
 
-
 export interface Simulation {
   id: string;
   name: string;

--- a/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
+++ b/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
@@ -10,9 +10,7 @@ import {
 import {
   SimulationLogs,
   RawSimulationLog,
-  SedReportLog,
-  SedPlot2DLog,
-  SedPlot3DLog,
+  CombineArchiveLog,
   SimulationStatus,
 } from '../../simulation-logs-datamodel';
 
@@ -107,7 +105,7 @@ export class DispatchService {
         }
 
         // get structured log
-        const structuredLog = undefined;
+        const structuredLog: CombineArchiveLog | undefined = undefined;
 
         // return combineed log
         return {

--- a/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
+++ b/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
@@ -107,7 +107,7 @@ export class DispatchService {
         }
 
         // get structured log
-        const structuredLog = undefined;        
+        const structuredLog = undefined;
 
         // return combineed log
         return {

--- a/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
+++ b/biosimulations/apps/dispatch/src/app/services/dispatch/dispatch.service.ts
@@ -7,6 +7,14 @@ import {
   SimulationRun,
   UploadSimulationRun,
 } from '@biosimulations/dispatch/api-models';
+import {
+  SimulationLogs,
+  RawSimulationLog,
+  SedReportLog,
+  SedPlot2DLog,
+  SedPlot3DLog,
+  SimulationStatus,
+} from '../../simulation-logs-datamodel';
 
 export interface SimulatorVersionsMap {
   [id: string]: string[];
@@ -85,9 +93,30 @@ export class DispatchService {
     );
   }
 
-  getSimulationLogs(uuid: string) {
+  getSimulationLogs(uuid: string): Observable<SimulationLogs> {
     const endpoint = `${urls.dispatchApi}logs/${uuid}?download=false`;
-    return this.http.get(endpoint);
+    return this.http.get(endpoint).pipe(
+      map((response: any): SimulationLogs => {
+        // get raw log
+        let rawLog: RawSimulationLog = '';
+        if (response.data === undefined) {
+          // TODO: should this be interpreted as an error message?
+          rawLog = response.message;
+        } else {
+          rawLog = response.data.output + response.data.error;
+        }
+
+        // get structured log
+        const structuredLog = undefined;        
+
+        // return combineed log
+        return {
+          raw: rawLog,
+          structured: structuredLog,
+        };
+      })
+    );
+
   }
 
   constructor(private http: HttpClient) { }

--- a/biosimulations/apps/dispatch/src/app/services/ontology/ontology.service.ts
+++ b/biosimulations/apps/dispatch/src/app/services/ontology/ontology.service.ts
@@ -1,0 +1,111 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import {
+  AlgorithmKisaoDescriptionFragment,
+  AlgorithmKisaoDescriptionFragmentType,
+} from '../../simulation-logs-datamodel';
+
+import {
+  IOntologyTerm,
+  Ontologies,
+  KisaoTerm,
+} from '@biosimulations/datamodel/common';
+import { Observable, of } from 'rxjs';
+import { catchError, map, shareReplay } from 'rxjs/operators';
+import { urls } from '@biosimulations/config/common';
+@Injectable({ providedIn: 'root' })
+export class OntologyService {
+  kisaoTerms: Observable<{ [id: string]: KisaoTerm }>;
+
+  constructor(private http: HttpClient) {
+    this.kisaoTerms = this.fetchTerms<KisaoTerm>(Ontologies.KISAO) as Observable<{ [id: string]: KisaoTerm }>;
+    this.kisaoTerms.subscribe();
+  }
+
+  endpoint = urls.ontologyApi;
+
+  private fetchTerms<T extends IOntologyTerm>(ontologyId: Ontologies): Observable<{ [id: string]: T }> {
+    return this.http.get<T[]>(this.endpoint  + ontologyId + '/list').pipe(
+      shareReplay(1),
+      map((terms) => {
+        const termSet: { [id: string]: T } = {};
+        terms.forEach((term) => {
+          termSet[term.id] = term;
+        });
+        return termSet;
+      })
+    );
+  }
+
+  private getTerms<T extends IOntologyTerm>(ontologyId: Ontologies): Observable<{ [id: string]: T }> | null {
+    switch (ontologyId) {
+      case Ontologies.KISAO: return this.kisaoTerms as Observable<{ [id: string]: T }>;
+    }
+    return null;
+  }
+
+  private getTerm<T extends IOntologyTerm>(
+    ontologyId: Ontologies,
+    term: string
+  ): Observable<T> {
+    const termsObservable = this.getTerms<T>(ontologyId) as Observable<{ [id: string]: T }>;
+    return termsObservable.pipe(
+      map((terms: { [id: string]: T }): T => {
+        const setTerm = terms[term];
+
+        if (setTerm) {
+          return setTerm;
+        } else {
+          throw new Error(`Term with id ${term} not found in ontology ${ontologyId}`);
+        }
+      }),
+      catchError((terms: { [id: string]: T }): Observable<T> => {
+        return of(({
+          namespace: (terms[Object.keys(terms)[0]] as T).namespace,
+          id: term,
+          name: term,
+          description: 'Unknown term',
+          url: '',
+          iri: '',
+        } as unknown) as T);
+      })
+    );
+  }
+
+  getKisaoTerm(id: string): Observable<KisaoTerm> {
+    return this.getTerm<KisaoTerm>(Ontologies.KISAO, id);
+  }
+
+  formatKisaoDescription(value: string | null): AlgorithmKisaoDescriptionFragment[] | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const formattedValue: AlgorithmKisaoDescriptionFragment[] = [];
+    let prevEnd = 0;
+
+    const regExp = /\[(https?:\/\/.*?)\]/gi;
+    let match;
+    while ((match = regExp.exec(value)) !== null) {
+      if (match.index > 0) {
+        formattedValue.push({
+          type: AlgorithmKisaoDescriptionFragmentType.text,
+          value: value.substring(prevEnd, match.index),
+        });
+      }
+      prevEnd = match.index + match[0].length;
+      formattedValue.push({
+        type: AlgorithmKisaoDescriptionFragmentType.href,
+        value: match[1],
+      });
+    }
+    if (prevEnd < value?.length) {
+      formattedValue.push({
+        type: AlgorithmKisaoDescriptionFragmentType.text,
+        value: value.substring(prevEnd),
+      });
+    }
+    return formattedValue;
+  }
+}

--- a/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
@@ -32,6 +32,7 @@ export interface StructuredSimulationLog {
 }
 
 export interface SedOutputLog extends StructuredSimulationLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
@@ -39,63 +40,76 @@ export interface SedOutputLog extends StructuredSimulationLog {
   duration: number | null;
 }
 
-export type DataSetLogs = {
-  [dataSetId: string]: SimulationStatus;
+export interface DataSetLog {
+  id: string;
+  status: SimulationStatus;
 };
 
-export type CurveLogs = {
-  [curveId: string]: SimulationStatus;
-};
+export interface CurveLog {
+  id: string;
+  status: SimulationStatus;
+}
 
-export type SurfaceLogs = {
-  [surfaceId: string]: SimulationStatus;
-};
+export interface SurfaceLog {
+  id: string;
+  status: SimulationStatus;
+}
 
 export interface SedReportLog extends SedOutputLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  dataSets: DataSetLogs | null;
+  dataSets: DataSetLog[] | null;
 }
 
 export interface SedPlot2DLog extends SedOutputLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  curves: CurveLogs | null;
+  curves: CurveLog[] | null;
 }
 
 export interface SedPlot3DLog extends SedOutputLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  surfaces: SurfaceLogs | null;
+  surfaces: SurfaceLog[] | null;
+}
+
+export interface SimulatorDetail {
+  key: string;
+  value: any;
 }
 
 export interface SedTaskLog extends StructuredSimulationLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  algorithm: string;
-  simulatorDetails: {[key: string]: any}
+  algorithm: string | null;
+  simulatorDetails: SimulatorDetail[] | null;
 }
 
 export interface SedDocumentLog extends StructuredSimulationLog {
+  id: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  tasks: {[taskId: string]: SedTaskLog} | null;
-  outputs: {[outputId: string]: SedOutputLog | null} | null;
+  tasks: SedTaskLog[] | null;
+  outputs: (SedReportLog | SedPlot2DLog | SedPlot3DLog)[] | null;
 }
 
 export interface CombineArchiveLog extends StructuredSimulationLog {
@@ -104,7 +118,7 @@ export interface CombineArchiveLog extends StructuredSimulationLog {
   skipReason: Exception | null;
   output: string | null;
   duration: number | null;
-  sedDocuments: {[sedDocumentId: string]: SedDocumentLog} | null;
+  sedDocuments: SedDocumentLog[] | null;
 }
 
 /* Logs */

--- a/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
@@ -1,0 +1,114 @@
+/* Raw log */
+export type RawSimulationLog = string;
+
+/* Structured log */
+export enum StructuredLogLevel {
+  None = 0,
+  CombineArchive = 1,
+  SedDocument = 2,
+  SedTaskOutput = 3,
+  SedDataSetCurveSurface = 4,
+}
+
+export enum SimulationStatus {
+  QUEUED = 'QUEUED',
+  RUNNING = 'RUNNING',
+  SUCCEEDED = 'SUCCEEDED',
+  SKIPPED = 'SKIPPED',
+  FAILED = 'FAILED',
+}
+
+export interface Exception {
+  category: string;
+  message: string;
+}
+
+export interface StructuredSimulationLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+}
+
+export interface SedOutputLog extends StructuredSimulationLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+}
+
+export type DataSetLogs = {
+  [dataSetId: string]: SimulationStatus;
+};
+
+export type CurveLogs = {
+  [curveId: string]: SimulationStatus;
+};
+
+export type SurfaceLogs = {
+  [surfaceId: string]: SimulationStatus;
+};
+
+export interface SedReportLog extends SedOutputLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  dataSets: DataSetLogs | null;
+}
+
+export interface SedPlot2DLog extends SedOutputLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  curves: CurveLogs | null;
+}
+
+export interface SedPlot3DLog extends SedOutputLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  surfaces: SurfaceLogs | null;
+}
+
+export interface SedTaskLog extends StructuredSimulationLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  algorithm: string;
+  simulatorDetails: {[key: string]: any}
+}
+
+export interface SedDocumentLog extends StructuredSimulationLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  tasks: {[taskId: string]: SedTaskLog} | null;
+  outputs: {[outputId: string]: SedOutputLog | null} | null;
+}
+
+export interface CombineArchiveLog extends StructuredSimulationLog {
+  status: SimulationStatus;
+  exception: Exception;
+  skipReason: Exception;
+  output: string;
+  duration: number;
+  sedDocuments: {[sedDocumentId: string]: SedDocumentLog} | null;
+}
+
+/* Logs */
+export interface SimulationLogs {
+  raw: RawSimulationLog;
+  structured: CombineArchiveLog | undefined;
+}

--- a/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
@@ -102,7 +102,7 @@ export interface SedTaskLog extends StructuredSimulationLog {
 }
 
 export interface SedDocumentLog extends StructuredSimulationLog {
-  id: string;
+  location: string;
   status: SimulationStatus;
   exception: Exception | null;
   skipReason: Exception | null;

--- a/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
@@ -25,18 +25,18 @@ export interface Exception {
 
 export interface StructuredSimulationLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
 }
 
 export interface SedOutputLog extends StructuredSimulationLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
 }
 
 export type DataSetLogs = {
@@ -53,57 +53,57 @@ export type SurfaceLogs = {
 
 export interface SedReportLog extends SedOutputLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   dataSets: DataSetLogs | null;
 }
 
 export interface SedPlot2DLog extends SedOutputLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   curves: CurveLogs | null;
 }
 
 export interface SedPlot3DLog extends SedOutputLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   surfaces: SurfaceLogs | null;
 }
 
 export interface SedTaskLog extends StructuredSimulationLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   algorithm: string;
   simulatorDetails: {[key: string]: any}
 }
 
 export interface SedDocumentLog extends StructuredSimulationLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   tasks: {[taskId: string]: SedTaskLog} | null;
   outputs: {[outputId: string]: SedOutputLog | null} | null;
 }
 
 export interface CombineArchiveLog extends StructuredSimulationLog {
   status: SimulationStatus;
-  exception: Exception;
-  skipReason: Exception;
-  output: string;
-  duration: number;
+  exception: Exception | null;
+  skipReason: Exception | null;
+  output: string | null;
+  duration: number | null;
   sedDocuments: {[sedDocumentId: string]: SedDocumentLog} | null;
 }
 

--- a/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
+++ b/biosimulations/apps/dispatch/src/app/simulation-logs-datamodel.ts
@@ -112,3 +112,14 @@ export interface SimulationLogs {
   raw: RawSimulationLog;
   structured: CombineArchiveLog | undefined;
 }
+
+/* Descriptions of KiSAO terms */
+export enum AlgorithmKisaoDescriptionFragmentType {
+  text = 'text',
+  href = 'href',
+}
+
+export interface AlgorithmKisaoDescriptionFragment {
+  type: AlgorithmKisaoDescriptionFragmentType;
+  value: string;
+}

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -572,7 +572,11 @@
                 </li>
                 <li>Tests: {{ validationTests.numTests }}</li>
                 <ul>
-                  <li>Passed: {{ validationTests.numTestsPassed }}</li>
+                  <li>Passed: {{ validationTests.numTestsPassed }}
+                    <ul>
+                      <li>With warnings: {{ validationTests.numTestPassedWithWarnings }}</li>
+                    </ul>
+                  </li>
                   <li>Skipped: {{ validationTests.numTestsSkipped }}</li>
                   <li>Failed: {{ validationTests.numTestsFailed }}</li>
                 </ul>
@@ -618,6 +622,9 @@
             <biosimulations-text-page-content-section
               *ngFor="let result of validationTests.results"
               [heading]="result.case.id"
+              [class]="['status-section', result.resultType === 'Passed' && result.warnings?.length > 0 ? 'Warned' : result.resultType]"
+              [compact]="true"
+              iconActionType="toggle"
             >
               <p class="subsection-heading no-bottom-margin">Description</p>
               <p [innerHTML]="result.case.description"></p>

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.interface.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.interface.ts
@@ -154,6 +154,7 @@ export interface ViewValidationTests {
   testSuiteVersionUrl: string;
   numTests: number;
   numTestsPassed: number;
+  numTestPassedWithWarnings: number;
   numTestsSkipped: number;
   numTestsFailed: number;
   results: ViewTestCaseResult[];

--- a/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
+++ b/biosimulations/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
@@ -98,15 +98,19 @@ export class ViewSimulatorService {
       const validationTests: IValidationTests = sim.biosimulators.validationTests;
 
       let numTestsPassed = 0;
+      let numTestPassedWithWarnings = 0;
       let numTestsSkipped = 0;
       let numTestsFailed = 0;
       validationTests.results.forEach((result: ITestCaseResult): void => {
         if (result.resultType == TestCaseResultType.passed) {
-          numTestsPassed += 1;
+          numTestsPassed++;
+          if (result.warnings?.length > 0) {
+            numTestPassedWithWarnings++;
+          }
         } else if (result.resultType == TestCaseResultType.skipped) {
-          numTestsSkipped += 1;
+          numTestsSkipped++;
         } else{
-          numTestsFailed += 1;
+          numTestsFailed++;
         }
       });
 
@@ -151,6 +155,7 @@ export class ViewSimulatorService {
         testSuiteVersionUrl: 'https://github.com/biosimulators/Biosimulators_test_suite/releases/tag/' + validationTests.testSuiteVersion,
         numTests: validationTests.results.length,
         numTestsPassed: numTestsPassed,
+        numTestPassedWithWarnings: numTestPassedWithWarnings,
         numTestsSkipped: numTestsSkipped,
         numTestsFailed: numTestsFailed,
         results: viewResults,

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-doc-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-doc-level-log.json
@@ -6,7 +6,7 @@
    "duration": 6.0,
    "sedDocuments": [
       {
-         "id": "doc_1.sedml",
+         "location": "doc_1.sedml",
          "status": "FAILED",
          "exception": {
           "type": "FileNotFoundError",

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-doc-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-doc-level-log.json
@@ -4,8 +4,9 @@
    "skipReason": null,
    "output": null,
    "duration": 6.0,
-   "sedDocuments": {
-      "doc_1.sedml": {
+   "sedDocuments": [
+      {
+         "id": "doc_1.sedml",
          "status": "FAILED",
          "exception": {
           "type": "FileNotFoundError",
@@ -17,5 +18,5 @@
          "tasks": null,
          "outputs": null
       }
-   }
+   ]
 }

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-element-level-log.json
@@ -4,15 +4,17 @@
    "skipReason": null,
    "output": null,
    "duration": 6.0,
-   "sedDocuments": {
-      "doc_1.sedml": {
+   "sedDocuments": [
+      {
+         "id": "doc_1.sedml",
          "status": "FAILED",
          "exception": null,
          "skipReason": null,
          "output": null,
          "duration": 5.0,
-         "tasks": {
-            "task_1_ss": {
+         "tasks": [
+            {
+               "id": "task_1_ss",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
@@ -21,7 +23,8 @@
                "algorithm": null,
                "simulatorDetails": null
             },
-            "task_2_time_course": {
+            {
+               "id": "task_2_time_course",
                "status": "FAILED",
                "exception": {
                 "type": "FileNotFoundError",
@@ -33,20 +36,22 @@
                "algorithm": null,
                "simulatorDetails": null
             }
-         },
-         "outputs": {
-            "report_1": {
+         ],
+         "outputs": [
+            {
+               "id": "report_1",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
                "output": null,
                "duration": 0.1,
-               "dataSets": {
-                  "dataset_1": "SUCCEEDED",
-                  "dataset_2": "SUCCEEDED"
-               }
+               "dataSets": [
+                  {"id": "dataset_1", "status": "SUCCEEDED"},
+                  {"id": "dataset_2", "status": "SUCCEEDED"}
+               ]
             },
-            "plot_1": {
+            {
+               "id": "plot_1",
                "status": "SKIPPED",
                "exception": null,
                "skipReason": {
@@ -55,11 +60,11 @@
                },
                "output": null,
                "duration": 0.01,
-               "curves": {
-                  "curve_1": "SKIPPED"
-               }
+               "curves": [
+                  {"id": "curve_1", "status": "SKIPPED"}
+               ]
             }
-         }
+         ]
       }
-   }
+   ]
 }

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-failed-element-level-log.json
@@ -6,7 +6,7 @@
    "duration": 6.0,
    "sedDocuments": [
       {
-         "id": "doc_1.sedml",
+         "location": "doc_1.sedml",
          "status": "FAILED",
          "exception": null,
          "skipReason": null,

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-succeeded-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-succeeded-element-level-log.json
@@ -4,15 +4,17 @@
    "skipReason": null,
    "output": null,
    "duration": 6.0,
-   "sedDocuments": {
-      "doc_1.sedml": {
+   "sedDocuments": [
+      {
+         "id": "doc_1.sedml",
          "status": "SUCCEEDED",
          "exception": null,
          "skipReason": null,
          "output": null,
          "duration": 5.0,
-         "tasks": {
-            "task_1_ss": {
+         "tasks": [
+            {
+               "id": "task_1_ss",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
@@ -21,7 +23,8 @@
                "algorithm": null,
                "simulatorDetails": null
             },
-            "task_2_time_course": {
+            {
+               "id": "task_2_time_course",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
@@ -30,30 +33,32 @@
                "algorithm": null,
                "simulatorDetails": null
             }
-         },
-         "outputs": {
-            "report_1": {
+         ],
+         "outputs": [
+            {
+               "id": "report_1",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
                "output": null,
                "duration": 0.1,
-               "dataSets": {
-                  "dataset_1": "SUCCEEDED",
-                  "dataset_2": "SUCCEEDED"
-               }
+               "dataSets": [
+                  {"id": "dataset_1", "status": "SUCCEEDED"},
+                  {"id": "dataset_2", "status": "SUCCEEDED"}
+               ]
             },
-            "plot_1": {
+            {
+               "id": "plot_1",
                "status": "SUCCEEDED",
                "exception": null,
                "skipReason": null,
                "output": null,
                "duration": 0.01,
-               "curves": {
-                  "curve_1": "SUCCEEDED"
-               }
+               "curves": [
+                  {"id": "curve_1", "status": "SUCCEEDED"}
+               ]
             }
-         }
+         ]
       }
-   }
+   ]
 }

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-succeeded-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/final-succeeded-element-level-log.json
@@ -6,7 +6,7 @@
    "duration": 6.0,
    "sedDocuments": [
       {
-         "id": "doc_1.sedml",
+         "location": "doc_1.sedml",
          "status": "SUCCEEDED",
          "exception": null,
          "skipReason": null,

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/init-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/init-element-level-log.json
@@ -4,15 +4,17 @@
    "skipReason": null,
    "output": null,
    "duration": null,
-   "sedDocuments": {
-      "doc_1.sedml": {
+   "sedDocuments": [
+      {
+         "id": "doc_1.sedml",
          "status": "QUEUED",
          "exception": null,
          "skipReason": null,
          "output": null,
          "duration": null,
-         "tasks": {
-            "task_1_ss": {
+         "tasks": [
+            {
+               "id": "task_1_ss",
                "status": "QUEUED",
                "exception": null,
                "skipReason": null,
@@ -21,7 +23,8 @@
                "algorithm": null,
                "simulatorDetails": null
             },
-            "task_2_time_course": {
+            {
+               "id": "task_2_time_course",
                "status": "QUEUED",
                "exception": null,
                "skipReason": null,
@@ -30,30 +33,32 @@
                "algorithm": null,
                "simulatorDetails": null
             }
-         },
-         "outputs": {
-            "report_1": {
+         ],
+         "outputs": [
+            {
+               "id": "report_1",
                "status": "QUEUED",
                "exception": null,
                "skipReason": null,
                "output": null,
                "duration": null,
-               "dataSets": {
-                  "dataset_1": "QUEUED",
-                  "dataset_2": "QUEUED"
-               }
+               "dataSets": [
+                  {"id": "dataset_1", "status": "QUEUED"},
+                  {"id": "dataset_2", "status": "QUEUED"}
+               ]
             },
-            "plot_1": {
+            {
+               "id": "plot_1",
                "status": "QUEUED",
                "exception": null,
                "skipReason": null,
                "output": null,
                "duration": null,
-               "curves": {
-                  "curve_1": "QUEUED"
-               }
+               "curves": [
+                  {"id": "curve_1", "status": "QUEUED"}
+               ]
             }
-         }
+         ]
       }
-   }
+   ]
 }

--- a/biosimulations/apps/simulators/src/app/standards/simulation-logs/init-element-level-log.json
+++ b/biosimulations/apps/simulators/src/app/standards/simulation-logs/init-element-level-log.json
@@ -6,7 +6,7 @@
    "duration": null,
    "sedDocuments": [
       {
-         "id": "doc_1.sedml",
+         "location": "doc_1.sedml",
          "status": "QUEUED",
          "exception": null,
          "skipReason": null,

--- a/biosimulations/declarations.d.ts
+++ b/biosimulations/declarations.d.ts
@@ -5,3 +5,4 @@ declare module 'highlight.js/lib/languages/typescript';
 declare module 'highlight.js/lib/languages/yaml';
 declare module 'highlight.js/lib/core';
 declare module '@openapi-contrib/openapi-schema-to-json-schema';
+declare module 'ansi-to-html';

--- a/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
+++ b/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
@@ -11,7 +11,18 @@ export class Exception {
   message!: string;
 }
 
+export class SedOutputElementLog {
+  @ApiProperty({ type: String })
+  id!: string;
+
+  @ApiProperty({ type: String, enum: Status })
+  status!: Status;
+}
+
 export class SedReportLog {
+  @ApiProperty({ type: String })
+  id!: string;
+
   @ApiProperty({ type: String, enum: Status })
   status!: Status;
 
@@ -31,11 +42,14 @@ export class SedReportLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
-  dataSets!: SedOutputElementStatus[] | null;
+  @ApiProperty({ type: [SedOutputElementLog], nullable: true })
+  dataSets!: SedOutputElementLog[] | null;
 }
 
 export class SedPlot2DLog {
+  @ApiProperty({ type: String })
+  id!: string;
+
   @ApiProperty({ type: String, enum: Status })
   status!: Status;
 
@@ -55,11 +69,14 @@ export class SedPlot2DLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
-  curves!: SedOutputElementStatus[] | null;
+  @ApiProperty({ type: [SedOutputElementLog], nullable: true })
+  curves!: SedOutputElementLog[] | null;
 }
 
 export class SedPlot3DLog {
+  @ApiProperty({ type: String })
+  id!: string;
+
   @ApiProperty({ type: String, enum: Status })
   status!: Status;
 
@@ -79,8 +96,8 @@ export class SedPlot3DLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
-  surfaces!: SedOutputElementStatus[] | null;
+  @ApiProperty({ type: [SedOutputElementLog], nullable: true })
+  surfaces!: SedOutputElementLog[] | null;
 }
 
 export class SimulatorDetail {
@@ -92,6 +109,9 @@ export class SimulatorDetail {
 }
 
 export class SedTaskLog {
+  @ApiProperty({ type: String })
+  id!: string;
+
   @ApiProperty({ type: String, enum: Status })
   status!: Status;
 
@@ -113,12 +133,15 @@ export class SedTaskLog {
 
   @ApiProperty({ type: String, example: 'KISAO_0000019', nullable: true })
   algorithm: string | null;
-  
-  @ApiProperty({ type: [SimulatorDetail], nullable: true })  
+
+  @ApiProperty({ type: [SimulatorDetail], nullable: true })
   simulatorDetails: SimulatorDetail[] | null;
 }
 
 export class SedDocumentLog {
+  @ApiProperty({ type: String })
+  location!: string;
+
   @ApiProperty({ type: String, enum: Status })
   status!: Status;
 
@@ -141,8 +164,8 @@ export class SedDocumentLog {
   @ApiProperty({ type: [SedTaskLog], nullable: true })
   tasks!: SedTaskLog[] | null;
 
-  @ApiProperty({ 
-    type: 'array', 
+  @ApiProperty({
+    type: 'array',
     items: {
       oneOf: [
         { type: SedReportLog },

--- a/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
+++ b/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
@@ -116,7 +116,7 @@ export class SedTaskLog {
   algorithm: string | null;
   
   @ApiProperty({ type: Object, example: {method: 'simulator.cvode', arguments: {relTol: 1e-6, absTol: 1e-8}}, nullable: true })  
-  simulatorDetails: {[key: string]: any} | nullable;
+  simulatorDetails: {[key: string]: any} | null;
 }
 
 export type SedTaskLogMap = { [id: string]: SedTaskLog };

--- a/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
+++ b/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
@@ -1,16 +1,7 @@
 import {
   ApiProperty,
 } from '@nestjs/swagger';
-import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 import { SimulationRunLogStatus as Status } from '@biosimulations/datamodel/common';
-
-export type SedOutputElementStatusMap = { [id: string]: Status };
-export const SedOutputElementStatusMapArraySchema: SchemaObject = { type: 'array', items: { type: 'Status' } };
-export const SedOutputElementStatusMapSchema: Omit<SchemaObject, 'required'> = {
-  type: 'object',
-  additionalProperties: SedOutputElementStatusMapArraySchema,
-  nullable: true,
-};
 
 export class Exception {
   @ApiProperty({ type: String, example: 'FileNotFoundError' })
@@ -40,8 +31,8 @@ export class SedReportLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty(SedOutputElementStatusMapSchema)
-  dataSets!: SedOutputElementStatusMap | null;
+  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
+  dataSets!: SedOutputElementStatus[] | null;
 }
 
 export class SedPlot2DLog {
@@ -64,8 +55,8 @@ export class SedPlot2DLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty(SedOutputElementStatusMapSchema)
-  curves!: SedOutputElementStatusMap | null;
+  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
+  curves!: SedOutputElementStatus[] | null;
 }
 
 export class SedPlot3DLog {
@@ -88,8 +79,16 @@ export class SedPlot3DLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty(SedOutputElementStatusMapSchema)
-  surfaces!: SedOutputElementStatusMap | null;
+  @ApiProperty({ type: [SedOutputElementStatus], nullable: true })
+  surfaces!: SedOutputElementStatus[] | null;
+}
+
+export class SimulatorDetail {
+  @ApiProperty({ type: String, example: 'arguments' })
+  key!: string;
+
+  @ApiProperty({ type: Object, example: {relTol: 1e-6, absTol: 1e-8} })
+  value!: any;
 }
 
 export class SedTaskLog {
@@ -115,30 +114,9 @@ export class SedTaskLog {
   @ApiProperty({ type: String, example: 'KISAO_0000019', nullable: true })
   algorithm: string | null;
   
-  @ApiProperty({ type: Object, example: {method: 'simulator.cvode', arguments: {relTol: 1e-6, absTol: 1e-8}}, nullable: true })  
-  simulatorDetails: {[key: string]: any} | null;
+  @ApiProperty({ type: [SimulatorDetail], nullable: true })  
+  simulatorDetails: SimulatorDetail[] | null;
 }
-
-export type SedTaskLogMap = { [id: string]: SedTaskLog };
-export type SedOutputLogMap = { [id: string]: SedReportLog | SedPlot2DLog | SedPlot3DLog };
-export const SedTaskLogMapArraySchema: SchemaObject = { type: 'array', items: { type: 'SedTaskLog' } };
-export const SedOutputLogMapArraySchema: SchemaObject = { 
-    oneOf: [
-        {type: 'array', items: { type: 'SedReportLog' }},
-        {type: 'array', items: { type: 'SedPlot2DLog' }},
-        {type: 'array', items: { type: 'SedPlot3DLog' }},
-    ],
-};
-export const SedTaskLogMapSchema: Omit<SchemaObject, 'required'> = {
-  type: 'object',
-  additionalProperties: SedTaskLogMapArraySchema,
-  nullable: true,
-};
-export const SedOutputLogMapSchema: Omit<SchemaObject, 'required'> = {
-  type: 'object',
-  additionalProperties: SedOutputLogMapArraySchema,
-  nullable: true,
-};
 
 export class SedDocumentLog {
   @ApiProperty({ type: String, enum: Status })
@@ -160,20 +138,22 @@ export class SedDocumentLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty(SedTaskLogMapSchema)
-  tasks!: SedTaskLogMap | null;
+  @ApiProperty({ type: [SedTaskLog], nullable: true })
+  tasks!: SedTaskLog[] | null;
 
-  @ApiProperty(SedOutputLogMapSchema)
-  outputs!: SedOutputLogMap | null;
+  @ApiProperty({ 
+    type: 'array', 
+    items: {
+      oneOf: [
+        { type: SedReportLog },
+        { type: SedPlot2DLog },
+        { type: SedPlot3DLog },
+      ],
+    },
+    nullable: true
+  })
+  outputs!: (SedReportLog | SedPlot2DLog | SedPlot3DLog)[] | null;
 }
-
-export type SedDocumentLogMap = { [id: string]: SedDocumentLog };
-export const SedDocumentLogMapArraySchema: SchemaObject = { type: 'array', items: { type: 'SedDocumentLog' } };
-export const SedDocumentLogMapSchema: Omit<SchemaObject, 'required'> = {
-  type: 'object',
-  additionalProperties: SedDocumentLogMapArraySchema,
-  nullable: true,
-};
 
 export class CombineArchiveLog {
   @ApiProperty({ type: String, enum: Status })
@@ -195,6 +175,6 @@ export class CombineArchiveLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty(SedDocumentLogMapSchema)
-  sedDocuments!: SedDocumentLogMap | null;
+  @ApiProperty({ type: [SedDocumentLog], nullable: true })
+  sedDocuments!: SedDocumentLog[] | null;
 }

--- a/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
+++ b/biosimulations/libs/dispatch/api-models/src/lib/simulationRunLog.ts
@@ -111,6 +111,12 @@ export class SedTaskLog {
 
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
+
+  @ApiProperty({ type: String, example: 'KISAO_0000019', nullable: true })
+  algorithm: string | null;
+  
+  @ApiProperty({ type: Object, example: {method: 'simulator.cvode', arguments: {relTol: 1e-6, absTol: 1e-8}}, nullable: true })  
+  simulatorDetails: {[key: string]: any} | nullable;
 }
 
 export type SedTaskLogMap = { [id: string]: SedTaskLog };

--- a/biosimulations/libs/shared/icons/src/lib/icon/icon.component.ts
+++ b/biosimulations/libs/shared/icons/src/lib/icon/icon.component.ts
@@ -96,7 +96,9 @@ export type biosimulationsIcon =
   | 'funding'
   | 'spinner'
   | 'trash'
-  | 'progress';
+  | 'progress'
+  | 'open'
+  | 'close';
 @Component({
   selector: 'biosimulations-icon',
   templateUrl: './icon.component.html',
@@ -204,6 +206,8 @@ export class IconComponent implements OnInit {
     spinner: { type: 'fas', name: 'spinner', spin: true },
     trash: { type: 'fas', name: 'trash' },
     progress: { type: 'fas', name: 'tasks' },
+    open: { type: 'fas', name: 'chevron-down' },
+    close: { type: 'fas', name: 'chevron-up' },
   };
   constructor() {
     this.iconInfo = this.iconMap[this.icon];

--- a/biosimulations/libs/shared/icons/src/lib/shared-icons.module.ts
+++ b/biosimulations/libs/shared/icons/src/lib/shared-icons.module.ts
@@ -76,6 +76,8 @@ import {
   faSpinner,
   faFlask,
   faTrash,
+  faChevronUp,
+  faChevronDown,
 } from '@fortawesome/free-solid-svg-icons';
 import { fab, faGitAlt, faGithub, faDocker, faLinkedin, faOrcid, faCreativeCommons, faCreativeCommonsBy, faCreativeCommonsNc, faCreativeCommonsZero, faCreativeCommonsSa, faCreativeCommonsShare, faOsi } from '@fortawesome/free-brands-svg-icons';
 import { far, faFile, faFileAlt as farFileAlt, faStar as farStar } from '@fortawesome/free-regular-svg-icons';
@@ -139,6 +141,8 @@ export class BiosimulationsIconsModule {
       faSpinner,
       faFlask,
       faTrash,
+      faChevronUp,
+      faChevronDown,
       faTable,
       faDownload,
       faUpload,

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -349,6 +349,13 @@ code, code.hljs, pre {
   color: $dark-primary-text;
 }
 
+pre.dark {
+  &, code {
+    background: $dark-background;
+    color: $light-text;
+  }
+}
+
 .code {
   font-family: monospace;
 }
@@ -611,5 +618,57 @@ table {
 .ragged-columns {
   .column {
     height: max-content;
+  }
+}
+
+/* status colors */
+.status-label {
+  &.CREATED, &.QUEUED {
+    color: mat-color($theme-primary);
+  }
+
+  &.RUNNING, &.PROCESSING {
+    color: mat-color($theme-tertiary);
+  }
+
+  &.SUCCEEDED {
+    color: $dark-primary-text;
+  }
+
+  &.SKIPPED {
+    color: mat-color($theme-accent);
+  }
+
+  &.FAILED {
+    color: mat-color($theme-warn);
+  }
+}
+
+.status-section {
+  &.CREATED h2,
+  &.QUEUED h2 {
+    color: mat-color($theme-primary);
+    background: $theme-primary-lightest;
+  }
+
+  &.RUNNING h2,
+  &.PROCESSING h2 {
+    color: mat-color($theme-tertiary);
+    background: $theme-tertiary-lightest;
+  }
+
+  &.SUCCEEDED h2 {
+    color: $dark-primary-text;
+    background: $light-background;
+  }
+
+  &.SKIPPED h2 {
+    color: mat-color($theme-accent);
+    background: $theme-accent-lightest;
+  }
+
+  &.FAILED h2 {
+    color: mat-color($theme-warn);
+    background: $theme-warn-lightest;
   }
 }

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -625,53 +625,22 @@ table {
 .status-label {
   &.CREATED, &.QUEUED {
     color: mat-color($theme-primary);
-    &a:hover {
-      color: darken(mat-color($theme-primary), 10%);
-    }
-    &a:active {
-      color: darken(mat-color($theme-primary), 20%);
-    }
   }
 
   &.RUNNING, &.PROCESSING {
     color: mat-color($theme-tertiary);
-    &a:hover {
-      color: darken(mat-color($theme-tertiary), 8%);
-      text-decoration-line: underline;
-    }
-    &a:active {
-      color: darken(mat-color($theme-tertiary), 16%);
-    }
   }
 
   &.SUCCEEDED {
     color: $dark-primary-text;
-    &a:hover {
-      color: darken($dark-primary-text, 10%);
-    }
-    &a:active {
-      color: darken($dark-primary-text, 20%);
-    }
   }
 
   &.SKIPPED {
     color: mat-color($theme-accent);
-    &a:hover {
-      color: darken(mat-color($theme-accent), 10%);
-    }
-    &a:active {
-      color: darken(mat-color($theme-accent), 20%);
-    }
   }
 
   &.FAILED {
     color: mat-color($theme-warn);
-    &a:hover {
-      color: darken(mat-color($theme-warn), 10%);
-    }
-    &a:active {
-      color: darken(mat-color($theme-warn), 20%);
-    }
   }
 }
 
@@ -727,26 +696,71 @@ a.status-label {
   &.QUEUED h2 {
     color: mat-color($theme-primary);
     background: $theme-primary-lightest;
+
+    .mat-icon-button.biosimulations-icon-button {
+      &:hover {
+        color: darken(mat-color($theme-primary), 10%) !important;
+      }
+      &:active {
+        color: darken(mat-color($theme-primary), 20%) !important;
+      }
+    }
   }
 
   &.RUNNING h2,
   &.PROCESSING h2 {
     color: mat-color($theme-tertiary);
     background: $theme-tertiary-lightest;
+
+    .mat-icon-button.biosimulations-icon-button {
+      &:hover {
+        color: darken(mat-color($theme-tertiary), 8%) !important;
+      }
+      &:active {
+        color: darken(mat-color($theme-tertiary), 16%) !important;
+      }
+    }
   }
 
   &.SUCCEEDED h2 {
     color: $dark-primary-text;
     background: $light-background;
+
+    .mat-icon-button.biosimulations-icon-button {
+      &:hover {
+        color: darken(#333333, 15%) !important;
+      }
+      &:active {
+        color: darken(#333333, 30%) !important;
+      }
+    }
   }
 
   &.SKIPPED h2 {
     color: mat-color($theme-accent);
     background: $theme-accent-lightest;
+
+    .mat-icon-button.biosimulations-icon-button {
+      &:hover {
+        color: darken(mat-color($theme-accent), 7%) !important;
+      }
+      &:active {
+        color: darken(mat-color($theme-accent), 14%) !important;
+      }
+    }
   }
 
   &.FAILED h2 {
     color: mat-color($theme-warn);
     background: $theme-warn-lightest;
+
+    .mat-icon-button.biosimulations-icon-button {
+      &:hover {
+        color: darken(mat-color($theme-warn), 15%) !important;
+      }
+      &:active {
+        color: darken(mat-color($theme-warn), 30%) !important;
+      }
+    }
   }
 }

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -692,74 +692,82 @@ a.status-label {
 }
 
 .status-section {
-  &.CREATED h2,
-  &.QUEUED h2 {
-    color: mat-color($theme-primary);
-    background: $theme-primary-lightest;
+  &.CREATED, &.QUEUED, &.Warned {
+    h2 {
+      color: mat-color($theme-primary);
+      background: $theme-primary-lightest;
 
-    .mat-icon-button.biosimulations-icon-button {
-      &:hover {
-        color: darken(mat-color($theme-primary), 10%) !important;
-      }
-      &:active {
-        color: darken(mat-color($theme-primary), 20%) !important;
-      }
-    }
-  }
-
-  &.RUNNING h2,
-  &.PROCESSING h2 {
-    color: mat-color($theme-tertiary);
-    background: $theme-tertiary-lightest;
-
-    .mat-icon-button.biosimulations-icon-button {
-      &:hover {
-        color: darken(mat-color($theme-tertiary), 8%) !important;
-      }
-      &:active {
-        color: darken(mat-color($theme-tertiary), 16%) !important;
+      .mat-icon-button.biosimulations-icon-button {
+        &:hover {
+          color: darken(mat-color($theme-primary), 10%) !important;
+        }
+        &:active {
+          color: darken(mat-color($theme-primary), 20%) !important;
+        }
       }
     }
   }
 
-  &.SUCCEEDED h2 {
-    color: $dark-primary-text;
-    background: $light-background;
+  &.RUNNING, &.PROCESSING, &.Passed {
+    h2 {
+      color: mat-color($theme-tertiary);
+      background: $theme-tertiary-lightest;
 
-    .mat-icon-button.biosimulations-icon-button {
-      &:hover {
-        color: darken(#333333, 15%) !important;
-      }
-      &:active {
-        color: darken(#333333, 30%) !important;
-      }
-    }
-  }
-
-  &.SKIPPED h2 {
-    color: mat-color($theme-accent);
-    background: $theme-accent-lightest;
-
-    .mat-icon-button.biosimulations-icon-button {
-      &:hover {
-        color: darken(mat-color($theme-accent), 7%) !important;
-      }
-      &:active {
-        color: darken(mat-color($theme-accent), 14%) !important;
+      .mat-icon-button.biosimulations-icon-button {
+        &:hover {
+          color: darken(mat-color($theme-tertiary), 8%) !important;
+        }
+        &:active {
+          color: darken(mat-color($theme-tertiary), 16%) !important;
+        }
       }
     }
   }
 
-  &.FAILED h2 {
-    color: mat-color($theme-warn);
-    background: $theme-warn-lightest;
+  &.SUCCEEDED, &.Skipped {
+    h2 {
+      color: $dark-primary-text;
+      background: $light-background;
 
-    .mat-icon-button.biosimulations-icon-button {
-      &:hover {
-        color: darken(mat-color($theme-warn), 15%) !important;
+      .mat-icon-button.biosimulations-icon-button {
+        &:hover {
+          color: darken(#333333, 15%) !important;
+        }
+        &:active {
+          color: darken(#333333, 30%) !important;
+        }
       }
-      &:active {
-        color: darken(mat-color($theme-warn), 30%) !important;
+    }
+  }
+
+  &.SKIPPED {
+    h2 {
+      color: mat-color($theme-accent);
+      background: $theme-accent-lightest;
+
+      .mat-icon-button.biosimulations-icon-button {
+        &:hover {
+          color: darken(mat-color($theme-accent), 7%) !important;
+        }
+        &:active {
+          color: darken(mat-color($theme-accent), 14%) !important;
+        }
+      }
+    }
+  }
+
+  &.FAILED, &.Failed {
+    h2 {
+      color: mat-color($theme-warn);
+      background: $theme-warn-lightest;
+
+      .mat-icon-button.biosimulations-icon-button {
+        &:hover {
+          color: darken(mat-color($theme-warn), 15%) !important;
+        }
+        &:active {
+          color: darken(mat-color($theme-warn), 30%) !important;
+        }
       }
     }
   }

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -577,7 +577,7 @@ table {
 
 /* section */
 .section-content {
-  padding: 0.5rem;
+  padding: 0.5rem 0;
 }
 
 .border {

--- a/biosimulations/libs/shared/styles/src/lib/_global.scss
+++ b/biosimulations/libs/shared/styles/src/lib/_global.scss
@@ -625,22 +625,100 @@ table {
 .status-label {
   &.CREATED, &.QUEUED {
     color: mat-color($theme-primary);
+    &a:hover {
+      color: darken(mat-color($theme-primary), 10%);
+    }
+    &a:active {
+      color: darken(mat-color($theme-primary), 20%);
+    }
   }
 
   &.RUNNING, &.PROCESSING {
     color: mat-color($theme-tertiary);
+    &a:hover {
+      color: darken(mat-color($theme-tertiary), 8%);
+      text-decoration-line: underline;
+    }
+    &a:active {
+      color: darken(mat-color($theme-tertiary), 16%);
+    }
   }
 
   &.SUCCEEDED {
     color: $dark-primary-text;
+    &a:hover {
+      color: darken($dark-primary-text, 10%);
+    }
+    &a:active {
+      color: darken($dark-primary-text, 20%);
+    }
   }
 
   &.SKIPPED {
     color: mat-color($theme-accent);
+    &a:hover {
+      color: darken(mat-color($theme-accent), 10%);
+    }
+    &a:active {
+      color: darken(mat-color($theme-accent), 20%);
+    }
   }
 
   &.FAILED {
     color: mat-color($theme-warn);
+    &a:hover {
+      color: darken(mat-color($theme-warn), 10%);
+    }
+    &a:active {
+      color: darken(mat-color($theme-warn), 20%);
+    }
+  }
+}
+
+a.status-label {
+  &.CREATED, &.QUEUED {
+    &:hover {
+      color: darken(mat-color($theme-primary), 10%);
+    }
+    &:active {
+      color: darken(mat-color($theme-primary), 20%);
+    }
+  }
+
+  &.RUNNING, &.PROCESSING {
+    &:hover {
+      color: darken(mat-color($theme-tertiary), 8%);
+    }
+    &:active {
+      color: darken(mat-color($theme-tertiary), 16%);
+    }
+  }
+
+  &.SUCCEEDED {
+    &:hover {
+      color: darken(#333333, 15%);
+    }
+    &:active {
+      color: darken(#333333, 30%);
+    }
+  }
+
+  &.SKIPPED {
+    &:hover {
+      color: darken(mat-color($theme-accent), 7%);
+    }
+    &:active {
+      color: darken(mat-color($theme-accent), 14%);
+    }
+  }
+
+  &.FAILED {
+    &:hover {
+      color: darken(mat-color($theme-warn), 15%);
+    }
+    &:active {
+      color: darken(mat-color($theme-warn), 30%);
+    }
   }
 }
 

--- a/biosimulations/libs/shared/styles/src/lib/biosimulations/biosimulations-colors.scss
+++ b/biosimulations/libs/shared/styles/src/lib/biosimulations/biosimulations-colors.scss
@@ -147,6 +147,7 @@ $theme-primary: mat-palette($mat-primary, main, lighter, darker);
 
 $theme-accent-main: #ff9800;
 $theme-accent-lighter: #ffe0b2; // 70%
+$theme-accent-lightest: #fff4e5; // 90%
 $theme-accent-darker: #ff7b00;
 
 body {
@@ -173,8 +174,67 @@ $mat-accent: (
 );
 $theme-accent: mat-palette($mat-accent, main, lighter, darker);
 
+$theme-tertiary-main: #38cc00;
+$theme-tertiary-lighter: #9bff75; // 55%
+$theme-tertiary-lightest: #ddffd1; // 80%
+$theme-tertiary-darker: #35c100; // 5%
+
+body {
+  --tertiary-color: #{$theme-tertiary-main};
+  --tertiary-lighter-color: #{$theme-tertiary-lighter};
+  --tertiary-darker-color: #{$theme-tertiary-darker};
+  --text-tertiary-color: #{$dark-primary-text};
+  --text-tertiary-lighter-color: #{$dark-primary-text};
+  --text-tertiary-darker-color: #{$dark-primary-text};
+}
+
+$mat-tertiary: (
+  main: $theme-tertiary-main,
+  lighter: $theme-tertiary-lighter,
+  darker: $theme-tertiary-darker,
+  200: $theme-tertiary-main,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $dark-primary-text,
+    ),
+);
+$theme-tertiary: mat-palette($mat-tertiary, main, lighter, darker);
+
+$theme-quartenary-main: #951ed9;
+$theme-quartenary-lighter: #d097f0; // 55%
+$theme-quartenary-lightest: #efdcfa; // 85%
+$theme-quartenary-darker: #8d1cce; // 5%
+
+body {
+  --quartenary-color: #{$theme-quartenary-main};
+  --quartenary-lighter-color: #{$theme-quartenary-lighter};
+  --quartenary-darker-color: #{$theme-quartenary-darker};
+  --text-quartenary-color: #{$dark-primary-text};
+  --text-quartenary-lighter-color: #{$dark-primary-text};
+  --text-quartenary-darker-color: #{$dark-primary-text};
+}
+
+$mat-quartenary: (
+  main: $theme-quartenary-main,
+  lighter: $theme-quartenary-lighter,
+  darker: $theme-quartenary-darker,
+  200: $theme-quartenary-main,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $dark-primary-text,
+    ),
+);
+$theme-quartenary: mat-palette($mat-quartenary, main, lighter, darker);
+
 $theme-warn-main: #f44336;
-$theme-warn-lighter: #fcc7c3;
+$theme-warn-lighter: #fcc7c3; // 75%
+$theme-warn-lightest: #fde2e0; // 85%
 $theme-warn-darker: #ef2c22;
 
 body {

--- a/biosimulations/libs/shared/styles/src/lib/biosimulators/biosimulations-colors.scss
+++ b/biosimulations/libs/shared/styles/src/lib/biosimulators/biosimulations-colors.scss
@@ -147,6 +147,7 @@ $theme-primary: mat-palette($mat-primary, main, lighter, darker);
 
 $theme-accent-main: #2196f3;
 $theme-accent-lighter: #9bcff9; // 55%
+$theme-accent-lightest: #d2eafc; // 80%
 $theme-accent-darker: #1479ed; // 5%
 
 body {
@@ -173,8 +174,81 @@ $mat-accent: (
 );
 $theme-accent: mat-palette($mat-accent, main, lighter, darker);
 
+$theme-tertiary-main: #38cc00;
+$theme-tertiary-lighter: #9bff75; // 55%
+$theme-tertiary-lightest: #ddffd1; // 80%
+$theme-tertiary-darker: #35c100; // 5%
+
+body {
+  --tertiary-color: #{$theme-tertiary-main};
+  --tertiary-lighter-color: #{$theme-tertiary-lighter};
+  --tertiary-darker-color: #{$theme-tertiary-darker};
+  --text-tertiary-color: #{$dark-primary-text};
+  --text-tertiary-lighter-color: #{$dark-primary-text};
+  --text-tertiary-darker-color: #{$dark-primary-text};
+}
+
+$mat-tertiary: (
+  main: $theme-tertiary-main,
+  lighter: $theme-tertiary-lighter,
+  darker: $theme-tertiary-darker,
+  200: $theme-tertiary-main,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $dark-primary-text,
+    ),
+);
+$theme-tertiary: mat-palette($mat-tertiary, main, lighter, darker);
+
+$theme-quartenary-main: #951ed9;
+$theme-quartenary-lighter: #d097f0; // 55%
+$theme-quartenary-lightest: #efdcfa; // 85%
+$theme-quartenary-darker: #8d1cce; // 5%
+
+body {
+  --quartenary-color: #{$theme-quartenary-main};
+  --quartenary-lighter-color: #{$theme-quartenary-lighter};
+  --quartenary-darker-color: #{$theme-quartenary-darker};
+  --text-quartenary-color: #{$dark-primary-text};
+  --text-quartenary-lighter-color: #{$dark-primary-text};
+  --text-quartenary-darker-color: #{$dark-primary-text};
+}
+
+$mat-quartenary: (
+  main: $theme-quartenary-main,
+  lighter: $theme-quartenary-lighter,
+  darker: $theme-quartenary-darker,
+  200: $theme-quartenary-main,
+  // For slide toggle,
+    contrast:
+    (
+      main: $dark-primary-text,
+      lighter: $dark-primary-text,
+      darker: $dark-primary-text,
+    ),
+);
+$theme-quartenary: mat-palette($mat-quartenary, main, lighter, darker);
+
 $theme-warn-main: #f44336;
-$theme-warn-lighter: #fcc7c3;
+$theme-warn-lighter: #fcc7c3; // 75%
+$theme-warn-lightest: #fde2e0; // 85%
+$theme-warn-darker: #ef2c22;
+
+body {
+  --warn-color: #{$theme-warn-main};
+  --warn-lighter-color: #{$theme-warn-lighter};
+  --warn-darker-color: #{$theme-warn-darker};
+  --text-warn-color: #{$light-primary-text};
+  --text-warn-lighter-color: #{$dark-primary-text};
+  --text-warn-darker-color: #{$light-primary-text};
+}
+
+$theme-warn-main: #f44336;
+$theme-warn-lighter: #fcc7c3; // 75%
+$theme-warn-lightest: #fde2e0; // 85%
 $theme-warn-darker: #ef2c22;
 
 body {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.html
@@ -4,6 +4,8 @@
   [highlight]="highlight"
   [compact]="compact"
   [closed]="closed"
+  [first]="first"
+  [last]="last"
 >
   <ng-content id="content"></ng-content>
 </biosimulations-text-page-section>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.html
@@ -2,6 +2,8 @@
   [heading]="heading" 
   [icon]="icon" [iconRouterLink]="iconRouterLink" [iconHref]="iconHref" [iconClick]="iconClick"
   [highlight]="highlight"
+  [compact]="compact"
+  [closed]="closed"
 >
   <ng-content id="content"></ng-content>
 </biosimulations-text-page-section>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.scss
@@ -21,5 +21,9 @@ biosimulations-text-page-section ::ng-deep h3 {
   padding: 0 0.5rem;
   border-radius: 4px;
   background: $light-background;
-  margin-top: 1.5rem;
+  margin-block-start: 1rem;
+
+  &:not(:first-child) {
+    margin-block-start: 1.5rem;
+  }
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
@@ -9,6 +9,7 @@ export enum IconActionType {
   scrollToTop = 'scrollToTop',
   routerLink = 'routerLink',
   href = 'href',
+  toggle = 'toggle',
 }
 
 @Component({
@@ -21,17 +22,8 @@ export class TextPageContentSectionComponent {
   @Input()
   heading = '';
 
-  _icon = 'toTop';
-
   @Input()
-  set icon(icon: string) {
-    this._icon = icon;
-    this.setIconAction();
-  }
-
-  get icon(): string {
-    return this._icon;
-  }
+  icon = 'toTop';
 
   _iconAction!: any;
   _iconActionType = IconActionType.scrollToTop;
@@ -73,11 +65,26 @@ export class TextPageContentSectionComponent {
       this.iconRouterLink = null;
       this.iconHref = this._iconAction;
       this.iconClick = () => {};
+    } else if (this._iconActionType === IconActionType.toggle) {
+      this.icon = 'open';
+      this.closed = true;
+      this.iconRouterLink = null;
+      this.iconHref = null;
+      this.iconClick = () => {
+        this.closed = !this.closed;
+        this.icon = this.closed ? 'open' : 'close';
+      };
     }
   }
 
   @Input()
   highlight = false;
+
+  @Input()
+  compact = false;
+
+  @Input()
+  closed = false;
 
   constructor(private scrollService: ScrollService) {
   }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
@@ -72,6 +72,8 @@ export class TextPageContentSectionComponent {
       this.iconHref = null;
       this.iconClick = () => {
         this.closed = !this.closed;
+
+        // TODO: make the toggle icon change; this seems like a change detection issue
         this.icon = this.closed ? 'open' : 'close';
       };
     }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-content-section.component.ts
@@ -86,6 +86,12 @@ export class TextPageContentSectionComponent {
   compact = false;
 
   @Input()
+  first = false;
+
+  @Input()
+  last = false;
+
+  @Input()
   closed = false;
 
   constructor(private scrollService: ScrollService) {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.html
@@ -1,6 +1,12 @@
 <div
   class="container"
-  [ngClass]="{ 'highlight-container': highlight, 'compact': compact, 'closed': closed }"
+  [ngClass]="{
+    'highlight-container': highlight,
+    'compact': compact,
+    'first': first,
+    'last': last,
+    'closed': closed
+  }"
 >
   <h2>
     <div class="heading">{{ heading }}</div>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.html
@@ -1,15 +1,37 @@
-<div class="container" [ngClass]="{'highlight-container': highlight}">
+<div
+  class="container"
+  [ngClass]="{ 'highlight-container': highlight, 'compact': compact, 'closed': closed }"
+>
   <h2>
     <div class="heading">{{ heading }}</div>
-    <a *ngIf="icon"
-        mat-icon-button
-        class="icon-container biosimulations-icon-button"
-        [routerLink]="iconRouterLink"
-        [href]="iconHref" [target]="iconHref != null ? '_blank' : null"
-        (click)="iconClick()"
-    >
-      <biosimulations-icon [icon]="icon"></biosimulations-icon>
-    </a>
+    <ng-container *ngIf="icon">
+      <a *ngIf="iconRouterLink; else noRouterLink"
+          mat-icon-button
+          class="icon-container biosimulations-icon-button"
+          [routerLink]="iconRouterLink"
+      >
+        <biosimulations-icon [icon]="icon"></biosimulations-icon>
+      </a>
+
+      <ng-template #noRouterLink>
+        <a *ngIf="iconHref; else noRouterHref"
+            mat-icon-button
+            class="icon-container biosimulations-icon-button"
+            [href]="iconHref" target="_blank"
+        >
+          <biosimulations-icon [icon]="icon"></biosimulations-icon>
+        </a>
+
+        <ng-template #noRouterHref>
+          <a mat-icon-button
+            class="icon-container biosimulations-icon-button"
+            (click)="iconClick()"
+          >
+            <biosimulations-icon [icon]="icon"></biosimulations-icon>
+          </a>
+        </ng-template>
+      </ng-template>
+    </ng-container>
     <div class="clear-float"></div>
   </h2>
   <div class="content">

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
@@ -88,7 +88,7 @@ h2 {
 .highlight-container {
   border: 1px solid mat-color($theme-primary);
   border-radius: 4px;
-  
+
   h2 {
     background: mat-color($theme-primary);
     color: $light-text;
@@ -112,6 +112,10 @@ h2 {
   border-left: 1px solid #eee;
   border-right: 1px solid #eee;
 
+  &:not(.last) {
+    border-bottom: 1px solid $dark-disabled-text;
+  }
+
   h2 {
     border-radius: 0;
     @include mat-typography-level-to-styles($fontConfig, body-2);
@@ -119,7 +123,7 @@ h2 {
   }
 
   .content {
-    padding: 0.5rem;    
+    padding: 0.5rem;
 
     ::ng-deep {
       h3 {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
@@ -102,3 +102,40 @@ h2 {
     }
   }
 }
+
+/* compact */
+.compact {
+  margin-top: 0;
+  border-radius: 0;
+  border-top: 1px solid #eee;
+  border-left: 1px solid #eee;
+  border-right: 1px solid #eee;
+
+  h2 {
+    border-radius: 0;
+  }
+
+  .content {
+    padding: 0.5rem;    
+
+    ::ng-deep {
+      h3 {
+        margin-block-start: 0;
+        margin-bottom: 0.25rem;
+        padding: 0 0.25rem;
+      }
+
+      pre {
+        padding: 0 0.25rem;
+      }
+    }
+  }
+}
+
+
+/* closed */
+.closed {
+  .content {
+    display: none;
+  }
+}

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
@@ -35,7 +35,7 @@ h2 {
 }
 
 .content {
-  padding: 0.5rem;
+  padding: 0.5rem 0;
 }
 
 ::ng-deep ol {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.scss
@@ -1,4 +1,5 @@
 @import 'biosimulations-colors';
+@import 'biosimulations-typography';
 
 .container {
   margin-top: 2rem;
@@ -113,6 +114,8 @@ h2 {
 
   h2 {
     border-radius: 0;
+    @include mat-typography-level-to-styles($fontConfig, body-2);
+    font-weight: 500;
   }
 
   .content {
@@ -122,7 +125,12 @@ h2 {
       h3 {
         margin-block-start: 0;
         margin-bottom: 0.25rem;
-        padding: 0 0.25rem;
+        padding: 0;
+        border-radius: 0;
+        @include mat-typography-level-to-styles($fontConfig, body-1);
+        font-weight: 500;
+        background: none;
+        border-bottom: 1px dotted $dark-primary-text;
       }
 
       pre {
@@ -131,7 +139,6 @@ h2 {
     }
   }
 }
-
 
 /* closed */
 .closed {

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.ts
@@ -33,5 +33,11 @@ export class TextPageSectionComponent {
   compact = false;
 
   @Input()
+  first = false;
+
+  @Input()
+  last = false;
+
+  @Input()
   closed = false;
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page-section.component.ts
@@ -28,4 +28,10 @@ export class TextPageSectionComponent {
 
   @Input()
   highlight = false;
+
+  @Input()
+  compact = false;
+
+  @Input()
+  closed = false;
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.html
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <div #sectionsContainer class="sections-container content-container">
+    <div #sectionsContainer class="sections-container content-container" [ngClass]="{'compact': compact}">
       <ng-content select="#content"></ng-content>
     </div>
   </div>

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -12,3 +12,9 @@
    margin-top: 0;
   }
 }
+
+.sections-container.compact {
+  margin-top: 0;
+  border-radius: 4px;
+  border-bottom: 1px solid #eee;
+}

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.scss
@@ -16,5 +16,4 @@
 .sections-container.compact {
   margin-top: 0;
   border-radius: 4px;
-  border-bottom: 1px solid #eee;
 }

--- a/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
+++ b/biosimulations/libs/shared/ui/src/lib/text-page/text-page.component.ts
@@ -60,6 +60,9 @@ export class TextPageComponent {
   });
   sideBarStyle$: Observable<SideBarStyle> = this.sideBarStyle.asObservable();
 
+  @Input()
+  compact = false;
+
   constructor(
     breakpointObserver: BreakpointObserver,
     private changeRef: ChangeDetectorRef,

--- a/biosimulations/package-lock.json
+++ b/biosimulations/package-lock.json
@@ -6326,6 +6326,21 @@
         "color-convert": "^2.0.1"
       }
     },
+    "ansi-to-html": {
+      "version": "0.6.14",
+      "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.14.tgz",
+      "integrity": "sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==",
+      "requires": {
+        "entities": "^1.1.2"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+        }
+      }
+    },
     "any-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",

--- a/biosimulations/package.json
+++ b/biosimulations/package.json
@@ -46,6 +46,7 @@
     "@sendgrid/mail": "^7.4.1",
     "@stoplight/json-ref-resolver": "^3.1.0",
     "@typegoose/typegoose": "^7.4.7",
+    "ansi-to-html": "^0.6.14",
     "archiver": "^5.2.0",
     "auth0": "^2.31.1",
     "cache-manager": "^3.4.0",


### PR DESCRIPTION
Started UI components for simulation logs

Still todo
- [x] Sort SED documents/tasks/outputs by their ids
- [x] Add internal links to table of contents
- [x] Display executed algorithm for each task
- [x] Display simulator details for each task
- [x] Black background, white text for stdout/err logs
- [x] Add summary to left column
- [x] Use accordion folding to better organize content
- [x] Add `.spec` files for new components
- [x] Copy similar styling to simulators test suite cases
    - [x] Heading colors for skipped, failed
    - [x] Accordion folding