### PR TITLE
fix(api): add permissions to get all specs

### DIFF
--- a/apps/api/src/specifications/specifications.controller.ts
+++ b/apps/api/src/specifications/specifications.controller.ts
@@ -11,6 +11,7 @@ import { ApiTags } from '@nestjs/swagger';
 import { SimulationRunSpecifications } from '@biosimulations/datamodel/api';
 import { SpecificationsService } from './specifications.service';
 import { SpecificationsModel } from './specifications.model';
+import { permissions } from '@biosimulations/auth/nest';
 @ApiTags('Specifications')
 @Controller('specifications')
 export class SpecificationsController {
@@ -19,6 +20,7 @@ export class SpecificationsController {
   public constructor(private service: SpecificationsService) {}
 
   @Get()
+  @permissions('read:Specifications')
   public async getSpecifications(): Promise<SimulationRunSpecifications[]> {
     const specs = await this.service.getSpecifications();
     return specs.map(this.returnSpec);


### PR DESCRIPTION
add 'read:Specifications' requirement to get all specs to prevent private simulations from being
displayed

closes #3136

**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* Adds ABC (closes #X)
* Adds XYZ (closes #X)

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* Fixes ABC (closes #X)
* Fixes XYZ (closes #X)

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* Corrects typos in documentation
* Changes theme of documentation

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* Added test for ABC
* Added test for XYZ

**Additional information**
Please describe any information needed to review this PR.
