### PR TITLE
feat(combine-service): isolating simulation execution into separate processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
       - name: Install Flake8
         run: |
           python -m pip install flake8
-      
+
       - name: Lint
         run: nx affected:lint
 
@@ -344,13 +344,7 @@ jobs:
               pipenv install --dev
               mv src src-ignore
               export PYTHONPATH=apps/${{ matrix.libOrApp }}
-              
-              export SKIPPED_SIMULATORS=neuron,netpyne
               /bin/bash /xvfb-startup.sh pipenv run python -m pytest --verbose --cov apps/${{ matrix.libOrApp }}/src/ --cov-report=xml apps/${{ matrix.libOrApp }}/tests/
-              
-              unset SKIPPED_SIMULATORS
-              /bin/bash /xvfb-startup.sh pipenv run python -m pytest --verbose --cov apps/${{ matrix.libOrApp }}/src/ apps/${{ matrix.libOrApp }}/tests/run/test_run_get_simulators.py -k neuron
-              /bin/bash /xvfb-startup.sh pipenv run python -m pytest --verbose --cov apps/${{ matrix.libOrApp }}/src/ apps/${{ matrix.libOrApp }}/tests/run/test_run_get_simulators.py -k netpyne
             "
 
       - name: Validate OpenAPI specification for library or app (Python)

--- a/Pipfile
+++ b/Pipfile
@@ -51,7 +51,7 @@ biosimulators-pyneuroml = {version = ">=0.0.7", extras = ["netpyne", "neuron"]}
 # Smoldyn
 smoldyn = "*"
 # tellurium
-biosimulators-tellurium = ">=0.1.13"
+biosimulators-tellurium = ">=0.1.16"
 # XPP
 biosimulators-xpp = ">=0.0.4"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a10ee72f3ae30606a287cba486de8b926a22dcf3550165d3475f872604079044"
+            "sha256": "7facefad1c0f4ad0f4d9b1e2d3e0c5d6790fe52fe795e67cde96a69c8c771239"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -21,13 +21,6 @@
                 "sha256:3c62971a87776b17c1974f8841f6db22999d3674a771bfc65766105a85e55cb4"
             ],
             "version": "==0.5.17"
