### PR TITLE
refactor(platform): added tool to publish example

### DIFF
--- a/tools/example-projects.json
+++ b/tools/example-projects.json
@@ -60,7 +60,7 @@
     "filename": "rba/Escherichia-coli-K12-WT.omex",
     "disabled": false,
     "publishToBioSimulations": true,
-    "bioSimulationsId": ""
+    "bioSimulationsId": "Escherichia-coli-resource-allocation-Bulovic-Metab-Eng-2019"
   },
   {
     "name": "Heat shock protein synthesis (Szymanska et al., J Theor Biol, 2009; SBML; CVODES; AMICI)",

--- a/tools/publish-example-projects
+++ b/tools/publish-example-projects
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import requests
+import requests.exceptions
+
+EXAMPLE_SIMULATIONS_FILENAME = os.path.join(os.path.dirname(__file__), 'example-projects.json')
+
+EXAMPLE_SIMULATIONS_RUNS_FILENAME = os.path.join(os.path.dirname(__file__),
+                                                 '..', 'apps', 'dispatch', 'src', 'app', 'components',
+                                                 'simulations', 'browse', 'example-simulations.{}.json')
+
+BIOSIMULATIONS_API_AUTH_ENDPOINT = 'https://auth.biosimulations.org/oauth/token'
+BIOSIMULATIONS_API_AUDIENCE = 'dispatch.biosimulations.org'
+BIOSIMULATIONS_API_CLIENT_ID = os.getenv('BIOSIMULATIONS_API_CLIENT_ID')
+BIOSIMULATIONS_API_CLIENT_SECRET = os.getenv('BIOSIMULATIONS_API_CLIENT_SECRET')
+
+
+def get_status_endpoint(biosimulations_api):
+    """ Get the endpoint for getting the status of runs
+
+    Args:
+        biosimulations_api (:obj:`str`): which deployment of the BioSimulations API to use (``dev``, ``org``, or ``local``)
+
+    Returns:
+        :obj:`str`: endpoint for getting the status of runs
+    """
+    if biosimulations_api == 'local':
+        return 'http://localhost:3333/runs'
+
+    return 'https://api.biosimulations.{}/runs'.format(biosimulations_api)
+
+
+def get_publish_endpoint(biosimulations_api):
+    """ Get the endpoint for publishing projects
+
+    Args:
+        biosimulations_api (:obj:`str`): which deployment of the BioSimulations API to use (``dev``, ``org``, or ``local``)
+
+    Returns:
+        :obj:`str`: endpoint for publishing projects
+    """
+    if biosimulations_api == 'local':
+        return 'http://localhost:3333/runs'
+
+    return 'https://api.biosimulations.{}/projects'.format(biosimulations_api)
+
+
+def did_run_succeed(biosimulations_api, id):
+    """ Check if a simulation run succeeded
+
+    Args:
+        biosimulations_api (:obj:`str`): which deployment of the BioSimulations API to use (``dev``, ``org``, or ``local``)
+        id (:obj:`str`): id of simulation run
+
+    Returns:
+        :obj:`bool`: whether the simulation run succeeded
+    """
+    response = requests.get(get_status_endpoint(biosimulations_api) + '/' + id)
+    response.raise_for_status()
+    return response.json()['status'] == 'SUCCEEDED'
+
+
+def get_auth_headers_for_biosimulations_api():
+    """ Get authorization headers for using the BioSimulations REST API.
+
+    Returns:
+        :obj:`dict`: authorization headers
+    """
+    response = requests.post(BIOSIMULATIONS_API_AUTH_ENDPOINT, json={
+        'client_id': BIOSIMULATIONS_API_CLIENT_ID,
+        'client_secret': BIOSIMULATIONS_API_CLIENT_SECRET,
+        'audience': BIOSIMULATIONS_API_AUDIENCE,
+        "grant_type": "client_credentials",
+    })
+    response.raise_for_status()
+    response_data = response.json()
+    return {'Authorization': response_data['token_type'] + ' ' + response_data['access_token']}
+
+
+def main(biosimulations_api, example_names, dry_run=False):
+    """ Publish example project to BioSimulations
+
+    Args:
+        biosimulations_api (:obj:`str`): which deployment of the BioSimulations API to use (``dev``, ``org``, or ``local``)
+        example_names (:obj:`list` of :obj:`str`): names of examples to publish. Default: publish all examples.
+        dry_run (:obj:`bool`, optional): If :obj:`True`, do not submit simulations to runBioSimulations
+    """
+
+    # read examples
+    with open(EXAMPLE_SIMULATIONS_FILENAME, 'r') as file:
+        examples = json.load(file)
+    num_total_examples = len(examples)
+
+    # filter out examples that shouldn't be published
+    examples = list(filter(
+        lambda example:
+        example['publishToBioSimulations'],
+        examples))
+
+    # filter to selected examples
+    if example_names:
+        examples = list(
+            filter(lambda example: example['name'] in example_names, examples))
+
+        missing_example_names = set(example_names).difference(
+            set(example['name'] for example in examples))
+        if missing_example_names:
+            raise ValueError('No examples have the following names:\n  - {}'.format(
+                '\n  - '.join(sorted(missing_example_names))))
+
+    # get runs
+    with open(EXAMPLE_SIMULATIONS_RUNS_FILENAME.format(biosimulations_api), 'r') as file:
+        runs = {run['name']: run for run in json.load(file)}
+
+    # filter out examples that don't have runs
+    examples = list(filter(
+        lambda example:
+        example['name'] in runs,
+        examples))
+
+    # filter out examples whose runs didn't succeed
+    examples = list(filter(
+        lambda example:
+        did_run_succeed(biosimulations_api, runs[example['name']]['id']),
+        examples))
+
+    # publish examples
+    auth_headers = get_auth_headers_for_biosimulations_api()
+    created = []
+    updated = []
+    for example in examples:
+        run = runs[example['name']]
+
+        if not example['bioSimulationsId']:
+            raise ValueError('{} must provide a BioSimulations id'.format(example['name']))
+
+        response = requests.get(get_publish_endpoint(biosimulations_api) + '/' + example['bioSimulationsId'])
+        try:
+            response.raise_for_status()
+            if run['id'] == response.json()['simulationRun']:
+                continue
+
+            method = requests.put
+            endpoint = get_publish_endpoint(biosimulations_api) + '/' + example['bioSimulationsId']
+            updated.append(example['name'])
+        except requests.exceptions.RequestException:
+            method = requests.post
+            endpoint = get_publish_endpoint(biosimulations_api)
+            created.append(example['name'])
+
+        if not dry_run:
+            response = method(
+                endpoint,
+                headers=auth_headers,
+                json={
+                    "id": example['bioSimulationsId'],
+                    "simulationRun": run['id'],
+                })
+            response.raise_for_status()
+
+    print('{} examples were created{}'.format(len(created), ''.join('\n  ' + example for example in created)))
+    print('{} examples were updated{}'.format(len(updated), ''.join('\n  ' + example for example in updated)))
+    print('{} examples were already published'.format(len(examples) - (len(created) + len(updated))))
+    print('{} examples were skipped'.format(num_total_examples - len(examples)))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Publish the example simulation runs to BioSimulations.'
+    )
+    parser.add_argument(
+        '--biosimulations-api', type=str, default='dev',
+        help='BioSimulations API which projects should be published to (`dev`, `org`, `local`). Default: `dev`.'
+    )
+    parser.add_argument(
+        '--example', type=str, nargs='*',
+        help='Names of the example projects to publish. Default: publish all projects.',
+        default=None,
+        dest='example_names',
+    )
+    parser.add_argument(
+        '--dry-run',
+        help='If set, do not publish simulations to BioSimulations',
+        action='store_true',
+
+    )
+    args = parser.parse_args()
+
+    main(biosimulations_api=args.biosimulations_api,
+         example_names=args.example_names,
+         dry_run=args.dry_run)

