### PR TITLE
test(api): fixed tests for SED-ML specs controller

### DIFF
--- a/apps/api/src/specifications/specifications.controller.spec.ts
+++ b/apps/api/src/specifications/specifications.controller.spec.ts
@@ -1,6 +1,9 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SpecificationsController } from './specifications.controller';
 import { SpecificationsService } from './specifications.service';
+import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
+import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
 
 describe('SpecificationsController', () => {
   let controller: SpecificationsController;
@@ -8,6 +11,11 @@ describe('SpecificationsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SpecificationsController],
+      imports: [
+        BiosimulationsAuthModule,
+        BiosimulationsConfigModule,
+        SharedNatsClientModule,
+      ],
       providers: [{ provide: SpecificationsService, useValue: {} }],
     }).compile();
 


### PR DESCRIPTION
Fixes failing test

```
FAIL api apps/api/src/specifications/specifications.controller.spec.ts
  ● SpecificationsController › should be defined

    Nest can't resolve dependencies of the PermissionsGuard (Reflector, ?). Please make sure that the argument AdminGuard at index [1] is available in the RootTestModule context.

    Potential solutions:
    - If AdminGuard is a provider, is it part of the current RootTestModule?
    - If AdminGuard is exported from a separate @Module, is that module imported within RootTestModule?
      @Module({
        imports: [ /* the Module containing AdminGuard */ ]
      })

      at Injector.lookupComponentInParentModules (../../node_modules/@nestjs/core/injector/injector.js:193:19)
      at Injector.resolveComponentInstance (../../node_modules/@nestjs/core/injector/injector.js:149:33)
      at resolveParam (../../node_modules/@nestjs/core/injector/injector.js:103:38)
          at async Promise.all (index 1)
      at Injector.resolveConstructorParams (../../node_modules/@nestjs/core/injector/injector.js:118:27)
      at Injector.loadInstance (../../node_modules/@nestjs/core/injector/injector.js:47:9)
      at Injector.loadInjectable (../../node_modules/@nestjs/core/injector/injector.js:65:9)
          at async Promise.all (index 1)
      at InstanceLoader.createInstancesOfInjectables (../../node_modules/@nestjs/core/injector/instance-loader.js:62:9)
      at ../../node_modules/@nestjs/core/injector/instance-loader.js:30:13
          at async Promise.all (index 1)
      at InstanceLoader.createInstances (../../node_modules/@nestjs/core/injector/instance-loader.js:28:9)
      at InstanceLoader.createInstancesOfDependencies (../../node_modules/@nestjs/core/injector/instance-loader.js:18:9)
      at TestingModuleBuilder.compile (../../node_modules/@nestjs/testing/testing-module.builder.js:43:9)
```