### PR TITLE
feat(api): add health module and endpoints

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -23,6 +23,8 @@ import { FilesModule } from '../files/files.module';
 import { SpecificationsModule } from '../specifications/specifications.module';
 import { ProjectsModule } from '../projects/projects.module';
 import * as redisStore from 'cache-manager-redis-store';
+import { HealthModule } from '../health/health.module';
+
 @Module({
   imports: [
     BiosimulationsConfigModule,
@@ -40,6 +42,7 @@ import * as redisStore from 'cache-manager-redis-store';
       }),
       inject: [ConfigService],
     }),
+    HealthModule,
     MongooseModule.forRootAsync({
       imports: [BiosimulationsConfigModule],
       useFactory: async (configService: ConfigService) => ({

--- a/apps/api/src/health/bullHealthCheck.ts
+++ b/apps/api/src/health/bullHealthCheck.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import {
+  HealthIndicator,
+  HealthIndicatorResult,
+  HealthCheckError,
+} from '@nestjs/terminus';
+import { InjectQueue, Process, Processor } from '@nestjs/bull';
+import { Job, Queue } from 'bull';
+
+@Processor('health')
+export class HealthCheckProcessor {
+  @Process()
+  private async healthCheck(job: Job<string>): Promise<boolean> {
+    return false;
+  }
+}
+
+@Injectable()
+export class BullHealthIndicator extends HealthIndicator {
+  public constructor(
+    @InjectQueue('health') private readonly healthQueue: Queue,
+  ) {
+    super();
+  }
+
+  public async isHealthy(key: string): Promise<HealthIndicatorResult> {
+    try {
+      const res = await this.healthQueue.add(
+        { key },
+        { timeout: 1000, attempts: 1 },
+      );
+      console.log(res);
+      const isHealthy = await res.finished();
+    } catch (e) {
+      throw new HealthCheckError('BullCheck failed', e.message);
+    }
+    return this.getStatus(key, true);
+  }
+}

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/apps/api/src/health/health.controller.spec.ts
+++ b/apps/api/src/health/health.controller.spec.ts
@@ -1,5 +1,7 @@
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
 import { TerminusModule } from '@nestjs/terminus';
 import { Test, TestingModule } from '@nestjs/testing';
+import { BullHealthIndicator } from './bullHealthCheck';
 import { HealthController } from './health.controller';
 
 describe('HealthController', () => {
@@ -7,7 +9,8 @@ describe('HealthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [TerminusModule],
+      imports: [TerminusModule, BiosimulationsConfigModule],
+      providers: [{ provide: BullHealthIndicator, useValue: {} }],
       controllers: [HealthController],
     }).compile();
 

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,0 +1,29 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheckService,
+  HttpHealthIndicator,
+  HealthCheck,
+  MongooseHealthIndicator,
+} from '@nestjs/terminus';
+
+@Controller('health')
+export class HealthController {
+  constructor(
+    private health: HealthCheckService,
+    private http: HttpHealthIndicator,
+    private db: MongooseHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  public check() {
+    return this.health.check([
+      () =>
+        this.http.pingCheck(
+          'combine-service',
+          'https://combine.api.biosimulations.org',
+        ),
+      () => this.db.pingCheck('database'),
+    ]);
+  }
+}

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,29 +1,101 @@
 import { Controller, Get } from '@nestjs/common';
+import { Transport } from '@nestjs/microservices';
 import {
   HealthCheckService,
   HttpHealthIndicator,
   HealthCheck,
   MongooseHealthIndicator,
+  MicroserviceHealthIndicator,
+  HealthIndicatorFunction,
+  HealthCheckResult,
 } from '@nestjs/terminus';
+import { ConfigService } from '@nestjs/config';
+import { Endpoints } from '@biosimulations/config/common';
+import { BullHealthIndicator } from './bullHealthCheck';
+import { ApiTags } from '@nestjs/swagger';
 
 @Controller('health')
+@ApiTags('Health')
 export class HealthController {
-  constructor(
+  private env = this.config.get('server.env');
+  private endpoints = new Endpoints(this.env);
+  private natsURL = this.config.get('nats.url');
+
+  public constructor(
     private health: HealthCheckService,
     private http: HttpHealthIndicator,
     private db: MongooseHealthIndicator,
+    private microservice: MicroserviceHealthIndicator,
+    private queue: BullHealthIndicator,
+    private config: ConfigService,
   ) {}
 
   @Get()
   @HealthCheck()
-  public check() {
+  public check(): Promise<HealthCheckResult> {
+    return this.health.check([this.mongoCheck, this.bullCheck]);
+  }
+
+  @Get('/status')
+  @HealthCheck()
+  public checkStatus(): Promise<HealthCheckResult> {
     return this.health.check([
-      () =>
-        this.http.pingCheck(
-          'combine-service',
-          'https://combine.api.biosimulations.org',
-        ),
-      () => this.db.pingCheck('database'),
+      this.combineCheck,
+      this.mongoCheck,
+      this.natsCheck,
+      this.bullCheck,
+      this.s3Check,
+      this.simulatorsCheck,
+      this.hpcCheck,
     ]);
   }
+
+  @Get('/database')
+  @HealthCheck()
+  public databaseCheck(): Promise<HealthCheckResult> {
+    return this.health.check([this.mongoCheck]);
+  }
+
+  @Get('/messaging')
+  @HealthCheck()
+  public messagingCheck(): Promise<HealthCheckResult> {
+    return this.health.check([this.natsCheck, this.bullCheck]);
+  }
+
+  private simulatorsCheck: HealthIndicatorFunction = () =>
+    this.http.pingCheck(
+      'Simulators API',
+      this.endpoints.getSimulatorApiHealthEndpoint(),
+    );
+
+  private combineCheck: HealthIndicatorFunction = () =>
+    this.http.pingCheck(
+      'Combine-service',
+      this.endpoints.getCombineHealthEndpoint(),
+    );
+  private mongoCheck: HealthIndicatorFunction = () =>
+    this.db.pingCheck('Database');
+
+  private natsCheck: HealthIndicatorFunction = () =>
+    this.microservice.pingCheck('Messaging', {
+      transport: Transport.NATS,
+      options: {
+        servers: [this.natsURL],
+      },
+    });
+
+  private bullCheck: HealthIndicatorFunction = () =>
+    this.queue.isHealthy('Queue');
+
+  private s3Check: HealthIndicatorFunction = () =>
+    this.http.pingCheck('Storage', this.endpoints.getStorageHealthEndpoint());
+
+  private hpcCheck: HealthIndicatorFunction = () =>
+    this.microservice.pingCheck('HPC', {
+      transport: Transport.TCP,
+      options: {
+        host: this.config.get('hpc.ssh.host'),
+        port: this.config.get('hpc.ssh.port'),
+      },
+    });
 }

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { TerminusModule } from '@nestjs/terminus';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/apps/api/src/health/health.module.ts
+++ b/apps/api/src/health/health.module.ts
@@ -1,9 +1,20 @@
 import { Module } from '@nestjs/common';
 import { HealthController } from './health.controller';
 import { TerminusModule } from '@nestjs/terminus';
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
+import { BullModule } from '@nestjs/bull';
+import { BullHealthIndicator, HealthCheckProcessor } from './bullHealthCheck';
 
 @Module({
-  imports: [TerminusModule],
+  imports: [
+    TerminusModule,
+    BiosimulationsConfigModule,
+    BullModule.registerQueue({
+      name: 'health',
+      prefix: '{health}',
+    }),
+  ],
+  providers: [HealthCheckProcessor, BullHealthIndicator],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/apps/api/src/projects/id.decorator.ts
+++ b/apps/api/src/projects/id.decorator.ts
@@ -10,9 +10,10 @@ import { projectIdRegExp } from './id.regex';
 export const ProjectId = createParamDecorator(
   (paramName: string, ctx: ExecutionContext) => {
     const request = ctx.switchToHttp().getRequest();
+
     const id = request.params[paramName];
-    if (!paramName) {
-      throw new BadRequestException('Project Id is required');
+    if (!id) {
+      throw new BadRequestException('Project id is required');
     }
     if (id.length < 3) {
       throw new BadRequestException(

--- a/apps/dispatch-service/src/app/app.module.ts
+++ b/apps/dispatch-service/src/app/app.module.ts
@@ -71,6 +71,10 @@ import { SedmlService } from '../sedml/sedml.service';
       name: JobQueue.fail,
       prefix: '{fail}',
     }),
+    BullModule.registerQueue({
+      name: JobQueue.health,
+      prefix: '{health}',
+    }),
   ],
   controllers: [],
   providers: [

--- a/apps/simulators-api/src/app/app.module.ts
+++ b/apps/simulators-api/src/app/app.module.ts
@@ -8,8 +8,8 @@ import { ConfigService } from '@nestjs/config';
 import { SimulatorsModule } from '../simulators/simulators.module';
 import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
 import { SharedExceptionsFiltersModule } from '@biosimulations/shared/exceptions/filters';
-// TODO create seperate auth environment for simulators-api
 import * as mongoose from 'mongoose';
+import { HealthModule } from '../health/health.module';
 mongoose.set('strict', 'throw');
 @Module({
   imports: [
@@ -26,6 +26,7 @@ mongoose.set('strict', 'throw');
     }),
     SimulatorsModule,
     SharedExceptionsFiltersModule,
+    HealthModule,
   ],
 })
 export class AppModule {}

--- a/apps/simulators-api/src/health/health.controller.spec.ts
+++ b/apps/simulators-api/src/health/health.controller.spec.ts
@@ -1,4 +1,3 @@
-import { TerminusModule } from '@nestjs/terminus';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
 
@@ -7,7 +6,6 @@ describe('HealthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      imports: [TerminusModule],
       controllers: [HealthController],
     }).compile();
 

--- a/apps/simulators-api/src/health/health.controller.spec.ts
+++ b/apps/simulators-api/src/health/health.controller.spec.ts
@@ -1,3 +1,4 @@
+import { TerminusModule } from '@nestjs/terminus';
 import { Test, TestingModule } from '@nestjs/testing';
 import { HealthController } from './health.controller';
 
@@ -6,6 +7,7 @@ describe('HealthController', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
+      imports: [TerminusModule],
       controllers: [HealthController],
     }).compile();
 

--- a/apps/simulators-api/src/health/health.controller.ts
+++ b/apps/simulators-api/src/health/health.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get } from '@nestjs/common';
+import {
+  HealthCheckService,
+  HealthCheck,
+  MongooseHealthIndicator,
+  HealthCheckResult,
+  HealthIndicatorFunction,
+} from '@nestjs/terminus';
+import { ApiTags } from '@nestjs/swagger';
+
+@Controller('health')
+@ApiTags('Health')
+export class HealthController {
+  public constructor(
+    private health: HealthCheckService,
+    private db: MongooseHealthIndicator,
+  ) {}
+
+  @Get()
+  @HealthCheck()
+  public check(): Promise<HealthCheckResult> {
+    return this.health.check([this.mongoCheck]);
+  }
+
+  private mongoCheck: HealthIndicatorFunction = () =>
+    this.db.pingCheck('Database');
+}

--- a/apps/simulators-api/src/health/health.module.ts
+++ b/apps/simulators-api/src/health/health.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { HealthController } from './health.controller';
+import { TerminusModule } from '@nestjs/terminus';
+
+@Module({
+  imports: [TerminusModule],
+  controllers: [HealthController],
+})
+export class HealthModule {}

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -160,33 +160,6 @@ export class Endpoints {
   }
 
   /**
-   * Create a URL to download a file from an omex file using the combine service
-   * @param archiveUrl The URL of a combine archive
-   * @param fileLocation The location of the file within the archive
-   * @returns A URL that resolves to a specific file within a combine archive
-   * @deprecated use getSimulationRunFileEndpoint instead if the simulation run has been submitted
-   * @see getSimulationRunFileEndpoint
-   */
-  private getCombineFilesEndpoint(
-    archiveUrl: string,
-    fileLocation: string,
-    external = false,
-  ): string {
-    if (external) {
-      if (this.env == 'local') {
-        return new Endpoints('dev').getCombineFilesEndpoint(
-          archiveUrl,
-          fileLocation,
-          true,
-        );
-      }
-    }
-    return `${this.combineFile}?url=${encodeURIComponent(
-      archiveUrl,
-    )}&location=${encodeURIComponent(fileLocation)}`;
-  }
-
-  /**
    * Create a URL to add a file to an OMEX file using the combine service
    * @returns A URL for POST endpoint for adding a file to an OMEX file using the combine service
    */
@@ -337,11 +310,49 @@ export class Endpoints {
     return `${this.simulationRunLogs}${runId}`;
   }
 
+  public getApiHealthEndpoint(): string {
+    return `${this.api}/health/status`;
+  }
+  public getSimulatorApiHealthEndpoint(): string {
+    return `${this.simulators}/health`;
+  }
+  public getCombineHealthEndpoint(): string {
+    return `${this.getCombineEndpoint}/health`;
+  }
+  public getStorageHealthEndpoint(): string {
+    return `${this.storage_endpoint}/helloWorld.txt`;
+  }
   /**
    *
    * @returns The base URL of the combine api
    */
   private getCombineEndpoint(): string {
     return this.combine_api;
+  }
+  /**
+   * Create a URL to download a file from an omex file using the combine service
+   * @param archiveUrl The URL of a combine archive
+   * @param fileLocation The location of the file within the archive
+   * @returns A URL that resolves to a specific file within a combine archive
+   * @deprecated use getSimulationRunFileEndpoint instead if the simulation run has been submitted
+   * @see getSimulationRunFileEndpoint
+   */
+  private getCombineFilesEndpoint(
+    archiveUrl: string,
+    fileLocation: string,
+    external = false,
+  ): string {
+    if (external) {
+      if (this.env == 'local') {
+        return new Endpoints('dev').getCombineFilesEndpoint(
+          archiveUrl,
+          fileLocation,
+          true,
+        );
+      }
+    }
+    return `${this.combineFile}?url=${encodeURIComponent(
+      archiveUrl,
+    )}&location=${encodeURIComponent(fileLocation)}`;
   }
 }

--- a/libs/messages/messages/src/lib/queues.ts
+++ b/libs/messages/messages/src/lib/queues.ts
@@ -8,6 +8,7 @@ export enum JobQueue {
   complete = 'complete',
   fail = 'fail',
   metadata = 'metadata',
+  health = 'health',
 }
 
 export class MonitorJob {

--- a/libs/shared/exceptions/filters/src/lib/http-exception.filter.ts
+++ b/libs/shared/exceptions/filters/src/lib/http-exception.filter.ts
@@ -10,17 +10,27 @@ import { makeErrorObjectFromHttp } from './utils';
 
 @Catch(HttpException)
 export class HttpExceptionFilter implements ExceptionFilter {
+  private ignorePaths = ['/health'];
+
   private logger = new Logger(HttpExceptionFilter.name);
 
   public catch(exception: HttpException, host: ArgumentsHost): void {
     const ctx = host.switchToHttp();
     const request = ctx.getRequest<Request>();
-
     this.logger.error(exception.getResponse(), request.url);
     const response = ctx.getResponse<Response>();
-
     const status = exception.getStatus();
-    const err = makeErrorObjectFromHttp(exception);
-    response.status(status).json({ error: [err] });
+    let ignore = false;
+    this.ignorePaths.forEach((path) => {
+      if (request.url.startsWith(path)) {
+        ignore = true;
+      }
+    });
+    if (ignore) {
+      response.status(status).json(exception.getResponse());
+    } else {
+      const err = makeErrorObjectFromHttp(exception);
+      response.status(status).json({ error: [err] });
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3440,6 +3440,14 @@
         "path-to-regexp": "3.2.0"
       }
     },
+    "@nestjs/terminus": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-8.0.1.tgz",
+      "integrity": "sha512-UUSKK3/kO2gMUdXGJaOsj89pYA6OJMoKQPDx+zoEKQhA3+TPp0Js4ndWrtms5g6ydf3BfQqGQgEBEBjiq+0LWQ==",
+      "requires": {
+        "check-disk-space": "3.0.1"
+      }
+    },
     "@nestjs/testing": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-8.1.1.tgz",
@@ -9932,6 +9940,11 @@
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
+    },
+    "check-disk-space": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/check-disk-space/-/check-disk-space-3.0.1.tgz",
+      "integrity": "sha512-wRG5ZihEZUXAKVCio5YkLgrHsHDrD+GjRBjxJvoJvN9wrze7EdvYGnOYJSsCyZ4b40jBa3lDmWDmESY9QDQGcg=="
     },
     "check-more-types": {
       "version": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@nestjs/platform-express": "8.1.1",
     "@nestjs/schedule": "1.0.1",
     "@nestjs/swagger": "5.1.0",
+    "@nestjs/terminus": "^8.0.1",
     "@ngbmodule/material-carousel": "0.7.1",
     "@openapi-contrib/openapi-schema-to-json-schema": "3.1.1",
     "@semantic-release/npm": "8.0.0",


### PR DESCRIPTION
add health endpoints

Endpoints for: 
- [x] Kubernetes health status (Should not fail due to failure of dependencies manged by kubernetes) 
- [x] User friendly status (Fails if any dependencies fail) 
- [x] MongoDB dependency
- [x] Nats dependency
- [x] Redis dependency
- [x] Http dependency
- [x] Combine service dependency 
- [x] S3 dependecy
- [x] SSH dependency 

closes #3238 #3213