--- a/tools/submit-example-simulation-runs
+++ b/tools/submit-example-simulation-runs
@@ -17,7 +17,7 @@ GET_SIMULATORS_ENDPOINT = 'https://api.biosimulators.{}/simulators/latest'
 
 EXAMPLE_COMBINE_ARCHIVES_BASE_URL = 'https://github.com/biosimulators/Biosimulators_test_suite/raw/{}/examples/'
 
-EXAMPLE_SIMULATIONS_FILENAME = __file__ + '.json'
+EXAMPLE_SIMULATIONS_FILENAME = os.path.join(os.path.dirname(__file__), 'example-projects.json')
 
 EXAMPLE_SIMULATIONS_RUNS_FILENAME = os.path.join(os.path.dirname(__file__),
                                                  '..', 'apps', 'dispatch', 'src', 'app', 'components',
@@ -45,17 +45,17 @@ def get_submit_endpoint(runbiosimulations_api):
 
 
 def main(runbiosimulations_api='dev', biosimulators_api='org',
-         biosimulators_test_suite_branch='deploy', simulation_names=None,
+         biosimulators_test_suite_branch='deploy', example_names=None,
          test_mode=False, browser=False, dry_run=False):
     """ Submit example simulations from the BioSimulators test suite to the runBioSimulations API and
     record their runs to ``example-simulations.json`` within the browse simulations module of the
     dispatch app so that users can load runs of these simulations as examples.
 
     Args:
-        runbiosimulations_api (:obj:`str`): which deployment of the runBioSimulations API to use (``dev`` or ``org``)
+        runbiosimulations_api (:obj:`str`): which deployment of the runBioSimulations API to use (``dev``, ``org``, or ``local``)
         biosimulators_api (:obj:`str`): which deployment of the BioSimulators API to use (``dev`` or ``org``)
         biosimulators_test_suite_branch (:obj:`str`): branch of the BioSimulators test suite to use (e.g., ``deploy`` or ``dev``).
-        simulation_names (:obj:`list` of :obj:`str`): filenames of example simulations to execute. Default: execute all examples.
+        example_names (:obj:`list` of :obj:`str`): names of example simulations to execute. Default: execute all examples.
         test_mode (:obj:`bool`, optional): whether to run this program in test mode
         browser (:obj:`bool`, optional): whether to open the simulations in a browser
         dry_run (:obj:`bool`, optional): If :obj:`True`, do not submit simulations to runBioSimulations
@@ -86,20 +86,20 @@ def main(runbiosimulations_api='dev', biosimulators_api='org',
         simulations))
 
     # filter to selected simulations
-    if simulation_names:
+    if example_names:
         simulations = list(
-            filter(lambda simulation: simulation['name'] in simulation_names, simulations))
+            filter(lambda simulation: simulation['name'] in example_names, simulations))
 
-        missing_simulation_names = set(simulation_names).difference(
+        missing_example_names = set(example_names).difference(
             set(simulation['name'] for simulation in simulations))
-        if missing_simulation_names:
-            raise ValueError('No example simulations have the following names:\n  - {}'.format(
-                '\n  - '.join(sorted(missing_simulation_names))))
+        if missing_example_names:
+            raise ValueError('No examples have the following names:\n  - {}'.format(
+                '\n  - '.join(sorted(missing_example_names))))
 
     # execution simulations
     temp_dir = tempfile.mkdtemp()
     new_simulation_runs = []
-    if simulation_names:
+    if example_names:
         with open(EXAMPLE_SIMULATIONS_RUNS_FILENAME.format(runbiosimulations_api), 'r') as file:
             simulation_runs = {run['name']: run for run in json.load(file)}
 
@@ -288,7 +288,7 @@ if __name__ == '__main__':
         description='Submit the example simulations to the runBioSimulations API and save their runs to the dispatch app.')
     parser.add_argument(
         '--runbiosimulations-api', type=str, default='dev',
-        help='runBioSimulations API which simulations should be submitted to (`dev`, `org`). Default: `dev`.')
+        help='runBioSimulations API which simulations should be submitted to (`dev`, `org`, `local`). Default: `dev`.')
     parser.add_argument(
         '--biosimulators-api', type=str, default='org',
         help=('BioSimulators API which should be used to select the version of each simulation tool used '
@@ -298,9 +298,9 @@ if __name__ == '__main__':
         help=('Branch of the BioSimulators test suite from which the example COMBINE/OMEX archives should be obtained. '
               'Default: `deploy`.'))
     parser.add_argument(
-        '--simulation', type=str, nargs='*',
+        '--example', type=str, nargs='*',
         help='Names of the example simulations to execute. Default: execute all simulations.',
-        default=None, dest='simulation_names',
+        default=None, dest='example_names',
 
     )
     parser.add_argument(
@@ -326,7 +326,7 @@ if __name__ == '__main__':
     main(runbiosimulations_api=args.runbiosimulations_api,
          biosimulators_api=args.biosimulators_api,
          biosimulators_test_suite_branch=args.biosimulators_test_suite_branch,
-         simulation_names=args.simulation_names,
+         example_names=args.example_names,
          test_mode=args.test_mode,
          browser=args.browser,
          dry_run=args.dry_run)

--- a/tools/submit-example-simulation-runs.json
+++ b/tools/submit-example-simulation-runs.json
@@ -1,282 +1,320 @@
-[
-  {
+[{
     "name": "Budding yeast cell cycle (Irons, J Theor Biol, 2009; SBML-qual; BoolNet; synchronous)",
     "simulator": "boolnet",
     "filename": "sbml-qual/Irons-J-Theor-Biol-2009-yeast-cell-cycle.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Budding yeast cell cycle (Irons, J Theor Biol, 2009; SBML-qual; GINsim; synchronous)",
     "simulator": "ginsim",
     "filename": "sbml-qual/Irons-J-Theor-Biol-2009-yeast-cell-cycle.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Yeast-cell-cycle-Irons-J-Theor-Biol-2009"
   },
   {
     "name": "Circadian clock (Vilar et al., PNAS, 2002; SBML; NRM; VCell)",
     "simulator": "vcell",
-    "filename": "sbml-core/Vilar-PNAS-2002-minimal-circardian-clock-discrete-NRM.omex",
+    "filename": "sbml-core/Vilar-PNAS-2002-minimal-circardian-clock.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Minimal-circardian-clock-Vilar-PNAS-2002"
   },
   {
     "name": "EGF and TNFα signaling (Chaouiya et al., BMC Syst Biol, 2013; SBML-qual; synchronous updating; BoolNet)",
     "simulator": "boolnet",
     "filename": "sbml-qual/Chaouiya-BMC-Syst-Biol-2013-EGF-TNFa-signaling.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "EGF and TNFα signaling (Chaouiya et al., BMC Syst Biol, 2013; SBML-qual; synchronous updating; GINsim)",
     "simulator": "ginsim",
     "filename": "sbml-qual/Chaouiya-BMC-Syst-Biol-2013-EGF-TNFa-signaling.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "EGF-TNFa-signaling-Chaouiya-BMC-Syst-Biol-2013"
   },
   {
     "name": "Escherichia coli core metabolism (COBRApy Team; SBML-fbc; FBA; CBMPy)",
     "simulator": "cbmpy",
     "filename": "sbml-fbc/Escherichia-coli-core-metabolism.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Escherichia coli core metabolism (COBRApy Team; SBML-fbc; FBA; COBRApy)",
     "simulator": "cobrapy",
     "filename": "sbml-fbc/Escherichia-coli-core-metabolism.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Escherichia-coli-core-metabolism-textbook"
   },
   {
     "name": "Escherichia coli resource allocation (Bulović et al., Metab Eng, 2019; RBA TSV/XML; RBA; RBApy)",
     "simulator": "rbapy",
     "filename": "rba/Escherichia-coli-K12-WT.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": ""
   },
   {
     "name": "Heat shock protein synthesis (Szymanska et al., J Theor Biol, 2009; SBML; CVODES; AMICI)",
     "simulator": "amici",
     "filename": "sbml-core/Szymanska-J-Theor-Biol-2009-HSP-synthesis.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "HSP-synthesis-Szymanska-J-Theor-Biol-2009"
   },
   {
     "name": "Hodgkin-Huxley cell (Gleeson; NeuroML/LEMS; CVODE; NetPyNe)",
     "simulator": "netpyne",
     "filename": "neuroml-lems/Hodgkin-Huxley-cell-CVODE.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Hodgkin-Huxley cell (Gleeson; NeuroML/LEMS; CVODE; Neuron)",
     "simulator": "neuron",
     "filename": "neuroml-lems/Hodgkin-Huxley-cell-CVODE.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Hodgkin-Huxley cell (Gleeson; NeuroML/LEMS; Euler; pyNeuroML)",
     "simulator": "pyneuroml",
     "filename": "neuroml-lems/Hodgkin-Huxley-cell-Euler.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Hodgkin-Huxley-cell-Gleeson"
   },
   {
     "name": "Iron distribution (Parmar et al., BMC Syst Biol, 2017; SBML; CVODE; PySCeS)",
     "simulator": "pysces",
     "filename": "sbml-core/Parmar-BMC-Syst-Biol-2017-iron-distribution.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Iron distribution (Parmar et al., BMC Syst Biol, 2017; SBML; CVODE; VCell)",
     "simulator": "vcell",
     "filename": "sbml-core/Parmar-BMC-Syst-Biol-2017-iron-distribution.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Iron distribution (Parmar et al., BMC Syst Biol, 2017; SBML; CVODE; tellurium)",
     "simulator": "tellurium",
     "filename": "sbml-core/Parmar-BMC-Syst-Biol-2017-iron-distribution.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Iron-distribution-Parmar-BMC-Syst-Biol-2017"
   },
   {
     "name": "Lorenz system (Garny; CellML; CVODE; OpenCOR)",
     "simulator": "opencor",
     "filename": "cellml/Lorenz-system.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Lorenz-system-Garny"
   },
   {
     "name": "Lotka-Volterra model (Andrews; Smoldyn; Smoluchowski method)",
     "simulator": "smoldyn",
     "filename": "smoldyn/Lotka-Volterra.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Lotka-Volterra-Andrews"
   },
   {
     "name": "Morphogenesis checkpoint (Ciliberto et al., J Cell Biol, 2003; SBML; CVODE; PySCeS)",
     "simulator": "pysces",
     "filename": "sbml-core/Ciliberto-J-Cell-Biol-2003-morphogenesis-checkpoint-continuous.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Morphogenesis checkpoint (Ciliberto et al., J Cell Biol, 2003; SBML; CVODE; VCell)",
     "simulator": "vcell",
     "filename": "sbml-core/Ciliberto-J-Cell-Biol-2003-morphogenesis-checkpoint-continuous.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false
   },
   {
     "name": "Morphogenesis checkpoint (Ciliberto et al., J Cell Biol, 2003; SBML; CVODE; tellurium)",
     "simulator": "tellurium",
     "filename": "sbml-core/Ciliberto-J-Cell-Biol-2003-morphogenesis-checkpoint-continuous.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Morphogenesis-checkpoint-continuous-Ciliberto-J-Cell-Biol-2003"
   },
   {
     "name": "Morphogenesis checkpoint (Ciliberto et al., J Cell Biol, 2003; SBML; Fehlberg; LibSBMLSim)",
     "simulator": "libsbmlsim",
     "filename": "sbml-core/Ciliberto-J-Cell-Biol-2003-morphogenesis-checkpoint-Fehlberg.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "mTOR signaling (Varusai & Nguyen, Sci Rep, 2018; SBML; LSODA/LSODAR; COPASI)",
     "simulator": "copasi",
     "filename": "sbml-core/Varusai-Sci-Rep-2018-mTOR-signaling-LSODA-LSODAR-SBML.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "mTOR-signaling-Varusai-Sci-Rep-2018"
   },
   {
     "name": "NFAT translocation (Tomida et al., EMBO J, 2003; SBML; LSODA/LSODAR; COPASI)",
     "simulator": "copasi",
     "filename": "sbml-core/Tomida-EMBO-J-2003-NFAT-translocation.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "NFAT-translocation-Tomida-EMBO-J-2003"
   },
   {
     "name": "Nicotinic excitatory post-synaptic potential (Edelstein et al., Biological Cybernetics, 1996; SBML; LSODA; GillesPy2)",
     "simulator": "gillespy2",
     "filename": "sbml-core/Edelstein-Biol-Cybern-1996-Nicotinic-excitation.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Nicotinic-excitation-Edelstein-Biol-Cybern-1996"
   },
   {
     "name": "Nicotinic excitatory post-synaptic potential (Edelstein et al., Biological Cybernetics, 1996; SBML; LSODA; PySCeS)",
     "simulator": "pysces",
     "filename": "sbml-core/Edelstein-Biol-Cybern-1996-Nicotinic-excitation.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Non-homologous end joining (Dolan et al., PLoS Comput Biol, 2020; BNGL; NFSim; BioNetGen)",
     "simulator": "bionetgen",
     "filename": "bngl/Dolan-PLoS-Comput-Biol-2015-NHEJ.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "NHEJ-Dolan-PLoS-Comput-Biol-2015"
   },
   {
     "name": "Pituitary GH(3) cells (Wu & Chang, Biochem Pharmacol, 2006; XPP; CVODE; XPP)",
     "simulator": "xpp",
     "filename": "xpp/Wu-Biochem-Pharmacol-2006-pituitary-GH3-cells.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Pituitary-GH3-cells-Wu-Biochem-Pharmacol-2006"
   },
   {
     "name": "RBC metabolism (Bordbar et al., Cell Syst, 2015; SBML-MASS; CVODE; MASSpy)",
     "simulator": "masspy",
     "filename": "mass/Bordbar-Cell-Syst-2015-RBC-metabolism.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "RBC-metabolism-Bordbar-Cell-Syst-2015"
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; CellML; CVODE; OpenCOR)",
     "simulator": "opencor",
     "filename": "cellml/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; CVODE; PySCeS)",
     "simulator": "pysces",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
     "disabled": "PySCeS' results aren't consistent with other tools",
-    "publishToBioSimulations": true
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; CVODE; tellurium)",
     "simulator": "tellurium",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; CVODE; VCell)",
     "simulator": "vcell",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; CVODES; AMICI)",
     "simulator": "amici",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; LSODA; GillesPy2)",
     "simulator": "gillespy2",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": "Cannot handle ln function"
+    "disabled": "Cannot handle ln function",
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; LSODA/LSODAR; COPASI)",
     "simulator": "copasi",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Repressilator-Elowitz-Nature-2000"
   },
   {
     "name": "Repressilator (Elowitz & Leibler, Nature, 2000; SBML; substituted; LibSBMLSim)",
     "simulator": "libsbmlsim",
     "filename": "sbml-core/Elowitz-Nature-2000-Repressilator.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Toy gene regulatory network (Saglam, 2020; BNGL; CVODE; BioNetGen)",
     "simulator": "bionetgen",
     "filename": "bngl/test-bngl.omex",
+    "disabled": false,
     "publishToBioSimulations": false,
-    "disabled": false
+    "bioSimulationsId": ""
   },
   {
     "name": "Tumor-suppressive oscillations (Caravagna et al., J Theor Biol, 2010; SBML; CVODE; PySCeS)",
     "simulator": "pysces",
     "filename": "sbml-core/Caravagna-J-Theor-Biol-2010-tumor-suppressive-oscillations.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Tumor-suppressive oscillations (Caravagna et al., J Theor Biol, 2010; SBML; CVODE; VCell)",
     "simulator": "vcell",
     "filename": "sbml-core/Caravagna-J-Theor-Biol-2010-tumor-suppressive-oscillations.omex",
-    "publishToBioSimulations": true,
-    "disabled": false
+    "disabled": false,
+    "publishToBioSimulations": false,
+    "bioSimulationsId": ""
   },
   {
     "name": "Tumor-suppressive oscillations (Caravagna et al., J Theor Biol, 2010; SBML; CVODE; tellurium)",
     "simulator": "tellurium",
     "filename": "sbml-core/Caravagna-J-Theor-Biol-2010-tumor-suppressive-oscillations.omex",
+    "disabled": false,
     "publishToBioSimulations": true,
-    "disabled": false
+    "bioSimulationsId": "Tumor-suppressive-oscillations-Caravagna-J-Theor-Biol-2010"
   }
 ]


### PR DESCRIPTION
- Indicated in which examples should be published and what ids to use in `tools/example-projects.json`
  - This avoids polluting our published projects with many versions of the same project with different simulation tools
- Added command-line program to update these published projects
- Presently requires a machine-to-machine api client and secret.