### PR TITLE
fix(dispatch): Simulation results not saved for some simulations and overall status doesn't reflect such errors

### DIFF
--- a/biosimulations/apps/dispatch-service/src/app/results/log.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/results/log.service.ts
@@ -70,6 +70,9 @@ export class LogService {
       .then((_) => {
         this.logger.debug('Sent Log to API');
       })
-      .catch((reason) => this.logger.error(reason));
+      .catch((reason) => {
+        this.logger.error(reason);
+        throw reason;
+      });
   }
 }

--- a/biosimulations/apps/dispatch-service/src/app/results/results.service.ts
+++ b/biosimulations/apps/dispatch-service/src/app/results/results.service.ts
@@ -135,7 +135,10 @@ export class ResultsService {
           `Successfully uploaded report ${resultId} for simulation ${simId}`,
         ),
       )
-      .catch((err) => this.logger.error(err));
+      .catch((err) => {
+        this.logger.error(err);
+        throw err;
+      });
   }
   private async parseToJson(
     file: resultFile,

--- a/biosimulations/tsconfig.base.json
+++ b/biosimulations/tsconfig.base.json
@@ -12,7 +12,7 @@
     "target": "es2015",
     "module": "esnext",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2017", "dom"],
+    "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",


### PR DESCRIPTION
The  simulation is now marked as failed if processing/uploading the results fails.
All results and logs are now updated independently. The issue with  results not being uploaded if logs failed was caused by the fail fast behavior of promise.All(). Using the new es2020 promise.allSetteled() fixes this problem, but requires updating the base tsconfig.

Fixes #2416