### PR TITLE
feat(simulators): added combined id/version property

### DIFF
--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -38,7 +38,7 @@ export class Endpoints {
 
       case 'dev':
         this.api = 'https://api.biosimulations.dev';
-        this.simulators_api = 'https://api.biosimulators.dev';
+        this.simulators_api = 'http://localhost:3333';
         this.combine_api = 'https://combine.api.biosimulations.dev';
         this.storage_endpoint = 'https://files-dev.biosimulations.org/s3';
         break;

--- a/libs/config/common/src/lib/urls.ts
+++ b/libs/config/common/src/lib/urls.ts
@@ -36,7 +36,7 @@ const envUrls: { [key in envs]: urlMap } = {
     accountApi: 'https://account.biosimulations.dev/',
     dispatchApi: 'https://run.api.biosimulations.dev/',
     combineApi: 'https://combine.api.biosimulations.dev/',
-    simulatorsApi: 'https://api.biosimulators.dev/',
+    simulatorsApi: 'http://localhost:3333/',
     platform: 'https://biosimulations.dev',
     account: 'https://login.biosimulations.dev',
     dispatch: 'https://run.biosimulations.dev',

--- a/libs/config/common/src/lib/urls.ts
+++ b/libs/config/common/src/lib/urls.ts
@@ -36,7 +36,7 @@ const envUrls: { [key in envs]: urlMap } = {
     accountApi: 'https://account.biosimulations.dev/',
     dispatchApi: 'https://run.api.biosimulations.dev/',
     combineApi: 'https://combine.api.biosimulations.dev/',
-    simulatorsApi: 'http://localhost:3333/',
+    simulatorsApi: 'https://api.biosimulators.dev/',
     platform: 'https://biosimulations.dev',
     account: 'https://login.biosimulations.dev',
     dispatch: 'https://run.biosimulations.dev',

--- a/libs/datamodel/api/src/lib/core/simulator.ts
+++ b/libs/datamodel/api/src/lib/core/simulator.ts
@@ -12,7 +12,7 @@ import {
   OperatingSystemType,
   ISimulator,
 } from '@biosimulations/datamodel/common';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiResponseProperty } from '@nestjs/swagger';
 
 import {
   Image,
@@ -26,10 +26,19 @@ export class Simulator implements ISimulator {
   @ApiProperty({ type: BiosimulatorsMeta })
   biosimulators!: BiosimulatorsMeta;
 
+  @ApiResponseProperty({
+    type: String,
+    example: 'tellurium:2.1.6',
+    // name: 'idVersion',
+    // description: 'Id and version of the simulation tool',
+  })
+  idVersion!: string;
+
   @ApiProperty({
     type: String,
     example: 'tellurium',
     name: 'id',
+    description: 'Id of the simulation tool',
   })
   id!: string;
 
@@ -39,11 +48,13 @@ export class Simulator implements ISimulator {
   @ApiProperty({
     type: String,
     example: '2.1.6',
+    description: 'Version of the simulation tool',
   })
   version!: string;
 
   @ApiProperty({
     type: String,
+    description: 'Brief summary of the simulation tool',
     example:
       'tellurium is a Python-based environment for model building, simulation, and analysis that facilitates reproducibility of models in systems and synthetic biology.',
   })
@@ -51,12 +62,14 @@ export class Simulator implements ISimulator {
 
   @ApiProperty({
     type: [Url],
+    description: 'URLs with additional information about the simulation tool',
   })
   urls!: Url[];
 
   @ApiProperty({
     nullable: true,
     type: Image,
+    description: 'Standardized Docker image for the simulation tool',
   })
   image!: Image | null;
 
@@ -69,40 +82,58 @@ export class Simulator implements ISimulator {
   @ApiProperty({
     nullable: true,
     type: PythonApi,
+    description: 'Standardized Python API for the simulation tool',
   })
   pythonApi!: PythonApi | null;
 
-  @ApiProperty({ type: [Person] })
+  @ApiProperty({
+    type: [Person],
+    description: 'Creators of the simulation tool',
+  })
   authors!: Person[];
 
-  @ApiProperty({ type: ExternalReferences })
+  @ApiProperty({
+    type: ExternalReferences,
+    description: 'Identifiers and citations for the simulation tool',
+  })
   references!: ExternalReferences;
 
-  @ApiProperty({ type: SpdxOntologyId, nullable: true })
+  @ApiProperty({
+    type: SpdxOntologyId,
+    nullable: true,
+    description: 'License for the simulation tool',
+  })
   license!: SpdxOntologyId | null;
 
-  @ApiProperty({ type: [Algorithm] })
+  @ApiProperty({
+    type: [Algorithm],
+    description: 'Algorithms implemented by the simulation tool, with information about supported model formats, model changes, observables, and algorithm parameters',
+  })
   algorithms!: Algorithm[];
 
   @ApiProperty({
     type: [String],
     enum: SoftwareInterfaceType,
+    description: 'Available interfaces to the simulation tool',
   })
   interfaceTypes!: SoftwareInterfaceType[];
 
   @ApiProperty({
     type: [String],
     enum: OperatingSystemType,
+    description: 'Operating systems that the simulation tool can be run on',
   })
   supportedOperatingSystemTypes!: OperatingSystemType[];
 
   @ApiProperty({
     type: [LinguistOntologyId],
+    description: 'Programming languages which the simulation tool provides APIs for',
   })
   supportedProgrammingLanguages!: LinguistOntologyId[];
 
   @ApiProperty({
     type: [Funding],
+    description: 'Funding which supported the development of the simulation tool',
   })
   funding!: Funding[];
 }

--- a/libs/datamodel/common/src/lib/core/simulator.ts
+++ b/libs/datamodel/common/src/lib/core/simulator.ts
@@ -65,6 +65,7 @@ export interface IBiosimulatorsMeta {
 
 export interface ISimulator {
   biosimulators: IBiosimulatorsMeta;
+  idVersion: string;
   id: string;
   name: string;
   version: string;

--- a/libs/simulators/database-models/src/lib/simulator.ts
+++ b/libs/simulators/database-models/src/lib/simulator.ts
@@ -36,10 +36,20 @@ export class Simulator extends Document implements ISimulator {
 
   @Prop({
     type: String,
+    required: true,
+    default: undefined,
+    unique: true,
+    index: true,
+  })
+  idVersion!: string;
+
+  @Prop({
+    type: String,
     lowercase: true,
     trim: true,
     required: true,
     default: undefined,
+    index: true,
   })
   id!: string;
 
@@ -48,6 +58,7 @@ export class Simulator extends Document implements ISimulator {
 
   @Prop({
     type: String,
+    trim: true,
     required: true,
     default: undefined,
     validate: [
@@ -152,7 +163,7 @@ export class Simulator extends Document implements ISimulator {
 export const SimulatorSchema = SchemaFactory.createForClass(Simulator);
 
 // Can not be set in the decorator for compund schemas.
-SimulatorSchema.index({ id: 1, version: 1 }, { unique: true });
+SimulatorSchema.index({ id: 1, version: 1 }, { unique: false });
 SimulatorSchema.set('strict', 'throw');
 //SimulatorSchema.set('id', false);
 


### PR DESCRIPTION
First steps toward #3164 

`idVersion` property is set just before saving/updating to database because I don't believe MongoDB has a great way to handle this. Pre-save hooks don't cover updating. Functions for defaults only apply when the value isn't directly set. Virtual properties can't be searched.

The simulators database could be migrated with the Python script below. I already ran this for the `dev` database. The first step saves a copy locally in case of any of problems.
```python
import json
import requests
import subprocess

response = requests.get('https://api.biosimulators.org/simulators?includeTests=true')
response.raise_for_status()
simulators = response.json()
with open('simulators.json', 'w') as file:
    json.dump(simulators, file)

response2 = requests.post('https://auth.biosimulations.org/oauth/token', json={
    'client_id': '...',
    'client_secret': '...',
    'audience': 'api.biosimulators.org',
    "grant_type": "client_credentials",
})
response2.raise_for_status()
response_data = response2.json()
auth = {'Authorization': response_data['token_type'] + ' ' + response_data['access_token']}

response2 = requests.delete(
    'https://api.biosimulators.org/simulators', json=simulator, headers=auth)
response2.raise_for_status()

for simulator in simulators:
    print(simulator['id'])

    response2 = requests.post(
        'https://api.biosimulators.org/simulators', json=simulator, headers=auth)
    response2.raise_for_status()
```