### PR TITLE
chore: disabled /run endpoints on production

### DIFF
--- a/apps/combine-service/src/app.py
+++ b/apps/combine-service/src/app.py
@@ -12,7 +12,7 @@ config = {
     **dotenv_values("secret/secret.env"),
     **dotenv_values("config/config.env"),
 }
-env = config.get("ENV", 'dev') || 'dev'
+env = config.get("ENV", 'dev') or 'dev'
 
 # disable ``/run`` endpoints from production
 if env.lower() == 'prod':

--- a/apps/combine-service/src/app.py
+++ b/apps/combine-service/src/app.py
@@ -11,9 +11,9 @@ spec_filename = 'spec.yml'
 config = {
     **dotenv_values("secret/secret.env"),
     **dotenv_values("config/config.env"),
-        }
-env= config.get("ENV")
-                
+}
+env = config.get("ENV", 'dev') || 'dev'
+
 # disable ``/run`` endpoints from production
 if env.lower() == 'prod':
     with open(os.path.join(os.path.dirname(__file__), spec_dirname, spec_filename), 'r') as file:

--- a/apps/combine-service/src/app.py
+++ b/apps/combine-service/src/app.py
@@ -4,12 +4,18 @@ import connexion
 import os
 import tempfile
 import yaml
-
+from dotenv import dotenv_values
 spec_dirname = 'spec'
 spec_filename = 'spec.yml'
 
+config = {
+    **dotenv_values("secret/secret.env"),
+    **dotenv_values("config/config.env"),
+        }
+env= config.get("ENV")
+                
 # disable ``/run`` endpoints from production
-if os.environ.get('ENV', 'dev').lower() == 'prod':
+if env.lower() == 'prod':
     with open(os.path.join(os.path.dirname(__file__), spec_dirname, spec_filename), 'r') as file:
         specs = yaml.load(file, Loader=yaml.Loader)
 
@@ -33,7 +39,7 @@ app.add_api(spec_filename,
             validate_responses=False)
 
 # clean up temporary spec file for production
-if os.environ.get('ENV', 'dev').lower() == 'prod':
+if env.lower() == 'prod':
     os.remove(temp_spec_filename)
 
 # Validate_response = True will give error when API returns something that

--- a/apps/combine-service/src/app.py
+++ b/apps/combine-service/src/app.py
@@ -1,14 +1,41 @@
 from . import exceptions
 from flask_cors import CORS
 import connexion
+import os
+import tempfile
+import yaml
+
+spec_dirname = 'spec'
+spec_filename = 'spec.yml'
+
+# disable ``/run`` endpoints from production
+if os.environ.get('ENV', 'dev').lower() == 'prod':
+    with open(os.path.join(os.path.dirname(__file__), spec_dirname, spec_filename), 'r') as file:
+        specs = yaml.load(file, Loader=yaml.Loader)
+
+    for key in list(specs['paths'].keys()):
+        if key.startswith('/run/'):
+            specs['paths'].pop(key)
+
+    fid, temp_spec_filename = tempfile.mkstemp(dir=os.path.join(os.path.dirname(__file__), spec_dirname), suffix='.yml')
+    os.close(fid)
+    with open(temp_spec_filename, 'w') as file:
+        file.write(yaml.dump(specs))
+
+    spec_filename = os.path.basename(temp_spec_filename)
 
 # Instantiate app from specs
-app = connexion.App(__name__, specification_dir='spec')
+app = connexion.App(__name__, specification_dir=spec_dirname)
 
 # Setup handlers for APIs
-app.add_api('spec.yml',
+app.add_api(spec_filename,
             strict_validation=True,
             validate_responses=False)
+
+# clean up temporary spec file for production
+if os.environ.get('ENV', 'dev').lower() == 'prod':
+    os.remove(temp_spec_filename)
+
 # Validate_response = True will give error when API returns something that
 # does not match the schema. If you want to send a response even if invalid,
 # set to false. Set to false in production if optimistic that client can


### PR DESCRIPTION
This removes the `/run` endpoints from production deployment. Hopefully this will clear up the performance issue. If not, the problem must be with the Python environment inside the Docker image. In that case, there aren't many options except not to include the simulators in the Python environment, in which case we won't be able to run simulations.

@bilalshaikh42 will the following enable me to detect the deployment environment (i.e., will the value of the `ENV` environment variable be `dev` for deployment and `prod` for production)?

```python
os.environ.get('ENV', 'dev').lower() == 'prod'
```