### PR TITLE
feat(dispatch-service): added passing software licenses from deployment secrets to Singularity run

### DIFF
--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -41,24 +41,16 @@ export class SbatchService {
       apiDomain = 'https://run.api.biosimulations.dev/';
     }
 
-    const singularityRunEnvVars: EnvironmentVariable[] = Object.entries(process.env as {[key: string]: string})
-      .filter((keyVal: [string, string]): boolean => {
-        return keyVal[0].startsWith('SINGULARITY_RUN_ENV_VAR_');
-      })
-      .map((keyVal: [string, string]): EnvironmentVariable => {
-        return {
-          key: keyVal[0].substr('SINGULARITY_RUN_ENV_VAR_'.length),
-          value: keyVal[1],
-        };
-      });
+    const singularityRunEnvVars = this.configService.get('singularity.envVars');
+
     const allEnvVars = envVars.concat(singularityRunEnvVars);
     const allEnvVarsString = allEnvVars
-          .map((envVar: EnvironmentVariable): string => {
-            const key = envVar.key.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
-            const val = envVar.value.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
-            return `${key}=${val}`;
-          })
-          .join(',');
+      .map((envVar: EnvironmentVariable): string => {
+        const key = envVar.key.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
+        const val = envVar.value.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
+        return `${key}=${val}`;
+      })
+      .join(',');
 
     const template = `#!/bin/bash
 #SBATCH --job-name=${simId}_Biosimulations

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -41,16 +41,24 @@ export class SbatchService {
       apiDomain = 'https://run.api.biosimulations.dev/';
     }
 
-    const envString = envVars.length
-      ? '--env ' +
-        envVars
+    const singularityRunEnvVars: EnvironmentVariable[] = Object.entries(process.env as {[key: string]: string})
+      .filter((keyVal: [string, string]): boolean => {
+        return keyVal[0].startsWith('SINGULARITY_RUN_ENV_VAR_');
+      })
+      .map((keyVal: [string, string]): EnvironmentVariable => {
+        return {
+          key: keyVal[0].substr('SINGULARITY_RUN_ENV_VAR_'.length),
+          value: keyVal[1],
+        };
+      });
+    const allEnvVars = envVars.concat(singularityRunEnvVars);
+    const allEnvVarsString = allEnvVars
           .map((envVar: EnvironmentVariable): string => {
             const key = envVar.key.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
             const val = envVar.value.replace(/([^a-zA-Z0-9,._+@%/-])/, '\\$&');
             return `${key}=${val}`;
           })
-          .join(',')
-      : '';
+          .join(',');
 
     const template = `#!/bin/bash
 #SBATCH --job-name=${simId}_Biosimulations
@@ -74,7 +82,7 @@ cd ${tempSimDir}
 echo -e '${cyan}=============Downloading Combine Archive=============${nc}'
 ( ulimit -f 1048576; srun wget --progress=bar:force ${apiDomain}run/${simId}/download -O '${omexName}')
 echo -e '${cyan}=============Running docker image for simulator=============${nc}'
-srun singularity run --tmpdir /local --bind ${tempSimDir}:/root "${envString}" ${simulator} -i '/root/${omexName}' -o '/root'
+srun singularity run --tmpdir /local --bind ${tempSimDir}:/root --env "${allEnvVarsString}" ${simulator} -i '/root/${omexName}' -o '/root'
 echo -e '${cyan}=============Uploading results to data-service=============${nc}'
 srun hsload -v reports.h5 '/results/${simId}'
 echo -e '${cyan}=============Creating output archive=============${nc}'

--- a/libs/config/nest/src/lib/biosimulations-config.module.ts
+++ b/libs/config/nest/src/lib/biosimulations-config.module.ts
@@ -11,6 +11,7 @@ import urlsConfig from './biosimulations-urls-config';
 import storageConfig from './biosimulations-storage-config';
 import queueConfig from './biosimulations-queue-config';
 import dataConfig from './biosimulations-data-config';
+import singularityConfig from './singularity-config';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import dataConfig from './biosimulations-data-config';
         storageConfig,
         queueConfig,
         dataConfig,
+        singularityConfig,
       ],
       envFilePath: [
         './shared/shared.env',

--- a/libs/config/nest/src/lib/singularity-config.ts
+++ b/libs/config/nest/src/lib/singularity-config.ts
@@ -1,0 +1,19 @@
+import { registerAs } from '@nestjs/config';
+import { EnvironmentVariable } from '@biosimulations/datamodel/common';
+
+export default registerAs('singularity', () => {
+  const singularityRunEnvVars: EnvironmentVariable[] = Object.entries(
+    process.env as { [key: string]: string },
+  )
+    .filter((keyVal: [string, string]): boolean => {
+      return keyVal[0].startsWith('SINGULARITY_RUN_ENV_VAR_');
+    })
+    .map((keyVal: [string, string]): EnvironmentVariable => {
+      return {
+        key: keyVal[0].substr('SINGULARITY_RUN_ENV_VAR_'.length),
+        value: keyVal[1],
+      };
+    });
+
+  return { envVars: singularityRunEnvVars };
+});

--- a/libs/config/nest/src/lib/singularity-config.ts
+++ b/libs/config/nest/src/lib/singularity-config.ts
@@ -1,5 +1,9 @@
 import { registerAs } from '@nestjs/config';
-import { EnvironmentVariable } from '@biosimulations/datamodel/common';
+
+interface EnvironmentVariable {
+  key: string;
+  value: string;
+}
 
 export default registerAs('singularity', () => {
   const singularityRunEnvVars: EnvironmentVariable[] = Object.entries(


### PR DESCRIPTION
Closes #2973 

I prefixed secrets to be passed to Singularity run with `SINGULARITY_RUN_ENV_VAR_`. These prefixes are stripped before being passed to Singularity run. Thus, new software licenses can be passed to Singularity run simply by adding environment variables with the above prefix to the `secrets` repository.