### PR TITLE
fix(simulators): reenabling display of simulator validation test results

### DIFF
--- a/apps/simulators/src/app/simulators/simulator.service.ts
+++ b/apps/simulators/src/app/simulators/simulator.service.ts
@@ -27,6 +27,7 @@ export class SimulatorService {
   getAll(): Observable<Simulator[]> {
     return this.allSims;
   }
+
   getLatest(): Observable<Simulator[]> {
     return this.latestSims;
   }
@@ -38,6 +39,7 @@ export class SimulatorService {
       }),
     );
   }
+
   getOneByVersion(id: string, version: string): Observable<Simulator> {
     return this.getAll().pipe(
       map((value: Simulator[]) => {
@@ -48,6 +50,7 @@ export class SimulatorService {
       }),
     );
   }
+
   getAllById(id: string): Observable<Simulator[]> {
     return this.getAll().pipe(
       map((sims: Simulator[]) => {
@@ -78,5 +81,11 @@ export class SimulatorService {
       }),
     );
   }
+
+  getValidationTestResultsForOneByVersion(id: string, version: string): Observable<Simulator> {
+    return this.http.get<Simulator>(this.endpoint + id + '/' + version,
+      {params: {includeTests: true}});
+  }
+
   constructor(private http: HttpClient) {}
 }

--- a/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
+++ b/apps/simulators/src/app/simulators/view-simulator/view-simulator.component.html
@@ -812,7 +812,7 @@
     <ng-container *ngIf="simulator | async as simulator">
       <ng-container
         *ngIf="
-          simulator?.validationTests as validationTests;
+          (simulator?.validationTests | async) as validationTests;
           else noValidationTestResults
         "
       >
@@ -979,16 +979,14 @@
       <ng-template #noValidationTestResults>
         <p
           class="info-message"
-          *ngIf="!simulator.validated; else testResultsNotRecorded"
+          *ngIf="!simulator.validated; else testResultsNotAvailable"
         >
           No test results are available because {{ simulator.name }} has not
           been validated.
         </p>
-        <ng-template #testResultsNotRecorded>
+        <ng-template #testResultsNotAvailable>
           <p class="info-message">
-            Test results are not available because {{ simulator.name }} was
-            validated before we began logging the results of the validation
-            tests.
+            Sorry!. Test results could not be retreived.
           </p>
         </ng-template>
       </ng-template>

--- a/apps/simulators/src/app/simulators/view-simulator/view-simulator.interface.ts
+++ b/apps/simulators/src/app/simulators/view-simulator/view-simulator.interface.ts
@@ -205,5 +205,5 @@ export interface ViewSimulator {
   created: string;
   updated: string;
   validated: boolean;
-  validationTests: ViewValidationTests | null;
+  validationTests: Observable<ViewValidationTests | null>;
 }

--- a/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
+++ b/apps/simulators/src/app/simulators/view-simulator/view-simulator.service.ts
@@ -94,85 +94,90 @@ export class ViewSimulatorService {
 
     const viewSimAlgorithms = new BehaviorSubject<ViewAlgorithm[]>([]);
 
-    let viewValidationTests: ViewValidationTests | null = null;
-    if (sim?.biosimulators?.validationTests) {
-      const validationTests: IValidationTests =
-        sim.biosimulators.validationTests;
+    const viewValidationTests = this.simService.getValidationTestResultsForOneByVersion(sim.id, sim.version)
+      .pipe(map((sim: Simulator): ViewValidationTests | null => {
+        let viewValidationTests: ViewValidationTests | null = null;
+        if (sim?.biosimulators?.validationTests) {
+          const validationTests: IValidationTests =
+            sim.biosimulators.validationTests;
 
-      let numTestsPassed = 0;
-      let numTestPassedWithWarnings = 0;
-      let numTestsSkipped = 0;
-      let numTestsFailed = 0;
-      validationTests.results.forEach((result: ITestCaseResult): void => {
-        if (result.resultType == TestCaseResultType.passed) {
-          numTestsPassed++;
-          if (result.warnings?.length > 0) {
-            numTestPassedWithWarnings++;
-          }
-        } else if (result.resultType == TestCaseResultType.skipped) {
-          numTestsSkipped++;
-        } else {
-          numTestsFailed++;
-        }
-      });
-
-      const viewResults = validationTests.results
-        .map((result: ITestCaseResult): ViewTestCaseResult => {
-          const caseArchive = result.case.id.split('/')?.[1] || null;
-
-          return {
-            case: {
-              id: result.case.id,
-              description: result.case.description.replace('\n', '<br/>'),
-            },
-            caseUrl:
-              'https://github.com/biosimulators/Biosimulators_test_suite/blob/' +
-              validationTests.testSuiteVersion +
-              '/biosimulators_test_suite/test_case/' +
-              result.case.id.split('.')[0] +
-              '.py',
-            caseClass: result.case.id.split(':')[0],
-            caseArchive: caseArchive,
-            caseArchiveUrl: caseArchive
-              ? 'https://github.com/biosimulators/Biosimulators_test_suite/raw/' +
-                validationTests.testSuiteVersion +
-                '/examples/' +
-                result.case.id.split(':')[1] +
-                '.omex'
-              : null,
-            resultType:
-              result.resultType.substring(0, 1).toUpperCase() +
-              result.resultType.substring(1),
-            duration: result.duration.toFixed(1),
-            exception: result.exception,
-            warnings: result.warnings,
-            skipReason: result.skipReason,
-            log: result.log,
-          };
-        })
-        .sort((a, b) => {
-          return a.case.id.localeCompare(b.case.id, undefined, {
-            numeric: true,
+          let numTestsPassed = 0;
+          let numTestPassedWithWarnings = 0;
+          let numTestsSkipped = 0;
+          let numTestsFailed = 0;
+          validationTests.results.forEach((result: ITestCaseResult): void => {
+            if (result.resultType == TestCaseResultType.passed) {
+              numTestsPassed++;
+              if (result.warnings?.length > 0) {
+                numTestPassedWithWarnings++;
+              }
+            } else if (result.resultType == TestCaseResultType.skipped) {
+              numTestsSkipped++;
+            } else {
+              numTestsFailed++;
+            }
           });
-        });
 
-      viewValidationTests = {
-        testSuiteVersion: validationTests.testSuiteVersion,
-        testSuiteVersionUrl:
-          'https://github.com/biosimulators/Biosimulators_test_suite/releases/tag/' +
-          validationTests.testSuiteVersion,
-        numTests: validationTests.results.length,
-        numTestsPassed: numTestsPassed,
-        numTestPassedWithWarnings: numTestPassedWithWarnings,
-        numTestsSkipped: numTestsSkipped,
-        numTestsFailed: numTestsFailed,
-        results: viewResults,
-        ghIssue: validationTests.ghIssue,
-        ghIssueUrl: `https://github.com/biosimulators/Biosimulators/issues/${validationTests.ghIssue}`,
-        ghActionRun: validationTests.ghActionRun,
-        ghActionRunUrl: `https://github.com/biosimulators/Biosimulators/actions/runs/${validationTests.ghActionRun}`,
-      };
-    }
+          const viewResults = validationTests.results
+            .map((result: ITestCaseResult): ViewTestCaseResult => {
+              const caseArchive = result.case.id.split('/')?.[1] || null;
+
+              return {
+                case: {
+                  id: result.case.id,
+                  description: result.case.description.replace('\n', '<br/>'),
+                },
+                caseUrl:
+                  'https://github.com/biosimulators/Biosimulators_test_suite/blob/' +
+                  validationTests.testSuiteVersion +
+                  '/biosimulators_test_suite/test_case/' +
+                  result.case.id.split('.')[0] +
+                  '.py',
+                caseClass: result.case.id.split(':')[0],
+                caseArchive: caseArchive,
+                caseArchiveUrl: caseArchive
+                  ? 'https://github.com/biosimulators/Biosimulators_test_suite/raw/' +
+                    validationTests.testSuiteVersion +
+                    '/examples/' +
+                    result.case.id.split(':')[1] +
+                    '.omex'
+                  : null,
+                resultType:
+                  result.resultType.substring(0, 1).toUpperCase() +
+                  result.resultType.substring(1),
+                duration: result.duration.toFixed(1),
+                exception: result.exception,
+                warnings: result.warnings,
+                skipReason: result.skipReason,
+                log: result.log,
+              };
+            })
+            .sort((a, b) => {
+              return a.case.id.localeCompare(b.case.id, undefined, {
+                numeric: true,
+              });
+            });
+
+          viewValidationTests = {
+            testSuiteVersion: validationTests.testSuiteVersion,
+            testSuiteVersionUrl:
+              'https://github.com/biosimulators/Biosimulators_test_suite/releases/tag/' +
+              validationTests.testSuiteVersion,
+            numTests: validationTests.results.length,
+            numTestsPassed: numTestsPassed,
+            numTestPassedWithWarnings: numTestPassedWithWarnings,
+            numTestsSkipped: numTestsSkipped,
+            numTestsFailed: numTestsFailed,
+            results: viewResults,
+            ghIssue: validationTests.ghIssue,
+            ghIssueUrl: `https://github.com/biosimulators/Biosimulators/issues/${validationTests.ghIssue}`,
+            ghActionRun: validationTests.ghActionRun,
+            ghActionRunUrl: `https://github.com/biosimulators/Biosimulators/actions/runs/${validationTests.ghActionRun}`,
+          };
+        }
+
+        return viewValidationTests;
+      }));
 
     const viewSim: ViewSimulator = {
       _json: JSON.stringify(sim, null, 2),


### PR DESCRIPTION
This information is now separately loaded from the specs of each simulator, using the new 'includeTests' query argument to the simulators API

closes #2696