-        },
-        "alabaster": {
-            "hashes": [
-                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
-                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
-            ],
-            "version": "==0.7.12"
         },
         "amici": {
             "hashes": [
@@ -99,14 +92,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==21.2.0"
-        },
-        "babel": {
-            "hashes": [
-                "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9",
-                "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.9.1"
         },
         "backcall": {
             "hashes": [
@@ -180,11 +165,11 @@
         },
         "biosimulators-gillespy2": {
             "hashes": [
-                "sha256:74f85d23a3756ade4a15f463443335be0894496deb281233f199bfdc17821e67",
-                "sha256:bd035a978728062ff7624b068aadbf707fd02f258e0bece7a3623ef35b951402"
+                "sha256:392d60d24057f3689529078558b5b42da4cdfcd7ba61f5edfc6753cd3c303bb0",
+                "sha256:fe9c530eeb128243c03923bf87dfc643f1980b85c5409a1c5e0c9ea78362d39a"
             ],
             "index": "pypi",
-            "version": "==0.1.30"
+            "version": "==0.1.31"
         },
         "biosimulators-ginsim": {
             "hashes": [
@@ -232,11 +217,11 @@
         },
         "biosimulators-tellurium": {
             "hashes": [
-                "sha256:41ed3be2d1dede43b19c33d1c237b99b5f3e736809f2cf0d6639f55e47dec7aa",
-                "sha256:e5d8e07735f8c314e8256ef44be0befeecf6eae62b57e0681624541ab5a82342"
+                "sha256:2626111a05012843a836b39c247c1b61b7891317250082895aa478c3301b8eea",
+                "sha256:ab56d6405804f323913fd0cc125779e8fdf8ebaa653e9eaa1e1e571d5c65fd84"
             ],
             "index": "pypi",
-            "version": "==0.1.14"
+            "version": "==0.1.16"
         },
         "biosimulators-utils": {
             "extras": [
@@ -249,11 +234,11 @@
                 "smoldyn"
             ],
             "hashes": [
-                "sha256:38b30603e3282f82eb755fd6e0c8475d0094390a25cdcc3b36d166c44c672762",
-                "sha256:faabc52ed01b2a390ce236c3d018dc78166468bbd187b0330a9d1b2e7a5662a8"
+                "sha256:7f1b9449c052ccfaa1b04a48b721fed8514174bc2eb1051b9a880f42daf3aa2c",
+                "sha256:c96808b4a0fdfb38082d0aad8ae370e8ee9780905b1cb2310a85332a4b122bed"
             ],
             "index": "pypi",
-            "version": "==0.1.107"
+            "version": "==0.1.108"
         },
         "biosimulators-xpp": {
             "hashes": [
@@ -265,11 +250,11 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:c1685a132e6a9a38bf93752e5faab33a9517a6c0bb2f37b785e47bf253bdb51d",
-                "sha256:ffa9221c6ac29399cc50fcc33473366edd0cf8d5e2cbbbb63296dc327fb67cc8"
+                "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da",
+                "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.0.0"
+            "version": "==4.1.0"
         },
         "bokeh": {
             "hashes": [
@@ -288,26 +273,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:39ed0f5004b671e4a4241ae23023ad63674cd25f766bfe1617cfc809728bc3e0",
-                "sha256:3eedef0719639892dc263bed7adfc00821544388e3d86a6fa31d82f936a6b613"
+                "sha256:4dc7e346e92c01e8a997daa58a4c990151841d2d2962067325d963f665c7287a",
+                "sha256:79b7e6e0167def749352968ed6eb96954d9e2dd1dca8f297f122414753ce73a3"
             ],
             "index": "pypi",
-            "version": "==1.18.26"
+            "version": "==1.18.29"
         },
         "botocore": {
             "hashes": [
-                "sha256:37f77bf5f72c86d9b5f38e107c3822da66dbf0ef123768a6e80a58590c2796bf",
-                "sha256:911246faac450e13a3ef0e81993dd9bd9c282a7c0f4546bfe8cccf9649364cef"
+                "sha256:1f16998b4f5a88e6844196feee7fa5eef6b36034d377f9845c7df12b8803b3be",
+                "sha256:fec924f63b40bd29b522fa109ecbc45f16eedcbeb22b68c6c79773c22a552b16"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==1.21.26"
-        },
-        "breathe": {
-            "hashes": [
-                "sha256:363dec85abc0c4b3f22628b0cf82cc2dc46c4397d8a18312d1a7d1365d49b014",
-                "sha256:7955d9e3627be425572105a3d721463afac6fa32f4d975083b0dacab5dae4745"
-            ],
-            "version": "==4.30.0"
+            "version": "==1.21.29"
         },
         "cachetools": {
             "hashes": [
@@ -452,11 +430,11 @@
         },
         "colorlog": {
             "hashes": [
-                "sha256:375fd730040e20618a05e9c3548330671bb53934f0eeaa8cb0abb3fd0ef8f1fa",
-                "sha256:a7cfd8226fadb1730019bca1f4c4f351649ce3a39350544a6a1fad5774282021"
+                "sha256:af99440154a01f27c09256760ea3477982bf782721feaa345904e806879df4d8",
+                "sha256:b13da382156711f7973bf7cbd1f40ea544aff51fde5dc3fb8f3fa602c321d645"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==6.3.0a1"
+            "version": "==6.4.1"
         },
         "commonmark": {
             "hashes": [
@@ -622,14 +600,6 @@
             "markers": "python_version >= '3'",
             "version": "==5.2.1"
         },
-        "docutils": {
-            "hashes": [
-                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
-                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.16"
-        },
         "entrypoints": {
             "hashes": [
                 "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
@@ -693,7 +663,7 @@
             "hashes": [
                 "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.18.2"
         },
         "gillespy2": {
@@ -743,19 +713,19 @@
         },
         "h5py": {
             "hashes": [
-                "sha256:09e78cefdef0b7566ab66366c5c7d9984c7b23142245bd51b82b744ad1eebf65",
-                "sha256:13355234c004ff8bd819f7d3420188aa1936b17d7f8470d622974a373421b7a5",
-                "sha256:5e2f22e66a3fb1815405cfe5711670450c973b8552507c535a546a23a468af3d",
-                "sha256:7ca7d23ebbdd59a4be9b4820de52fe67adc74e6a44d5084881305461765aac47",
-                "sha256:89d7e10409b62fed81c571e35798763cb8375442b98f8ebfc52ba41ac019e081",
-                "sha256:8e09b682e4059c8cd259ddcc34bee35d639b9170105efeeae6ad195e7c1cea7a",
-                "sha256:baef1a2cdef287a83e7f95ce9e0f4d762a9852fe7117b471063442c78b973695",
-                "sha256:e0dac887d779929778b3cfd13309a939359cc9e74756fc09af7c527a82797186",
-                "sha256:e0ea3330bf136f8213e43db67448994046ce501585dddc7ea4e8ceef0ef1600c",
-                "sha256:f3bba8ffddd1fd2bf06127c5ff7b73f022cc1c8b7164355ddc760dc3f8570136"
+                "sha256:0b0f002f5f341afe7d3d7e15198e80d9021da24a4d182d88068d79bfc91fba86",
+                "sha256:1edf33e722d47c6eb3878d51173b23dd848939f006f41b498bafceff87fb4cbd",
+                "sha256:46917f20021dde02865572a5fd2bb620945f7b7cd268bdc8e3f5720c32b38140",
+                "sha256:708ddff49af12c01d77e0f9782bb1a0364d96459ec0d1f85d90baea6d203764b",
+                "sha256:8745e5159830d7975a9cf38690455f22601509cda04de29b7e88b3fbdc747611",
+                "sha256:8e809149f95d9a3a33b1279bfbf894c78635a5497e8d5ac37420fa5ec0cf4f29",
+                "sha256:aa511bd05a9174c3008becdc93bd5785e254d34a6ab5f0425e6b2fbbc88afa6d",
+                "sha256:bb4ce46095e3b16c872aaf62adad33f40039fecae04674eb62c035386affcb91",
+                "sha256:be2a545f09074546f73305e0db6d36aaf1fb6ea2fcf1add2ce306b9c7f78e55a",
+                "sha256:ee1c683d91ab010d5e85cb61e8f9e7ee0d8eab545bf3dd50a9618f1d0e8f615e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.3.0"
+            "version": "==3.4.0"
         },
         "httpcore": {
             "hashes": [
@@ -787,14 +757,6 @@
                 "sha256:467fbad99067910785144ce333826c71fb0e63a425657295239737f7ecd125f3"
             ],
             "version": "==3.2"
-        },
-        "imagesize": {
-            "hashes": [
-                "sha256:6965f19a6a2039c7d48bca7dba2473069ff854c36ae6f19d2cde309d998228a1",
-                "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.2.0"
         },
         "importlib-resources": {
             "hashes": [
@@ -886,7 +848,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "jsonschema": {
@@ -906,11 +868,11 @@
         },
         "jupyter-core": {
             "hashes": [
-                "sha256:a05c0993fe0558af6bee05d7525fc52326952f3c66a8bb4cc10cae97e2499be3",
-                "sha256:a2b8ffc26d5b39a1bf7afab05a988b82d367b1f64836af2f428ebc8f4009744d"
+                "sha256:b166953ae17319ccf487440ac487ca01c6124f4291e8250170e7ebeaad3f6f68",
+                "sha256:f5c1d3c32c8f1d047e07c84163424f0ef2bebcaedb117106e9b95be39ac28b55"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==4.8.0b0"
+            "version": "==4.8.0rc0"
         },
         "jupyterlab-pygments": {
             "hashes": [
@@ -921,11 +883,11 @@
         },
         "kisao": {
             "hashes": [
-                "sha256:ae88e99ad2afc90051204935a01fbf2a12273a64693dfb915ec37eb74d1b27ec",
-                "sha256:eb026433f774142a06054d649cd623bb452d38d6471ecb75e8f293e33b1bd74e"
+                "sha256:884d4d6e5bcf0af3e8091c039ae1f1659bcfe27529a3e4d707b66e329c29e082",
+                "sha256:d2cd55e84535711935ee42bd9a907b237fd4a68c21d6a04abfec71536adc89f4"
             ],
             "index": "pypi",
-            "version": "==2.26"
+            "version": "==2.27"
         },
         "kiwisolver": {
             "hashes": [
@@ -1485,16 +1447,16 @@
                 "sha256:d20023bbeb42ee6d428a0fac6e0904631f545985a10cdd71a20aa58bc47a4209",
                 "sha256:deb4163ef11f75b520d822d9505c1f462761b4309b1bb713d08689759ea8b899"
             ],
-            "markers": "python_version >= '3.3' and python_version < '4'",
+            "markers": "python_version >= '3.3' and python_version < '4.0'",
             "version": "==1.5.5"
         },
         "plotly": {
             "hashes": [
-                "sha256:1575c34f87313818fc109a3d3326f2b91363d049c1e80cbf68561c8df24fb47c",
-                "sha256:bf7c8123541a2c6579c309561a8e1058c129434c67419651efbdc4922b11da8f"
+                "sha256:25ad75f8944c950b01811b4521f39104ce0ede92ebf7821aef74ba6530a63fab",
+                "sha256:809f0674a7991daaf4f287964d617d24e9fa44463acd5a5352ebd874cfd98b07"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==5.2.1"
+            "version": "==5.2.2"
         },
         "pluggy": {
             "hashes": [
@@ -1653,17 +1615,17 @@
         },
         "pyomexmeta": {
             "hashes": [
-                "sha256:1234685f6358e4029c76dfc5bf20f9d4fad67865810648559891bb0d8e77e574",
-                "sha256:2b33d5898447611b48ebf65efc4f9281851f19ef7f8063f897718798e1903751",
-                "sha256:3c8486b922f7152749f8d2cc5dfb4dca10acc711bab476914012669724d76d71",
-                "sha256:8e0a1da0dcc27918f492ca9621f62da2ec168710c73548b218cffe0db9498364",
-                "sha256:a6883d8c7161c5dbcc392c77a5ee270a4b0381a1175267b2bf37201705cdb10e",
-                "sha256:bad53af2e219969782011b42c3cdff8f6840cd5261124979d4788f4eed30a3a0",
-                "sha256:bb2618919af42b654401a319bc65956ad68e7a93b87d196399986823ff4fbe42",
-                "sha256:cf8884698410e537d3b38d20991bead9da3e0c03fbd2e33abac399af7f364448",
-                "sha256:e125c8f8ce57799f5ede7ed0c915d193deade9f1579bf00f585b5e11579b9515"
+                "sha256:17df074616456a59b54e437982648647204ec182c5329845c3d8118039bdc889",
+                "sha256:224dcafc24b104ceb2e6cbbd0fc68e765880cdb977f4a2339ab6b033d8fd1cf9",
+                "sha256:78ed94a31a99b37ff6deabb73d224188960110849ec4ac2afdfc8acc277a354d",
+                "sha256:a01a26546da78e0532b5bb894807ed039c91c4f2700446767a4b5d938743bd05",
+                "sha256:a04fbe7174fe5809d0d91fdbe1a89b38b6815a69bd0295c95c35cf4b661523be",
+                "sha256:b6b3265b1b314d07a4ab3ae61dc0979dcd84549dda018aaa56025c1ec729533b",
+                "sha256:e86b10acc666b360b996f449c09b811a89dabd6197afaeb84fa1aa62b38741cc",
+                "sha256:ea8919b17b9b0ad8c00b059d55a3b253e36cf8a8a8af115c44758a4dc8f36d54",
+                "sha256:fb55e838ec58215554a254766db3f2cea3ed9436040e32d9cc03ac7c2aa11e41"
             ],
-            "version": "==1.2.10"
+            "version": "==1.2.13"
         },
         "pyparsing": {
             "hashes": [
@@ -1995,13 +1957,6 @@
             "index": "pypi",
             "version": "==6.0.0"
         },
-        "recommonmark": {
-            "hashes": [
-                "sha256:1b1db69af0231efce3fa21b94ff627ea33dee7079a01dd0a7f8482c3da148b3f",
-                "sha256:bdb4db649f2222dcd8d2d844f0006b958d627f732415d399791ee436a3686d67"
-            ],
-            "version": "==0.7.1"
-        },
         "requests": {
             "hashes": [
                 "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
@@ -2033,7 +1988,7 @@
                 "sha256:13ac80676e12cf528dc4228dc682c8402f82577c2aa67191e294350fa2c3c4e9",
                 "sha256:517b4e0efd064dd1fe821ca93dd3095d73380ceac1f0a07173d507d9b18f1396"
             ],
-            "markers": "python_version >= '3.6' and python_version < '4'",
+            "markers": "python_version >= '3.6' and python_version < '4.0'",
             "version": "==10.7.0"
         },
         "rpy2": {
@@ -2055,11 +2010,11 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:02f0ed93e98ea32498d25a2952635bbd9fabd553599b8ad67724b4ac88dd8f6c",
-                "sha256:aa1a5b8041bab0d0e8c514949fa8e11b02653061dcbc68365c820b263f8c6ec7"
+                "sha256:4185fcfa9e037fea9ffd0bb6172354a03ec98c21e462355d72e068c74e493512",
+                "sha256:b59c548ba6a2a99a97a842db2321c5adf28470d1decb04bdd82ce9535936a2fa"
             ],
             "markers": "python_version >= '3'",
-            "version": "==0.17.13"
+            "version": "==0.17.14"
         },
         "ruamel.yaml.clib": {
             "hashes": [
@@ -2085,7 +2040,7 @@
                 "sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed",
                 "sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c"
             ],
-            "markers": "platform_python_implementation == 'CPython' and python_version < '3.10'",
+            "markers": "python_version < '3.10' and platform_python_implementation == 'CPython'",
             "version": "==0.2.6"
         },
         "s3transfer": {
@@ -2151,62 +2106,62 @@
         },
         "simplejson": {
             "hashes": [
-                "sha256:0040b8d823801120719390696a2c910e10024eccf63e7851748fba02bb1c2b0f",
-                "sha256:007d6c4babace6abe4092cddc2f557cb123e19bdc24c3b6e8319bafc210dae43",
-                "sha256:02db01370c3c60d09184b297b1ac702daece46eb6005e7fae7fab204dad3f8cc",
-                "sha256:09e20701a2319f5af3923ca6a83bd183803719823481692123423697c6c63f98",
-                "sha256:0e44d6f3bf93fcc09a9eefb09ccc7035a811157327c13ae8376a5c89c3540078",
-                "sha256:0f61981554c2bacbe968e70696c65f03c6c1ec2e50d8ecb2af926fcb18a97b7d",
-                "sha256:1ea0682aced01a5bbe9bb040b68ae3271c10fde3132542550b6e04921ef1c41b",
-                "sha256:2397a156bdf2f7e78ebaf2fae0c999cc54b271595e2728c0c2ca89c22f54ba7f",
-                "sha256:2af85e028714c4b6cb2eb6fc03aa91f39ffd654f2eb2f6f8f860e14aeefa6be1",
-                "sha256:2da83b371e5d0023f343fba038d677b60006e24aeddb2ddd80513ad808d96e04",
-                "sha256:2f647e5fe9783e7fe49c6c036102da31dc0db396b4ead6ed785033f2beb982df",
-                "sha256:302959ee24a4cf0ba91609d3c0878e524e4d65550d6c457b903c09a767e86bfe",
-                "sha256:31a51d317695a1c214f5aa1405d7970c91ec92f205ac4ef6997f7fd8946cc70f",
-                "sha256:33bbbaab29b4a15f85b48364fa8bd8a651d4a89d4ceebbc4e0c2ba73f2d07238",
-                "sha256:3a0175f6e0958a602fbff81777a59f7ea5294c3f657f1e467de586bbdfaa4e5d",
-                "sha256:45b9d8f725ac81f434759ec75d54884745f31f29960570ac02664438a8567663",
-                "sha256:530ea1e44065a7bb27135ef49ae581882ab217137b66ec0771e3271fcc0a423e",
-                "sha256:5c572ed94842440192da2ed4bb61015f9e2d295714d0c1925fe565a138f58520",
-                "sha256:60a956a896dd6bfa64057d13b3f837fecf0b554fc4c5daf399aa28ddd47912ab",
-                "sha256:651061490eff527eef5e6d81ee81978a0e3215348d27799f36b39c0012e11606",
-                "sha256:6b84897e40d3938eb089a5601a79248898c6d21777a25dcc6869b1f8614848bf",
-                "sha256:70e74bf39efc0199413b50885fc622b01fd892c5d8161af7dda7381233358135",
-                "sha256:77e1beb769f584a52ef6f5ac414bb50adedfe15ab8149d4e9bfaaa98d149d7b5",
-                "sha256:7b5c5e1004ebc2cf3cf0b9ed2d0b4987e459d2c6d4b4887926b875e72938b7e8",
-                "sha256:7bff90dff74c5ebac682b50f590e3535f1256ed9be8ff38f19a59c40d7998320",
-                "sha256:80dd583a1c6a02fd5d735195a7e04b21f3d9ac51205065a0d9e859a23e859942",
-                "sha256:819a7a369628511e129098d0f99e0a2a6702c0aba395d52ef06332d2463031ab",
-                "sha256:8a60cb29a9dcbb0dffbf3dd460d45b19e8de9bdb2bb26221a762a1ddf310597f",
-                "sha256:92d2f0c92174fc91bc36806e14717e70d8f5e63374d4e7c30d31d0bb510b3b33",
-                "sha256:93a23b0fdeefddb41bd382a59d3cb7b7c4c8b1f14052c821575856e2dc828ccf",
-                "sha256:9b2f7cfe67bc98b9123984520df014e7e9f4ed93b65ee0472af3e1230e967cb4",
-                "sha256:9dff1ffa871c2fc31aebf7dfe942dff20858823dc1bbc59e9797c85bf0b1a5e5",
-                "sha256:9e5f0580b60fda8d2ea930424ef23180599e119bf3b4c7518b0668494bc96e58",
-                "sha256:a6418959866bd14d49444dd5b9e65914d5cc1438dbdc25cdf968bd927849c36e",
-                "sha256:c22beb7c6c89343490ac9ad0c1360c4092f97efb2393c007d8a767b7160c8939",
-                "sha256:c452413cb3c9a39f52156bf21c9020ea7540bab323dafd0db7abeac2c12940f3",
-                "sha256:c4ce22af9c884803498432cbe2da70ec276ead17150fbaad28264e1342330592",
-                "sha256:cca54a1ea98b579b25d39154d353c4d4dbb4622217a49cceec79151005943133",
-                "sha256:d479f2d5cd4e3be25296f151cd912c8712ed8084d1be8ad2f999cba09b8d81df",
-                "sha256:d7132977504a16c63ced62926fdef5a7d6b92addcf912b44b66a8abf3ddccf81",
-                "sha256:da2b9425e12835500eab4e4eb304ea832a4c7baad0546f8eb4a1958515793afb",
-                "sha256:dbe07d4039f55323483cc881cc95e5e2cf589b0daccb69118a048c328e2d7ecd",
-                "sha256:dc65e10aca9e24e975106ebd442059823ceb80babeaccd968290b5a59086bb08",
-                "sha256:e2fb03cd1ec443aaecd13d42970243795df39817b93aadfc484ee0013632eb2d",
-                "sha256:ed967cac20cd84ad811ba5a66021fbb87dd208b5bea94f8871876e1afbd2742a",
-                "sha256:fdaa9e8576c529bdd714df5a1c08c703e6d3bb34660c51a32197a7ca83acb2df"
+                "sha256:065230b9659ac38c8021fa512802562d122afb0cf8d4b89e257014dcddb5730a",
+                "sha256:07707ba69324eaf58f0c6f59d289acc3e0ed9ec528dae5b0d4219c0d6da27dc5",
+                "sha256:10defa88dd10a0a4763f16c1b5504e96ae6dc68953cfe5fc572b4a8fcaf9409b",
+                "sha256:140eb58809f24d843736edb8080b220417e22c82ac07a3dfa473f57e78216b5f",
+                "sha256:188f2c78a8ac1eb7a70a4b2b7b9ad11f52181044957bf981fb3e399c719e30ee",
+                "sha256:1c2688365743b0f190392e674af5e313ebe9d621813d15f9332e874b7c1f2d04",
+                "sha256:24e413bd845bd17d4d72063d64e053898543fb7abc81afeae13e5c43cef9c171",
+                "sha256:2b59acd09b02da97728d0bae8ff48876d7efcbbb08e569c55e2d0c2e018324f5",
+                "sha256:2df15814529a4625ea6f7b354a083609b3944c269b954ece0d0e7455872e1b2a",
+                "sha256:352c11582aa1e49a2f0f7f7d8fd5ec5311da890d1354287e83c63ab6af857cf5",
+                "sha256:36b08b886027eac67e7a0e822e3a5bf419429efad7612e69501669d6252a21f2",
+                "sha256:376023f51edaf7290332dacfb055bc00ce864cb013c0338d0dea48731f37e42f",
+                "sha256:3ba82f8b421886f4a2311c43fb98faaf36c581976192349fef2a89ed0fcdbdef",
+                "sha256:3d72aa9e73134dacd049a2d6f9bd219f7be9c004d03d52395831611d66cedb71",
+                "sha256:40ece8fa730d1a947bff792bcc7824bd02d3ce6105432798e9a04a360c8c07b0",
+                "sha256:417b7e119d66085dc45bdd563dcb2c575ee10a3b1c492dd3502a029448d4be1c",
+                "sha256:42b7c7264229860fe879be961877f7466d9f7173bd6427b3ba98144a031d49fb",
+                "sha256:457d9cfe7ece1571770381edccdad7fc255b12cd7b5b813219441146d4f47595",
+                "sha256:4a6943816e10028eeed512ea03be52b54ea83108b408d1049b999f58a760089b",
+                "sha256:5b94df70bd34a3b946c0eb272022fb0f8a9eb27cad76e7f313fedbee2ebe4317",
+                "sha256:5f5051a13e7d53430a990604b532c9124253c5f348857e2d5106d45fc8533860",
+                "sha256:5f7f53b1edd4b23fb112b89208377480c0bcee45d43a03ffacf30f3290e0ed85",
+                "sha256:5fe8c6dcb9e6f7066bdc07d3c410a2fca78c0d0b4e0e72510ffd20a60a20eb8e",
+                "sha256:71a54815ec0212b0cba23adc1b2a731bdd2df7b9e4432718b2ed20e8aaf7f01a",
+                "sha256:7332f7b06d42153255f7bfeb10266141c08d48cc1a022a35473c95238ff2aebc",
+                "sha256:78c6f0ed72b440ebe1892d273c1e5f91e55e6861bea611d3b904e673152a7a4c",
+                "sha256:7c9b30a2524ae6983b708f12741a31fbc2fb8d6fecd0b6c8584a62fd59f59e09",
+                "sha256:86fcffc06f1125cb443e2bed812805739d64ceb78597ac3c1b2d439471a09717",
+                "sha256:87572213965fd8a4fb7a97f837221e01d8fddcfb558363c671b8aa93477fb6a2",
+                "sha256:8e595de17178dd3bbeb2c5b8ea97536341c63b7278639cb8ee2681a84c0ef037",
+                "sha256:917f01db71d5e720b731effa3ff4a2c702a1b6dacad9bcdc580d86a018dfc3ca",
+                "sha256:91cfb43fb91ff6d1e4258be04eee84b51a4ef40a28d899679b9ea2556322fb50",
+                "sha256:aa86cfdeb118795875855589934013e32895715ec2d9e8eb7a59be3e7e07a7e1",
+                "sha256:ade09aa3c284d11f39640aebdcbb748e1996f0c60504f8c4a0c5a9fec821e67a",
+                "sha256:b2a5688606dffbe95e1347a05b77eb90489fe337edde888e23bbb7fd81b0d93b",
+                "sha256:b92fbc2bc549c5045c8233d954f3260ccf99e0f3ec9edfd2372b74b350917752",
+                "sha256:c2d5334d935af711f6d6dfeec2d34e071cdf73ec0df8e8bd35ac435b26d8da97",
+                "sha256:cb0afc3bad49eb89a579103616574a54b523856d20fc539a4f7a513a0a8ba4b2",
+                "sha256:ce66f730031b9b3683b2fc6ad4160a18db86557c004c3d490a29bf8d450d7ab9",
+                "sha256:e29b9cea4216ec130df85d8c36efb9985fda1c9039e4706fb30e0fb6a67602ff",
+                "sha256:e2cc4b68e59319e3de778325e34fbff487bfdb2225530e89995402989898d681",
+                "sha256:e90d2e219c3dce1500dda95f5b893c293c4d53c4e330c968afbd4e7a90ff4a5b",
+                "sha256:f13c48cc4363829bdfecc0c181b6ddf28008931de54908a492dc8ccd0066cd60",
+                "sha256:f550730d18edec4ff9d4252784b62adfe885d4542946b6d5a54c8a6521b56afd",
+                "sha256:fa843ee0d34c7193f5a816e79df8142faff851549cab31e84b526f04878ac778",
+                "sha256:fe1c33f78d2060719d52ea9459d97d7ae3a5b707ec02548575c4fbed1d1d345b"
             ],
-            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2'",
-            "version": "==3.17.4"
+            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==3.17.5"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "smoldyn": {
@@ -2232,84 +2187,13 @@
             "markers": "python_version >= '3.5'",
             "version": "==1.2.0"
         },
-        "snowballstemmer": {
-            "hashes": [
-                "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2",
-                "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"
-            ],
-            "version": "==2.1.0"
-        },
         "soupsieve": {
             "hashes": [
                 "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
                 "sha256:c2c1c2d44f158cdbddab7824a9af8c4f83c76b1e23e049479aa432feb6c4c23b"
             ],
-            "markers": "python_version >= '3.0'",
+            "markers": "python_version >= '3'",
             "version": "==2.2.1"
-        },
-        "sphinx": {
-            "hashes": [
-                "sha256:3092d929cd807926d846018f2ace47ba2f3b671b309c7a89cd3306e80c826b13",
-                "sha256:46d52c6cee13fec44744b8c01ed692c18a640f6910a725cbb938bc36e8d64544"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.1.2"
-        },
-        "sphinx-tabs": {
-            "hashes": [
-                "sha256:1e1b1846c80137bd81a78e4a69b02664b98b1e1da361beb30600b939dfc75065",
-                "sha256:33137914ed9b276e6a686d7a337310ee77b1dae316fdcbce60476913a152e0a4"
-            ],
-            "markers": "python_version ~= '3.6'",
-            "version": "==3.2.0"
-        },
-        "sphinxcontrib-applehelp": {
-            "hashes": [
-                "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
-                "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.2"
-        },
-        "sphinxcontrib-devhelp": {
-            "hashes": [
-                "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
-                "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.2"
-        },
-        "sphinxcontrib-htmlhelp": {
-            "hashes": [
-                "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
-                "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
-            ],
-            "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
-        },
-        "sphinxcontrib-jsmath": {
-            "hashes": [
-                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
-                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.1"
-        },
-        "sphinxcontrib-qthelp": {
-            "hashes": [
-                "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
-                "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.0.3"
-        },
-        "sphinxcontrib-serializinghtml": {
-            "hashes": [
-                "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd",
-                "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
-            ],
-            "markers": "python_version >= '3.5'",
-            "version": "==1.1.5"
         },
         "stringcase": {
             "hashes": [
@@ -2419,7 +2303,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "toposort": {
@@ -2478,11 +2362,11 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:07856e19a1fe4d2d9621b539d3f072fa88c9c1ef1f3b7dd4d4953383134c3164",
-                "sha256:35540feeaca9ac40c304e916729e6b78045cbbeccd3e941b2868f09306798ac9"
+                "sha256:80aead664e6c1672c4ae20dc50e1cdc5e20eeff9b14aa23ecd426375b28be588",
+                "sha256:a4d6d112e507ef98513ac119ead1159d286deab17dffedd96921412c2d236ff5"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.62.1"
+            "version": "==4.62.2"
         },
         "traitlets": {
             "hashes": [
@@ -2529,7 +2413,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.6"
         },
         "validators": {
@@ -2564,11 +2448,11 @@
         },
         "wurlitzer": {
             "hashes": [
-                "sha256:01cb41f3bccc339632a28cb147b622241e785c23e11c69ce08efad5ebd2c427f",
-                "sha256:5168ad17ebed2db3c45a07fda05614c4a6f60baac98f2fa373c6ecd55f0240e5"
+                "sha256:36051ac530ddb461a86b6227c4b09d95f30a1d1043de2b4a592e97ae8a84fcdf",
+                "sha256:37f3ed1b08bf887172eda7f5177417241ec54cdd5e70df74c92d96875ceff632"
             ],
             "markers": "python_version >= '3.5'",
-            "version": "==3.0.0"
+            "version": "==3.0.2"
         },
         "xmltodict": {
             "hashes": [
@@ -2891,7 +2775,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "toml": {
@@ -2899,7 +2783,7 @@
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.2"
         },
         "urllib3": {
@@ -2907,7 +2791,7 @@
                 "sha256:39fb8672126159acb139a7718dd10806104dec1e2f0f6c88aab05d17df10c8d4",
                 "sha256:f57b4c16c62fa2760b7e3d97c35b255512fb6b59a259730f36ba32ce9f8e342f"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4.0'",
             "version": "==1.26.6"
         },
         "werkzeug": {

--- a/apps/combine-service/src/handlers/run/get_simulators.py
+++ b/apps/combine-service/src/handlers/run/get_simulators.py
@@ -14,5 +14,6 @@ def handler():
     simulators = []
 
     for sim in utils.get_simulators():
-        simulators.append(utils.get_simulator_metadata(sim['id']))
+        simulators.append(utils.exec_in_subprocess(utils.get_simulator_metadata, sim['id']))
+
     return simulators

--- a/apps/combine-service/src/handlers/run/utils.py
+++ b/apps/combine-service/src/handlers/run/utils.py
@@ -1,11 +1,21 @@
+from biosimulators_utils.log.data_model import CombineArchiveLog  # noqa: F401
+from biosimulators_utils.report.data_model import SedDocumentResults  # noqa: F401
 import functools
 import importlib
+import multiprocessing
 import os
+import sys
 import types  # noqa: F401
 import yaml
 
 
-__all__ = ['get_simulators', 'get_simulator_api']
+__all__ = [
+    'get_simulators',
+    'get_simulator_api',
+    'get_simulator_metadata',
+    'use_simulator_api_to_exec_sedml_docs_in_combine_archive',
+    'exec_in_subprocess',
+]
 
 
 @functools.lru_cache(maxsize=None)
@@ -36,7 +46,6 @@ def get_simulator_api(api, reload=False):
     return module
 
 
-@functools.lru_cache(maxsize=None)
 def get_simulator_metadata(id):
     """ Get metadata about a simulator
 
@@ -67,3 +76,120 @@ def get_simulator_metadata(id):
         },
         'specs': 'https://api.biosimulators.org/simulators/{}/{}'.format(id, version),
     }
+
+
+def use_simulator_api_to_exec_sedml_docs_in_combine_archive(api_name,
+                                                            archive_filename, out_dir,
+                                                            return_results=False,
+                                                            report_formats=None,
+                                                            plot_formats=None,
+                                                            bundle_outputs=None,
+                                                            keep_individual_outputs=None,
+                                                            raise_exceptions=True,
+                                                            **kwargs):
+    """ Execute the SED tasks defined in a COMBINE/OMEX archive and save the outputs
+
+    Args:
+        api (:obj:`str`): module which implements the API for the simulator
+        archive_filename (:obj:`str`): path to COMBINE/OMEX archive
+        out_dir (:obj:`str`): path to store the outputs of the archive
+
+            * CSV: directory in which to save outputs to files
+              ``{ out_dir }/{ relative-path-to-SED-ML-file-within-archive }/{ report.id }.csv``
+            * HDF5: directory in which to save a single HDF5 file (``{ out_dir }/reports.h5``),
+              with reports at keys ``{ relative-path-to-SED-ML-file-within-archive }/{ report.id }`` within the HDF5 file
+
+        return_results (:obj:`bool`, optional): whether to return the result of each output of each SED-ML file
+        report_formats (:obj:`list` of :obj:`ReportFormat`, optional): report format (e.g., csv or h5)
+        plot_formats (:obj:`list` of :obj:`VizFormat`, optional): report format (e.g., pdf)
+        bundle_outputs (:obj:`bool`, optional): if :obj:`True`, bundle outputs into archives for reports and plots
+        keep_individual_outputs (:obj:`bool`, optional): if :obj:`True`, keep individual output files
+        raise_exceptions (:obj:`bool`, optional): whether to raise exceptions):
+
+    Returns:
+        : obj: `tuple`:
+
+            *: obj: `SedDocumentResults`: results
+            *: obj: `CombineArchiveLog`: log
+    """
+    api = get_simulator_api(api_name)
+    results, log = api.exec_sedml_docs_in_combine_archive(archive_filename, out_dir,
+                                                          return_results=return_results,
+                                                          report_formats=report_formats,
+                                                          plot_formats=plot_formats,
+                                                          bundle_outputs=bundle_outputs,
+                                                          keep_individual_outputs=keep_individual_outputs,
+                                                          raise_exceptions=raise_exceptions,
+                                                          **kwargs)
+    return results, log.to_json()
+
+
+class Process(multiprocessing.context.ForkProcess):
+    """ Fork process which collects the exceptions of its child
+
+    Attributes:
+        _parent_conn (:obj:`multiprocessing.connection.Connection`): connection for the parent
+        _child_conn (:obj:`multiprocessing.connection.Connection`): connection for the child
+        _exception (:obj:`Exception` or :obj:`None`): exception, if any, from the process' child
+
+    Inspired by https: // stackoverflow.com/questions/19924104/
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(multiprocessing.context.ForkProcess, self).__init__(*args, **kwargs)
+        self._parent_conn, self._child_conn = multiprocessing.Pipe()
+        self._exception = None
+
+    def run(self):
+        """ Run the process """
+        try:
+            super(multiprocessing.context.ForkProcess, self).run()
+            self._child_conn.send(None)
+        except Exception as exception:
+            self._child_conn.send(exception.with_traceback(sys.exc_info()[2]))
+
+    @property
+    def exception(self):
+        """ Get the exception from process' child, if any
+
+        Returns:
+            :obj:`Exception` or :obj:`None`: exception, if any, from the process' child
+        """
+        if self._parent_conn.poll():
+            self._exception = self._parent_conn.recv()
+        return self._exception
+
+
+def exec_in_subprocess(func, *args, **kwargs):
+    """ Execute a function in a fork
+
+    Args:
+        func (:obj:`types.FunctionType`): function
+        args (:obj:`list`): list of positional arguments for the function
+        kwargs (:obj:`dict`): dictionary of keyword arguments for the function
+
+    Returns:
+        :obj:`object`: result of the function
+    """
+    context_instance = multiprocessing.get_context('fork')
+    queue = context_instance.Queue()
+    process = Process(target=subprocess_target, args=[queue, func] + list(args), kwargs=kwargs)
+    process.start()
+    if process.exception:
+        raise process.exception
+    results = queue.get()
+    process.join()
+    return results
+
+
+def subprocess_target(queue, func, *args, **kwargs):
+    """ Target executer for a subprocess
+
+    Args:
+        queue (:obj:`multiprocessing.queues.Queue`): queue to send the results of the function to
+        func (:obj:`types.FunctionType`): function to execute
+        args (:obj:`list`): list of positional arguments for the function
+        kwargs (:obj:`dict`): dictionary of keyword arguments for the function
+    """
+    result = func(*args, **kwargs)
+    queue.put(result)

--- a/apps/combine-service/tests/run/test_run_run.py
+++ b/apps/combine-service/tests/run/test_run_run.py
@@ -4,7 +4,6 @@ from biosimulators_utils.log.data_model import Status
 from biosimulators_utils.report.io import ReportReader
 from biosimulators_utils.sedml.io import SedmlSimulationReader
 from src import app
-from src.handlers.run.utils import get_simulator_api
 from unittest import mock
 from werkzeug.datastructures import FileStorage, MultiDict
 import json

--- a/apps/combine-service/tests/run/test_run_utils.py
+++ b/apps/combine-service/tests/run/test_run_utils.py
@@ -17,6 +17,10 @@ class CombineUtilsTestCase(unittest.TestCase):
         })
 
     def test_get_simulator_api(self):
+        utils.exec_in_subprocess(self._test_get_simulator_api)
+
+    @staticmethod
+    def _test_get_simulator_api():
         import biosimulators_copasi
         api = utils.get_simulator_api('biosimulators_copasi')
-        self.assertEqual(api, biosimulators_copasi)
+        assert api is biosimulators_copasi


### PR DESCRIPTION
closes #2851 

In my testing, this fixtures two issues
- Inability to run all simulators within one Python environment due to segmentation fault from interaction between NEURON and PySCeS
- Memory usage

Improved behavior
- I can now execute tests for all simulators from one parent Python environment (the individual simulators are run in subprocesses)
- Memory appears to be lower
- CPU usage is likely a little higher
- Latency is is likely slower