### PR TITLE
feat(dispatch): improving capabilities when COMBINE service is down

### DIFF
--- a/apps/dispatch/src/app/combine-sedml.interface.ts
+++ b/apps/dispatch/src/app/combine-sedml.interface.ts
@@ -95,7 +95,7 @@ export interface SedDataGenerator {
 export interface SedDataSet {
   _type: 'SedDataSet';
   id: string;
-  dataGenerator: SedDataGenerator;
+  dataGenerator?: SedDataGenerator;
   name: string | null;
   label: string | null;
 }

--- a/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -938,6 +938,7 @@
                           required
                           (ngModelChange)="displayUserViz()"
                           disableOptionCentering
+                          multiple
                         >
                           <mat-optgroup
                             *ngFor="
@@ -974,6 +975,7 @@
                           required
                           (ngModelChange)="displayUserViz()"
                           disableOptionCentering
+                          multiple
                         >
                           <mat-optgroup
                             *ngFor="

--- a/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -1133,7 +1133,7 @@
     <ng-template #noVisualizations>
       <div
         class="tab-spinner-container"
-        *ngIf="!(visualizations$ | async); else error"
+        *ngIf="(visualizations$ | async) === null; else error"
       >
         <biosimulations-spinner></biosimulations-spinner>
       </div>

--- a/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -1131,7 +1131,7 @@
     <ng-template #noVisualizations>
       <div
         class="tab-spinner-container"
-        *ngIf="(visualizations$ | async) === undefined; else error"
+        *ngIf="!(visualizations$ | async); else error"
       >
         <biosimulations-spinner></biosimulations-spinner>
       </div>

--- a/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -134,7 +134,7 @@
     icon="code"
     urlHashFragment="project"
   >
-    <ng-container *ngIf="metadataLoaded$; else loading">
+    <ng-container *ngIf="metadataLoaded$ | async; else loading">
       <ng-container *ngIf="metadata$ | async as metadata; else error">
         <ng-container
           *ngIf="metadata.archive as archiveMetadata; else noMetadata"
@@ -450,8 +450,8 @@
 
         <ng-template #noMetadata>
           <span class="info-message"
-            >No metadata is available about the simulation project is
-            avaiable.</span
+            >No metadata about the simulation project is
+            available.</span
           >
         </ng-template>
       </ng-container>

--- a/apps/dispatch/src/app/services/combine/combine.service.ts
+++ b/apps/dispatch/src/app/services/combine/combine.service.ts
@@ -5,7 +5,7 @@ import {
   HttpParams,
 } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { catchError, timeout } from 'rxjs/operators';
 import { urls } from '@biosimulations/config/common';
 import { environment } from '@biosimulations/shared/environments';
 import { CombineArchive } from '../../combine-sedml.interface';
@@ -127,6 +127,7 @@ export class CombineService {
         params: params,
       })
       .pipe(
+        timeout(2500),
         catchError((error: HttpErrorResponse): Observable<undefined> => {
           if (!environment.production) {
             console.error(error);


### PR DESCRIPTION
## Closes #2750

- Run simulation
  - Added timeout to loading similar algorithms
  - Enabled filtering of simulation tools without algorithm similarity from COMBINE service
- View simulation
  - Fixed display of metadata loading indicator
  - Fixed visualization loading indicator
  - Enabled designing and displaying plots without specs of SED-ML files from COMBINE service

## Closes #2738 

Added simpler way to create 2D line/scatter plot with multiple curves