### PR TITLE
feat(dispatch-api): extract files to s3 and replace combine archive file extraction endpoint

### DIFF
--- a/apps/dispatch-api/src/metadata/metadata.service.ts
+++ b/apps/dispatch-api/src/metadata/metadata.service.ts
@@ -61,11 +61,9 @@ export class MetadataService {
         if (thumbnails.length > 0) {
           archiveMetadata.thumbnails = thumbnails.map((thumbnail: string) => {
             if (thumbnail.startsWith('./')) {
-              // TODO change url of file on S3
-              const endpoint = this.endpoints.getCombineFilesEndpoint(
-                this.endpoints.getRunDownloadEndpoint(data.id, true),
+              const endpoint = this.endpoints.getSimulationRunFileEndpoint(
+                data.id,
                 thumbnail,
-                true,
               );
 
               return endpoint;
@@ -80,7 +78,6 @@ export class MetadataService {
     data.metadata = transformData;
 
     const metadata = new this.metadataModel(data);
-
     return await metadata.save();
   }
 }

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -81,7 +81,9 @@ export SINGULARITY_PULLFOLDER=${homeDir}/singularity/images/
 cd ${tempSimDir}
 echo -e '${cyan}=============Downloading Combine Archive=============${nc}'
 ( ulimit -f 1048576; srun wget --progress=bar:force ${apiDomain}run/${simId}/download -O '${omexName}')
-echo -e '${cyan}=============Running docker image for simulator=============${nc}'
+echo -e '${cyan}=============Extracting Combine Archive==============${nc}'
+unzip -o ${omexName} -d contents
+echo -e '${cyan}=================Running simulation==================${nc}'
 srun singularity run --tmpdir /local --bind ${tempSimDir}:/root "${allEnvVarsString}" ${simulator} -i '/root/${omexName}' -o '/root'
 echo -e '${cyan}=============Uploading results to data-service=============${nc}'
 srun hsload -v reports.h5 '/results/${simId}'

--- a/apps/platform/src/app/projects/projects.service.ts
+++ b/apps/platform/src/app/projects/projects.service.ts
@@ -14,8 +14,7 @@ export class ProjectsService {
   constructor(private http: HttpClient) {}
 
   public getProjectFile(id: string, file: string) {
-    const archiveUrl = this.endpoints.getRunDownloadEndpoint(id, true);
-    const url = this.endpoints.getCombineFilesEndpoint(archiveUrl, file);
+    const url = this.endpoints.getSimulationRunFileEndpoint(id, file);
     return this.http.get(url);
   }
   public getArchiveContents(id: string): Observable<any> {


### PR DESCRIPTION
The combine archive is extracted to the s3 bucket, giving a url in the files domain. The thumbnails
and project files url are updated to directly point to the file rather than point to the combine
service

closes #2945

