### PR TITLE
validationErrorHandling

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -29,6 +29,7 @@ module.exports = {
         'storage',
         'release',
         'combine-service',
+        'shared-exceptions',
       ],
     ],
   },

--- a/libs/shared/exceptions/exceptions/src/index.ts
+++ b/libs/shared/exceptions/exceptions/src/index.ts
@@ -1,2 +1,2 @@
-export * from './lib/shared-exceptions.module';
 export { BiosimulationsException } from './lib/exception';
+export { BiosimulationsValidationExceptionFactory } from './lib/validationExceptionFactory';

--- a/libs/shared/exceptions/exceptions/src/lib/exception.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/exception.ts
@@ -51,7 +51,7 @@ export class BiosimulationsException extends Error {
       error.source = source;
     }
     if (this.meta) {
-      error.meta = { meta: this.meta };
+      error.meta = this.meta;
     }
     return error;
   }

--- a/libs/shared/exceptions/exceptions/src/lib/shared-exceptions.module.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/shared-exceptions.module.ts
@@ -1,8 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({
-  controllers: [],
-  providers: [],
-  exports: [],
-})
-export class SharedExceptionsModule {}

--- a/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
@@ -1,0 +1,22 @@
+import { HttpStatus, ValidationError } from '@nestjs/common';
+import { BiosimulationsException } from './exception';
+
+export const BiosimulationsValidationExceptionFactory = (
+  errors: ValidationError[],
+): BiosimulationsException => {
+  const err = errors[0];
+  const message = err.property + 'failed validation';
+
+  const bioSimErr = new BiosimulationsException(
+    HttpStatus.BAD_REQUEST,
+    'Validation Error',
+    message,
+    undefined,
+    undefined,
+    err.property,
+    undefined,
+    { errors: errors },
+  );
+
+  return bioSimErr;
+};

--- a/libs/shared/exceptions/filters/src/lib/biosimulations-exception.filter.ts
+++ b/libs/shared/exceptions/filters/src/lib/biosimulations-exception.filter.ts
@@ -20,11 +20,9 @@ export class BiosimulationsExceptionFilter implements ExceptionFilter {
 
     status = exception.getStatus();
     resbody = exception.getError();
+    resbody.meta = resbody.meta || {};
+    (resbody.meta['time'] = Date.now()), (resbody.meta['url'] = request.url);
 
-    resbody.meta = {
-      time: Date.now(),
-      url: request.url,
-    };
     const responseError: ErrorResponseDocument = { error: [resbody] };
     this.logger.log(responseError);
     response.status(status).json(responseError);


### PR DESCRIPTION
Errors can provide their own metadata. The error reposnse was overiding this rather than appending
it.