### PR TITLE
feat(dispatch): recorded simulator versions and digests for simulation runs

### DIFF
--- a/apps/api/src/simulation-run/simulation-run.controller.ts
+++ b/apps/api/src/simulation-run/simulation-run.controller.ts
@@ -47,6 +47,7 @@ import {
   ApiBody,
   ApiUnauthorizedResponse,
   ApiForbiddenResponse,
+  ApiInternalServerErrorResponse,
 } from '@nestjs/swagger';
 import { Response, Request } from 'express';
 import {
@@ -175,6 +176,10 @@ export class SimulationRunController {
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
     description: 'No image for the simulator/version is registered with BioSimulators',
+  })
+  @ApiInternalServerErrorResponse({
+    description: 'An error occurred in retrieving the simulator/version',
+    type: ErrorResponseDocument,
   })
   @Post()
   public async createRun(

--- a/apps/api/src/simulation-run/simulation-run.controller.ts
+++ b/apps/api/src/simulation-run/simulation-run.controller.ts
@@ -172,6 +172,10 @@ export class SimulationRunController {
     description:
       'The submitted COMBINE/OMEX archive file is too large. Uploaded archives must be less than 1 GB. Larger archives up to 5 TB may be submitted via URLs.',
   })
+  @ApiBadRequestResponse({
+    type: ErrorResponseDocument,
+    description: 'No image for the simulator/version is registered with BioSimulators',
+  })
   @Post()
   public async createRun(
     @Body() body: multipartSimulationRunBody | UploadSimulationRunUrl,
@@ -247,6 +251,7 @@ export class SimulationRunController {
       run.name,
       run.simulator,
       run.simulatorVersion,
+      run.simulatorDigest,
       run.cpus,
       run.memory,
       run.maxTime,

--- a/apps/api/src/simulation-run/simulation-run.model.ts
+++ b/apps/api/src/simulation-run/simulation-run.model.ts
@@ -9,7 +9,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document } from 'mongoose';
 import { Types } from 'mongoose';
 import { SimulationFile } from './file.model';
-import { SimulationRunStatus, Purpose } from '@biosimulations/datamodel/common';
+import { SimulationRun, SimulationRunStatus, Purpose } from '@biosimulations/datamodel/common';
 import { omitPrivate } from '@biosimulations/datamodel-database';
 import { isEmail, isUrl } from '@biosimulations/datamodel-database';
 
@@ -25,7 +25,7 @@ export const EnvironmentVariableSchema =
   SchemaFactory.createForClass(EnvironmentVariable);
 
 @Schema({ collection: 'Simulation Runs', id: false })
-export class SimulationRunModel extends Document {
+export class SimulationRunModel extends Document implements SimulationRun {
   @Prop({ required: true, unique: true, index: true })
   id!: string;
 
@@ -80,6 +80,25 @@ export class SimulationRunModel extends Document {
 
   @Prop({ type: String, required: true })
   simulatorVersion!: string;
+
+  @Prop({
+    type: String,
+    required: true,
+    validate: [
+      {
+        validator: (value: any): boolean => {
+          return (
+            typeof value === 'string' &&
+            value.match(/^sha256:[a-z0-9]{64,64}$/) !== null
+          );
+        },
+        message: (props: any): string =>
+          `${props.value} is not a valid Docker repository digest`,
+      },
+    ],
+    default: undefined,
+  })
+  simulatorDigest!: string;
 
   @Prop({
     type: Number,
@@ -183,6 +202,7 @@ export type SimulationRunModelType = Pick<
   | 'resultsSize'
   | 'simulator'
   | 'simulatorVersion'
+  | 'simulatorDigest'
   | 'cpus'
   | 'memory'
   | 'maxTime'

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -44,6 +44,7 @@ import { catchError } from 'rxjs/operators';
 import { DeleteResult } from 'mongodb';
 import { Endpoints } from '@biosimulations/config/common';
 import { HttpErrorResponse } from '@angular/common/http';
+import { ConfigService } from '@nestjs/config';
 
 // 1gb in bytes to be used as file size limits
 const ONE_GIGABYTE = 1000000000;
@@ -57,7 +58,7 @@ const toApi = <T extends SimulationRunModelType>(
 
 @Injectable()
 export class SimulationRunService {
-  private endpoints = new Endpoints();
+  private endpoints: Endpoints;
   private logger = new Logger(SimulationRunService.name);
 
   public constructor(
@@ -67,7 +68,11 @@ export class SimulationRunService {
     private simulationStorageService: SimulationStorageService,
     private http: HttpService,
     @Inject('NATS_CLIENT') private client: ClientProxy,
-  ) {}
+    private configService: ConfigService,
+  ) {
+    const env = this.configService.get('server.env');
+    this.endpoints = new Endpoints(env);
+  }
 
   public async setStatus(
     id: string,

--- a/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
+++ b/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
@@ -37,11 +37,11 @@ import {
   SimulationRunStatus,
   EnvironmentVariable,
   MODEL_FORMATS,
+  SimulationRun,
 } from '@biosimulations/datamodel/common';
 import { Observable, Subscription } from 'rxjs';
 import { map, concatAll, withLatestFrom } from 'rxjs/operators';
 import { ConfigService } from '@biosimulations/shared/services';
-import { SimulationRun } from '@biosimulations/datamodel/api';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
 
@@ -789,7 +789,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
   }
 
   private processSimulationResponse(
-    data: any,
+    data: SimulationRun,
     name: string,
     simulator: string,
     simulatorVersion: string,
@@ -800,7 +800,10 @@ export class DispatchComponent implements OnInit, OnDestroy {
     purpose: Purpose,
     email: string | null,
   ): void {
-    const simulationId = data['id'];
+    const simulationId = data.id;
+    const simulatorDigest = data.simulatorDigest;
+    const submitted = new Date(data.submitted);
+    const updated = new Date(data.submitted);
 
     const simulation: Simulation = {
       id: simulationId,
@@ -808,6 +811,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
       email: email || undefined,
       simulator: simulator,
       simulatorVersion: simulatorVersion,
+      simulatorDigest: simulatorDigest,
       cpus: cpus,
       memory: memory,
       maxTime: maxTime,
@@ -816,8 +820,8 @@ export class DispatchComponent implements OnInit, OnDestroy {
       submittedLocally: true,
       status: SimulationRunStatus.QUEUED,
       runtime: undefined,
-      submitted: new Date(),
-      updated: new Date(),
+      submitted: submitted,
+      updated: updated,
     };
     this.simulationService.storeNewLocalSimulation(simulation);
 

--- a/apps/dispatch/src/app/components/simulations/view/view.model.ts
+++ b/apps/dispatch/src/app/components/simulations/view/view.model.ts
@@ -9,6 +9,7 @@ export interface FormattedSimulation {
   name: string;
   simulator: string;
   simulatorVersion: string;
+  simulatorDigest: string;
   simulatorUrl: string;
   cpus: number;
   memory: string;

--- a/apps/dispatch/src/app/components/simulations/view/view.service.ts
+++ b/apps/dispatch/src/app/components/simulations/view/view.service.ts
@@ -25,6 +25,7 @@ export class ViewService {
       name: simulation.name,
       simulator: simulation.simulator,
       simulatorVersion: simulation.simulatorVersion,
+      simulatorDigest: simulation.simulatorDigest,
       cpus: simulation.cpus || 1,
       memory: UtilsService.formatDigitalSize((simulation.memory || 8) * 1e9),
       maxTime: UtilsService.formatDuration((simulation.maxTime || 20) * 60),

--- a/apps/dispatch/src/app/datamodel.ts
+++ b/apps/dispatch/src/app/datamodel.ts
@@ -11,6 +11,7 @@ export interface UnknownSimulation {
   submittedLocally?: null;
   simulator?: null;
   simulatorVersion?: null;
+  simulatorDigest?: null;
   cpus?: null;
   memory?: null; // GB
   maxTime?: null; // min
@@ -31,6 +32,7 @@ export interface Simulation {
   submittedLocally?: boolean;
   simulator: string;
   simulatorVersion: string;
+  simulatorDigest: string;
   cpus: number;
   memory: number; // GB
   maxTime: number; // min

--- a/apps/dispatch/src/app/services/simulation/simulation.service.ts
+++ b/apps/dispatch/src/app/services/simulation/simulation.service.ts
@@ -243,6 +243,7 @@ export class SimulationService {
               submittedLocally: false,
               simulator: dispatchSimulation.simulator,
               simulatorVersion: dispatchSimulation.simulatorVersion,
+              simulatorDigest: dispatchSimulation.simulatorDigest,
               cpus: dispatchSimulation.cpus,
               memory: dispatchSimulation.memory,
               maxTime: dispatchSimulation.maxTime,

--- a/apps/simulators-api/src/simulators/simulators.controller.ts
+++ b/apps/simulators-api/src/simulators/simulators.controller.ts
@@ -109,29 +109,8 @@ export class SimulatorsController {
     allSims.forEach((element) => {
       const latestSim = latest.get(element.id) as Simulator;
       if (latestSim) {
-        const latestVersion = latestSim.version.replace(/-/g, '.');
-        const currentVersion = element.version.replace(/-/g, '.');
-        try {
-          if (compareVersions(latestVersion, currentVersion) == -1) {
-            latest.set(element.id, element);
-          }
-        } catch {
-          try {
-            if (
-              compareVersionsWithAdditionalPoints(
-                latestVersion,
-                currentVersion,
-              ) == -1
-            ) {
-              latest.set(element.id, element);
-            }
-          } catch {
-            if (
-              element.biosimulators.created > latestSim.biosimulators.created
-            ) {
-              latest.set(element.id, element);
-            }
-          }
+        if (this.compareSimulatorVersions(latestSim, element) === -1) {
+          latest.set(element.id, element);
         }
       } else {
         latest.set(element.id, element);
@@ -142,6 +121,26 @@ export class SimulatorsController {
       return results.filter((value) => value.id === id);
     } else {
       return results;
+    }
+  }
+
+  compareSimulatorVersions(a: Simulator, b: Simulator): number {
+    const aVersion = a.version.replace(/-/g, '.');
+    const bVersion = b.version.replace(/-/g, '.');
+    try {
+      return compareVersions(aVersion, bVersion);
+    } catch {
+      try {
+        return compareVersionsWithAdditionalPoints(aVersion, bVersion);
+      } catch {
+        if (b.biosimulators.created > a.biosimulators.created) {
+          return -1;
+        } else if (b.biosimulators.created < a.biosimulators.created) {
+          return 1;
+        } else {
+          return 0;
+        }
+      }
     }
   }
 
@@ -189,12 +188,14 @@ export class SimulatorsController {
   @ApiParam({
     name: 'id',
     description: 'Id of the simulation tool',
+    example: 'tellurium',
     required: true,
     type: String,
   })
   @ApiParam({
     name: 'version',
     description: 'Version of the simulation tool',
+    example: '2.2.1',
     required: true,
     type: String,
   })

--- a/apps/simulators-api/src/simulators/simulators.service.ts
+++ b/apps/simulators-api/src/simulators/simulators.service.ts
@@ -50,6 +50,7 @@ export class SimulatorsService {
     }
     return this.simulator.find({ id: id }, projection).lean().exec();
   }
+  
   public async findByVersion(
     id: string,
     version: string,

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -20,9 +20,9 @@ import {
 } from '@biosimulations/datamodel/api';
 @Injectable({})
 export class SimulationRunService {
-  private endpoint = this.configService.get('urls').dispatchApi;
-  private endpoints = new Endpoints();
+  private endpoints: Endpoints;
   private logger = new Logger(SimulationRunService.name);
+  
   public constructor(
     private auth: AuthClientService,
     private http: HttpService,
@@ -73,7 +73,7 @@ export class SimulationRunService {
       map((token) => {
         const httpRes = this.http
           .patch<SimulationRun>(
-            `${this.endpoint}run/${id}`,
+            this.endpoints.getSimulationRunEndpoint(id),
             {
               status,
               statusReason,
@@ -101,7 +101,7 @@ export class SimulationRunService {
       map((token) => {
         return this.http
           .patch<SimulationRun>(
-            `${this.endpoint}run/${id}`,
+            this.endpoints.getSimulationRunEndpoint(id),
             { resultsSize: size },
             {
               headers: {
@@ -122,11 +122,13 @@ export class SimulationRunService {
     );
   }
 
-  public getJob(simId: string): Observable<SimulationRun> {
+  public getJob(id: string): Observable<SimulationRun> {
     return from(this.auth.getToken()).pipe(
       map((token) => {
         return this.http
-          .get<SimulationRun>(`${this.endpoint}run/${simId}`, {
+          .get<SimulationRun>(
+            this.endpoints.getSimulationRunEndpoint(id), 
+            {
             headers: {
               Authorization: `Bearer ${token}`,
             },

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -127,7 +127,7 @@ export class SimulationRunService {
       map((token) => {
         return this.http
           .get<SimulationRun>(
-            this.endpoints.getSimulationRunEndpoint(id), 
+            this.endpoints.getSimulationRunEndpoint(id),
             {
             headers: {
               Authorization: `Bearer ${token}`,

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -289,6 +289,7 @@ export class Endpoints {
     id ? (id = `/${id}`) : (id = '');
     return `${this.simulationRunLogs}${id}`;
   }
+
   /**
    *
    * @param id The id of the simulator
@@ -299,6 +300,16 @@ export class Endpoints {
     id ? (id = `/${id}`) : (id = '');
     version ? (version = `/${version}`) : (version = '');
     return `${this.simulators}${id}${version}`;
+  }
+
+  /**
+   *
+   * @param id The id of the simulator
+   * @returns  A URL to get the latest version of each simulator, or the latest version of a specific simulator
+   */
+  public getLatestSimulatorsEndpoint(id?: string): string {
+    id ? (id = `?id=${id}`) : (id = '');
+    return `${this.simulators}/latest${id}`;
   }
 
   /**

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -31,7 +31,7 @@ export class Endpoints {
     switch (env) {
       case 'local':
         this.api = 'http://localhost:3333';
-        this.simulators_api = '/simulators-api';
+        this.simulators_api = 'https://api.biosimulators.dev';
         this.combine_api = '/combine-api';
         this.storage_endpoint = 'https://files-dev.biosimulations.org/s3';
         break;

--- a/libs/datamodel/api/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRun.ts
@@ -278,14 +278,6 @@ export class PatchSimulationRun {
   public?: boolean;
 
   @ApiPropertyOptional({
-    description: 'Digest of the simulation tool for the simulation run',
-    type: String,
-    pattern: '^sha256:[a-z0-9]{64,64}$',
-    example: 'sha256:5d1595553608436a2a343f8ab7e650798ef5ba5dab007b9fe31cd342bf18ec81',
-  })
-  simulatorDigest?: string;
-
-  @ApiPropertyOptional({
     description: 'Status of the simulation run',
     type: String,
     enum: SimulationRunStatus,

--- a/libs/datamodel/api/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRun.ts
@@ -14,7 +14,7 @@ import {
   PartialType,
   PickType,
 } from '@nestjs/swagger';
-import { SimulationRunStatus, Purpose } from '@biosimulations/datamodel/common';
+import { SimulationRun as ISimulationRun, SimulationRunStatus, Purpose } from '@biosimulations/datamodel/common';
 
 export class EnvironmentVariable {
   @ApiProperty({
@@ -32,7 +32,7 @@ export class EnvironmentVariable {
   value!: string;
 }
 
-export class SimulationRun {
+export class SimulationRun implements ISimulationRun {
   // Explicitly make sure not to send out file id from database
   file!: never;
   fileUrl!: never;
@@ -68,6 +68,14 @@ export class SimulationRun {
     example: '2.2.0',
   })
   simulatorVersion!: string;
+
+  @ApiResponseProperty({
+    // description: 'Digest of the simulation tool for the simulation run',
+    type: String,
+    // pattern: '^sha256:[a-z0-9]{64,64}$',
+    example: 'sha256:5d1595553608436a2a343f8ab7e650798ef5ba5dab007b9fe31cd342bf18ec81',
+  })
+  simulatorDigest!: string;
 
   // The optional properities cannot contain the '!' assertion since they are not garunteed!! Must be set in the constructor
   @ApiPropertyOptional({
@@ -182,6 +190,7 @@ export class SimulationRun {
     name: string,
     simulator: string,
     simulatorVersion: string,
+    simulatorDigest: string,
     cpus: number,
     memory: number,
     maxTime: number,
@@ -201,6 +210,7 @@ export class SimulationRun {
     this.name = name;
     this.simulator = simulator;
     this.simulatorVersion = simulatorVersion;
+    this.simulatorDigest = simulatorDigest;
     this.cpus = cpus || 1;
     this.memory = memory || 8;
     this.maxTime = maxTime || 20;
@@ -266,6 +276,14 @@ export class PatchSimulationRun {
     type: Boolean,
   })
   public?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Digest of the simulation tool for the simulation run',
+    type: String,
+    pattern: '^sha256:[a-z0-9]{64,64}$',
+    example: 'sha256:5d1595553608436a2a343f8ab7e650798ef5ba5dab007b9fe31cd342bf18ec81',
+  })
+  simulatorDigest?: string;
 
   @ApiPropertyOptional({
     description: 'Status of the simulation run',

--- a/libs/datamodel/api/src/lib/core/simulator.ts
+++ b/libs/datamodel/api/src/lib/core/simulator.ts
@@ -10,6 +10,7 @@ import {
 import {
   SoftwareInterfaceType,
   OperatingSystemType,
+  ISimulator,
 } from '@biosimulations/datamodel/common';
 import { ApiProperty } from '@nestjs/swagger';
 
@@ -21,7 +22,7 @@ import {
   BiosimulatorsMeta,
 } from '../simulators';
 
-export class Simulator {
+export class Simulator implements ISimulator {
   @ApiProperty({ type: BiosimulatorsMeta })
   biosimulators!: BiosimulatorsMeta;
 

--- a/libs/datamodel/common/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/common/src/lib/core/simulationRun.ts
@@ -1,4 +1,5 @@
 import { SimulationRunLogStatus } from './simulationRunLog';
+import { Purpose } from './purpose';
 
 export enum SimulationRunStatus {
   // The api has created the entry
@@ -43,4 +44,26 @@ export const SimulationStatusToSimulationLogStatus = (
 export interface EnvironmentVariable {
   key: string;
   value: string;
+}
+
+export interface SimulationRun {
+  id: string;
+  name: string;
+  simulator: string;
+  simulatorVersion: string;
+  simulatorDigest: string;
+  cpus: number;
+  memory: number;
+  maxTime: number;
+  envVars: EnvironmentVariable[];
+  purpose: Purpose;
+  email: string | null;
+  public: boolean;
+  status: SimulationRunStatus;
+  statusReason?: string;
+  runtime?: number;
+  projectSize?: number;
+  resultsSize?: number;
+  submitted: Date;
+  updated: Date;
 }

--- a/libs/datamodel/common/src/lib/core/simulator.ts
+++ b/libs/datamodel/common/src/lib/core/simulator.ts
@@ -1,3 +1,18 @@
+import {
+  Url,
+  IImage,
+  ICli,
+  IPythonApi,
+  Person,
+  ExternalReferences,
+  SoftwareInterfaceType,
+  OperatingSystemType,
+  Funding,
+  ISpdxOntologyId,
+  ILinguistOntologyId,
+} from '../common';
+import { IAlgorithm } from './algorithm';
+
 export enum specificationVersions {
   latest = '1.0.0',
   '1.0.0' = '1.0.0',
@@ -46,4 +61,24 @@ export interface IBiosimulatorsMeta {
   imageVersion: imageVersions;
   validated: boolean;
   validationTests: IValidationTests | null;
+}
+
+export interface ISimulator {
+  biosimulators: IBiosimulatorsMeta;
+  id: string;
+  name: string;
+  version: string;
+  description: string;
+  urls: Url[];
+  image: IImage | null;
+  cli: ICli | null;
+  pythonApi: IPythonApi | null;
+  authors: Person[];
+  references: ExternalReferences;
+  license: ISpdxOntologyId | null;
+  algorithms: IAlgorithm[];
+  interfaceTypes: SoftwareInterfaceType[];
+  supportedOperatingSystemTypes: OperatingSystemType[];
+  supportedProgrammingLanguages: ILinguistOntologyId[];
+  funding: Funding[];
 }

--- a/libs/simulators/database-models/src/lib/simulator.ts
+++ b/libs/simulators/database-models/src/lib/simulator.ts
@@ -20,6 +20,7 @@ import {
   SoftwareInterfaceType,
   OperatingSystemType,
   Funding,
+  ISimulator,
 } from '@biosimulations/datamodel/common';
 import { addValidationForNullableAttributes } from '@biosimulations/datamodel-database';
 import { ExternalReferencesSchema, PersonSchema, UrlSchema } from './common';
@@ -29,7 +30,7 @@ import {
 } from './biosimulatorsMeta';
 
 @Schema({})
-export class Simulator extends Document {
+export class Simulator extends Document implements ISimulator {
   @Prop({ type: BiosimulatorsMetaSchema, required: true, default: undefined })
   biosimulators!: BiosimulatorsMeta;
 

--- a/libs/simulators/database-models/src/lib/simulator.ts
+++ b/libs/simulators/database-models/src/lib/simulator.ts
@@ -46,7 +46,20 @@ export class Simulator extends Document implements ISimulator {
   @Prop({ type: String, required: true, default: undefined })
   name!: string;
 
-  @Prop({ type: String, required: true, default: undefined })
+  @Prop({
+    type: String,
+    required: true,
+    default: undefined,
+    validate: [
+      {
+        validator: (value: string): boolean => {
+          return value !== 'latest';
+        },
+        message: (props: any): string =>
+          '"latest" is not a valid version. "latest" is reserved to automatically refer to the latest version.',
+      },
+    ],
+  })
   version!: string;
 
   @Prop({ type: String, text: true, required: true, default: undefined })


### PR DESCRIPTION
closes #3195

- Uses simulators database to validate requested simulator/version
- Raises BadRequestException if an image isn't registered for the requested simulator/version
- Saves digest (hash) for simulator/version to `SimulationRun`
- Added common data models for simulators and simulation runs
- Added simulatorDigest to SimulationRunUpdate. I added this when thinking about using the SBatch service to get image digests. This could be removed. I ended up not using this and instead getting digests from the simulators database.

@bilalshaikh42 the key thing to review is the integration of the simulator API (L307 of `apps/api/src/simulation-run/simulation-run.service.ts`).
