### PR TITLE
fix(simulators-api0: Account for '-' being used instead of '.'

### DIFF
--- a/apps/simulators-api/src/simulators/simulators.controller.spec.ts
+++ b/apps/simulators-api/src/simulators/simulators.controller.spec.ts
@@ -28,6 +28,13 @@ class MockSimulatorService {
         id: 'sim3',
         version: '1.7',
       },
+      {
+        id: 'sim4',
+        version: '2020-01-05'
+      },
+      {
+        id: 'sim4',
+      version: '2020-02-01'}
     ];
   }
 }
@@ -61,5 +68,6 @@ describe('SimulatorsController', () => {
     expect(latest[0].version).toBe('1.11');
     expect(latest[1].version).toBe('1.2');
     expect(latest[2].version).toBe('1.7');
+    expect(latest[3].version).toBe('2020-02-01');
   });
 });

--- a/apps/simulators-api/src/simulators/simulators.controller.ts
+++ b/apps/simulators-api/src/simulators/simulators.controller.ts
@@ -81,8 +81,8 @@ export class SimulatorsController {
     allSims.forEach((element) => {
       const latestSim = latest.get(element.id);
       if (latestSim) {
-        const latestVersion = latestSim.version;
-        const currentVersion = element.version;
+        const latestVersion = latestSim.version.replace(/-/g,".");
+        const currentVersion = element.version.replace(/-/g,".");
         if (compareVersions(latestVersion, currentVersion) == -1) {
           latest.set(element.id, element);
         }


### PR DESCRIPTION
The api using a version-comparision library to determine what the latest version of each tool is.
The library depends on versions being in semantic format. However, there are some tools that have date based versions such as "2020-02-15". This change replaces the "-" charecters with "." during the comparision to enable correct sorting.

fix #2681