### PR TITLE
feat(api): added database model and validation endpoint for simulation run logs

### DIFF
--- a/apps/api/src/files/files.controller.ts
+++ b/apps/api/src/files/files.controller.ts
@@ -137,7 +137,7 @@ export class FilesController {
   //@Post(':runId')
   @permissions('write:Files')
   public async createSimulationFiles(
-    @Param() runId: string,
+    @Param('runId') runId: string,
     @Body() files: any[],
   ): Promise<void> {}
 

--- a/apps/api/src/logs/logs.controller.spec.ts
+++ b/apps/api/src/logs/logs.controller.spec.ts
@@ -39,7 +39,7 @@ describe('LogsController', () => {
   it(' should get logs from service', async () => {
     const getSpy = jest.spyOn(mockService, 'getLog').mockReturnValue('test');
 
-    const log = await controller.getLogs('testId');
+    const log = await controller.getLog('testId');
     expect(getSpy).toHaveBeenCalled();
     //@ts-ignore
     expect(log).toBe('test');

--- a/apps/api/src/logs/logs.controller.ts
+++ b/apps/api/src/logs/logs.controller.ts
@@ -31,6 +31,7 @@ import {
   ApiPayloadTooLargeResponse,
   ApiBadRequestResponse,
   ApiBody,
+  ApiConflictResponse,
 } from '@nestjs/swagger';
 import {
   CombineArchiveLog,
@@ -148,6 +149,11 @@ export class LogsController {
     type: ErrorResponseDocument,
     description:
       'The specifications of the simulation tool are invalid. See https://biosimulators.org/conventions and https://api.biosimulators.org for examples and documentation.',
+  })
+  @ApiConflictResponse({
+    type: ErrorResponseDocument,
+    description:
+      'The log could not be saved because the database already includes a log for the simulation run.',
   })
   public async createLog(
     @Body() body: CreateSimulationRunLogBody,

--- a/apps/api/src/logs/logs.controller.ts
+++ b/apps/api/src/logs/logs.controller.ts
@@ -160,7 +160,7 @@ export class LogsController {
     summary: 'Delete the log for a simulation run',
     description: 'Delete the log for a simulation run',
   })
-  @Delete(':runId')  
+  @Delete(':runId')
   @ApiParam({
     name: 'runId',
     description: 'Id of the simulation run',
@@ -195,7 +195,7 @@ export class LogsController {
   @ApiOperation({
     summary: 'Replace the log for a simulation run',
     description: 'Replace the log for a simulation run',
-  })  
+  })
   @Put(':runId')
   @ApiParam({
     name: 'runId',
@@ -234,7 +234,7 @@ export class LogsController {
     return this.service.replaceLog(runId, body).then((res) => res);
   }
 
-  @Post('validate')  
+  @Post('validate')
   @ApiOperation({
     summary: 'Validate a log for a simulation run',
     description: 'Validate a log for a simulation run',

--- a/apps/api/src/logs/logs.model.ts
+++ b/apps/api/src/logs/logs.model.ts
@@ -5,7 +5,7 @@
  * @license MIT
  */
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
-import { 
+import {
   CombineArchiveLog as ICombineArchiveLog,
   SedDocumentLog as ISedDocumentLog,
   SedTaskLog as ISedTaskLog,
@@ -53,8 +53,8 @@ export class SedOutputElementLog implements ISedOutputElementLog{
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -79,8 +79,8 @@ export class SedReportLog implements ISedReportLog {
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -120,8 +120,8 @@ export class SedPlot2DLog implements ISedPlot2DLog {
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -161,8 +161,8 @@ export class SedPlot3DLog implements ISedPlot3DLog {
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -209,8 +209,8 @@ export class SedOutputLog implements ISedOutputLog {
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -260,8 +260,8 @@ export class SedTaskLog implements ISedTaskLog {
   @Prop({ type: String, required: true, default: undefined })
   id!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -284,7 +284,7 @@ export class SedTaskLog implements ISedTaskLog {
   @Prop({ type: Number, required: false, default: undefined })
   duration!: number | null;
 
-  @Prop({ 
+  @Prop({
     type: String,
     required: false,
     default: undefined,
@@ -319,8 +319,8 @@ export class SedDocumentLog implements ISedDocumentLog {
   @Prop({ type: String, required: true, default: undefined })
   location!: string;
 
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];
@@ -367,8 +367,8 @@ outputsArraySchema.discriminator(SedPlot3DLog.name, SedPlot3DLogSchema);
   strict: 'throw',
 })
 export class CombineArchiveLog implements ICombineArchiveLog {
-  @Prop({ 
-    type: String, 
+  @Prop({
+    type: String,
     enum: Object.entries(SimulationRunLogStatus).map(
       (keyVal: [string, string]): string => {
         return keyVal[1];

--- a/apps/api/src/logs/logs.model.ts
+++ b/apps/api/src/logs/logs.model.ts
@@ -5,11 +5,397 @@
  * @license MIT
  */
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
-import { CombineArchiveLog } from '@biosimulations/datamodel/api';
+import { 
+  CombineArchiveLog as ICombineArchiveLog,
+  SedDocumentLog as ISedDocumentLog,
+  SedTaskLog as ISedTaskLog,
+  SimulatorDetail as ISimulatorDetail,
+  SedOutputLog as ISedOutputLog,
+  SedReportLog as ISedReportLog,
+  SedPlot2DLog as ISedPlot2DLog,
+  SedPlot3DLog as ISedPlot3DLog,
+  SedOutputElementLog as ISedOutputElementLog,
+  SimulationRunLogStatus,
+  Exception as IException,
+} from '@biosimulations/datamodel/common';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { Types, Document } from 'mongoose';
+import { Types, Document, Schema as MongooseSchema } from 'mongoose';
 import { ObjectIdValidator } from '@biosimulations/datamodel-database';
 import { SimulationRunModel } from '../simulation-run/simulation-run.model';
+import {
+  Ontologies,
+  KisaoIdRegEx,
+} from '@biosimulations/datamodel/common';
+import { OntologiesService } from '@biosimulations/ontology/ontologies';
+// import { addValidationForNullableAttributes } from '@biosimulations/datamodel-database';
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class Exception implements IException {
+  @Prop({ type: String, required: true, default: undefined })
+  category!: string;
+
+  @Prop({ type: String, required: true, default: undefined })
+  message!: string;
+}
+export const ExceptionSchema =
+  SchemaFactory.createForClass(Exception);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedOutputElementLog implements ISedOutputElementLog{
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+}
+export const SedOutputElementLogSchema =
+  SchemaFactory.createForClass(SedOutputElementLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedReportLog implements ISedReportLog {
+  _type!: string;
+
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ type: [SedOutputElementLogSchema], required: false, default: undefined })
+  dataSets!: ISedOutputElementLog[] | null;
+}
+export const SedReportLogSchema =
+  SchemaFactory.createForClass(SedReportLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedPlot2DLog implements ISedPlot2DLog {
+  _type!: string;
+
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ type: [SedOutputElementLogSchema], required: false, default: undefined })
+  curves!: ISedOutputElementLog[] | null;
+}
+export const SedPlot2DLogSchema =
+  SchemaFactory.createForClass(SedPlot2DLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedPlot3DLog implements ISedPlot3DLog {
+  _type!: string;
+
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ type: [SedOutputElementLogSchema], required: false, default: undefined })
+  surfaces!: ISedOutputElementLog[] | null;
+}
+export const SedPlot3DLogSchema =
+  SchemaFactory.createForClass(SedPlot3DLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+  discriminatorKey: '_type',
+})
+export class SedOutputLog implements ISedOutputLog {
+  @Prop({
+    type: String,
+    required: true,
+    enum: [SedReportLog.name, SedPlot2DLog.name, SedPlot3DLog.name],
+    default: undefined,
+  })
+  _type!: string;
+
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+}
+export const SedOutputLogSchema =
+  SchemaFactory.createForClass(SedOutputLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SimulatorDetail implements ISimulatorDetail {
+  @Prop({ type: String, required: true, default: undefined })
+  key!: string;
+
+  @Prop({ type: Object, required: false, default: undefined })
+  value!: any;
+}
+export const SimulatorDetailSchema =
+  SchemaFactory.createForClass(SimulatorDetail);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedTaskLog implements ISedTaskLog {
+  @Prop({ type: String, required: true, default: undefined })
+  id!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ 
+    type: String,
+    required: false,
+    default: undefined,
+    validate: [
+      {
+        validator: (value: any): boolean => {
+          if (typeof value === 'string') {
+            return value.match(KisaoIdRegEx) !== null && OntologiesService.isTermId(Ontologies.KISAO, value);
+          } else {
+            return value === null;
+          }
+        },
+        message: (props: any): string =>
+          `${props.value} is not an id of a KiSAO term`,
+      },
+    ],
+  })
+  algorithm!: string | null;
+
+  @Prop({ type: [SimulatorDetailSchema], required: false, default: undefined })
+  simulatorDetails!: ISimulatorDetail[] | null;
+}
+export const SedTaskLogSchema =
+  SchemaFactory.createForClass(SedTaskLog);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class SedDocumentLog implements ISedDocumentLog {
+  @Prop({ type: String, required: true, default: undefined })
+  location!: string;
+
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ type: [SedTaskLogSchema], required: false, default: undefined })
+  tasks!: ISedTaskLog[] | null;
+
+  @Prop({
+    type: [SedOutputLogSchema],
+    required: false,
+    default: undefined,
+  })
+  outputs!: (SedReportLog | SedPlot2DLog | SedPlot3DLog)[] | null;
+}
+export const SedDocumentLogSchema =
+  SchemaFactory.createForClass(SedDocumentLog);
+
+const outputsArraySchema = SedDocumentLogSchema.path('outputs') as MongooseSchema.Types.DocumentArray;
+outputsArraySchema.discriminator(SedReportLog.name, SedReportLogSchema);
+outputsArraySchema.discriminator(SedPlot2DLog.name, SedPlot2DLogSchema);
+outputsArraySchema.discriminator(SedPlot3DLog.name, SedPlot3DLogSchema);
+
+@Schema({
+  _id: false,
+  storeSubdocValidationError: false,
+  strict: 'throw',
+})
+export class CombineArchiveLog implements ICombineArchiveLog {
+  @Prop({ 
+    type: String, 
+    enum: Object.entries(SimulationRunLogStatus).map(
+      (keyVal: [string, string]): string => {
+        return keyVal[1];
+      },
+    ),
+    required: true,
+    default: undefined,
+  })
+  status!: SimulationRunLogStatus;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  exception!: IException | null;
+
+  @Prop({ type: ExceptionSchema, required: false, default: undefined })
+  skipReason!: IException | null;
+
+  @Prop({ type: String, required: false, default: undefined })
+  output!: string | null;
+
+  @Prop({ type: Number, required: false, default: undefined })
+  duration!: number | null;
+
+  @Prop({ type: [SedDocumentLogSchema], required: false, default: undefined })
+  sedDocuments!: ISedDocumentLog[] | null;
+}
+export const CombineArchiveLogSchema =
+  SchemaFactory.createForClass(CombineArchiveLog);
 
 @Schema({ collection: 'Simulation Run Logs', minimize: false })
 export class SimulationRunLog extends Document {
@@ -19,14 +405,13 @@ export class SimulationRunLog extends Document {
     validate: ObjectIdValidator,
     unique: true,
     index: true,
+    required: true,
+    default: undefined,
   })
   simId!: string;
 
-  @Prop({ type: Object })
-  log!: CombineArchiveLog;
-
-  @Prop({ type: String, text: true })
-  stdOut!: string;
+  @Prop({ type: CombineArchiveLogSchema, required: true, default: undefined })
+  log!: ICombineArchiveLog;
 
   @Prop()
   created!: Date;
@@ -40,3 +425,16 @@ SimulationRunLogSchema.set('timestamps', {
   createdAt: 'created',
   updatedAt: 'updated',
 });
+
+SimulationRunLogSchema.set('strict', 'throw');
+CombineArchiveLogSchema.set('strict', 'throw');
+SedDocumentLogSchema.set('strict', 'throw');
+SedTaskLogSchema.set('strict', 'throw');
+SedOutputLogSchema.set('strict', 'throw');
+SedReportLogSchema.set('strict', 'throw');
+SedPlot2DLogSchema.set('strict', 'throw');
+SedPlot3DLogSchema.set('strict', 'throw');
+SimulatorDetailSchema.set('strict', 'throw');
+SedOutputElementLogSchema.set('strict', 'throw');
+ExceptionSchema.set('strict', 'throw');
+// addValidationForNullableAttributes(SimulationRunLogSchema);

--- a/apps/api/src/logs/logs.module.ts
+++ b/apps/api/src/logs/logs.module.ts
@@ -6,7 +6,14 @@ import {
   SimulationRunModelSchema,
 } from '../simulation-run/simulation-run.model';
 import { LogsController } from './logs.controller';
-import { SimulationRunLog, SimulationRunLogSchema } from './logs.model';
+import {
+  SimulationRunLog, SimulationRunLogSchema, 
+  CombineArchiveLog, CombineArchiveLogSchema,
+  SedOutputLog, SedOutputLogSchema,
+  SedReportLog, SedReportLogSchema,
+  SedPlot2DLog, SedPlot2DLogSchema,
+  SedPlot3DLog, SedPlot3DLogSchema,
+} from './logs.model';
 
 import { LogsService } from './logs.service';
 
@@ -17,6 +24,16 @@ import { LogsService } from './logs.service';
     MongooseModule.forFeature([
       { name: SimulationRunLog.name, schema: SimulationRunLogSchema },
       { name: SimulationRunModel.name, schema: SimulationRunModelSchema },
+      { name: CombineArchiveLog.name, schema: CombineArchiveLogSchema },
+      {
+        name: SedOutputLog.name,
+        schema: SedOutputLogSchema,
+        discriminators: [
+          { name: SedReportLog.name, schema: SedReportLogSchema },
+          { name: SedPlot2DLog.name, schema: SedPlot2DLogSchema },
+          { name: SedPlot3DLog.name, schema: SedPlot3DLogSchema },
+        ],
+      },
     ]),
   ],
 

--- a/apps/api/src/logs/logs.module.ts
+++ b/apps/api/src/logs/logs.module.ts
@@ -7,7 +7,7 @@ import {
 } from '../simulation-run/simulation-run.model';
 import { LogsController } from './logs.controller';
 import {
-  SimulationRunLog, SimulationRunLogSchema, 
+  SimulationRunLog, SimulationRunLogSchema,
   CombineArchiveLog, CombineArchiveLogSchema,
   SedOutputLog, SedOutputLogSchema,
   SedReportLog, SedReportLogSchema,

--- a/apps/api/src/logs/logs.service.spec.ts
+++ b/apps/api/src/logs/logs.service.spec.ts
@@ -3,15 +3,15 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Server } from 'http';
 import { SimulationRunModel } from '../simulation-run/simulation-run.model';
-import { SimulationRunLog } from './logs.model';
+import { SimulationRunLog, CombineArchiveLog } from './logs.model';
 import { LogsService } from './logs.service';
 
 describe('LogsService', () => {
   let service: LogsService;
-  class mockLogModel {
+  class mockModel {
     constructor(private data: any) {}
     static save = jest.fn().mockResolvedValue('test');
-    save = mockLogModel.save;
+    save = mockModel.save;
     static find = jest.fn().mockResolvedValue({});
     static findOne = jest.fn().mockResolvedValue({});
     static findOneAndUpdate = jest.fn().mockResolvedValue({});
@@ -24,7 +24,11 @@ describe('LogsService', () => {
         LogsService,
         {
           provide: getModelToken(SimulationRunLog.name),
-          useValue: mockLogModel,
+          useValue: mockModel,
+        },
+        {
+          provide: getModelToken(CombineArchiveLog.name),
+          useValue: mockModel,
         },
       ],
       imports: [BiosimulationsConfigModule],

--- a/apps/api/src/logs/logs.service.ts
+++ b/apps/api/src/logs/logs.service.ts
@@ -12,8 +12,8 @@ import { Injectable, ConflictException, BadRequestException, NotFoundException, 
 import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
 import {
-  SimulationRunLog, 
-  CombineArchiveLog as DbCombineArchiveLog, 
+  SimulationRunLog,
+  CombineArchiveLog as DbCombineArchiveLog,
   SedReportLog as DbSedReportLog,
   SedPlot2DLog as DbSedPlot2DLog,
   SedPlot3DLog as DbSedPlot3DLog,
@@ -27,7 +27,7 @@ export class LogsService {
 
   public constructor(
     private configService: ConfigService,
-    @InjectModel(SimulationRunLog.name)    
+    @InjectModel(SimulationRunLog.name)
     private logModel: Model<SimulationRunLog>,
     @InjectModel(DbCombineArchiveLog.name)
     private validateModel: Model<DbCombineArchiveLog>,
@@ -67,7 +67,7 @@ export class LogsService {
       projection['log.output'] = 0;
       projection['log.sedDocuments.output'] = 0;
       projection['log.sedDocuments.tasks.output'] = 0;
-      projection['log.sedDocuments.outputs.output'] = 0;      
+      projection['log.sedDocuments.outputs.output'] = 0;
     }
 
     const log = await this.logModel
@@ -249,7 +249,7 @@ export class LogsService {
       return apiException;
     }
 
-    const dbException:any = {}; 
+    const dbException:any = {};
     Object.assign(dbException, apiException);
     return dbException;
   }

--- a/apps/api/src/logs/logs.service.ts
+++ b/apps/api/src/logs/logs.service.ts
@@ -8,7 +8,7 @@ import {
   CombineArchiveLog as ApiCombineArchiveLog,
 } from '@biosimulations/datamodel/common';
 
-import { Injectable, ConflictException, BadRequestException, NotFoundException, Logger } from '@nestjs/common';
+import { Injectable, BadRequestException, NotFoundException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
 import {
@@ -42,8 +42,7 @@ export class LogsService {
       log: this.apiToDbCombineArchiveLog(apiLog),
     });
 
-    let res: SimulationRunLog;
-    res = await log.save();
+    const res: SimulationRunLog = await log.save();
     return this.dbToApiCombineArchiveLog(res);
   }
 

--- a/apps/api/src/logs/logs.service.ts
+++ b/apps/api/src/logs/logs.service.ts
@@ -43,19 +43,7 @@ export class LogsService {
     });
 
     let res: SimulationRunLog;
-    try {
-      res = await log.save();
-    } catch (e) {
-      if (e.name == 'MongoError' && e.code == 11000) {
-        throw new ConflictException(
-          `Log with run id: ${runId} already exists`,
-        );
-      } else {
-        // Will be caught by other filters
-        throw e;
-      }
-    }
-
+    res = await log.save();
     return this.dbToApiCombineArchiveLog(res);
   }
 

--- a/apps/api/src/logs/logs.service.ts
+++ b/apps/api/src/logs/logs.service.ts
@@ -4,13 +4,22 @@
  * @copyright Biosimulations Team, 2020
  * @license MIT
  */
-import { CombineArchiveLog } from '@biosimulations/datamodel/api';
+import {
+  CombineArchiveLog as ApiCombineArchiveLog,
+} from '@biosimulations/datamodel/common';
 
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, ConflictException, BadRequestException, NotFoundException, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { InjectModel } from '@nestjs/mongoose';
-import { SimulationRunLog } from './logs.model';
-import { Model } from 'mongoose';
+import {
+  SimulationRunLog, 
+  CombineArchiveLog as DbCombineArchiveLog, 
+  SedReportLog as DbSedReportLog,
+  SedPlot2DLog as DbSedPlot2DLog,
+  SedPlot3DLog as DbSedPlot3DLog,
+} from './logs.model';
+import { Model, LeanDocument } from 'mongoose';
+
 @Injectable()
 export class LogsService {
   private logger = new Logger(LogsService.name);
@@ -18,28 +27,244 @@ export class LogsService {
 
   public constructor(
     private configService: ConfigService,
-    @InjectModel(SimulationRunLog.name)
+    @InjectModel(SimulationRunLog.name)    
     private logModel: Model<SimulationRunLog>,
+    @InjectModel(DbCombineArchiveLog.name)
+    private validateModel: Model<DbCombineArchiveLog>,
   ) {}
-
+  
   public async createLog(
-    id: string,
-    data: CombineArchiveLog,
-  ): Promise<SimulationRunLog> {
+    runId: string,
+    apiLog: ApiCombineArchiveLog,
+  ): Promise<DbCombineArchiveLog> {
     const log = new this.logModel({
-      simId: id,
-      log: data,
+      simId: runId,
+      log: this.apiToDbCombineArchiveLog(apiLog),
     });
 
-    return log.save();
+    let res: SimulationRunLog;
+    try {
+      res = await log.save();
+    } catch (e) {
+      if (e.name == 'MongoError' && e.code == 11000) {
+        throw new ConflictException(
+          `Log with run id: ${runId} already exists`,
+        );
+      } else {
+        // Will be caught by other filters
+        throw e;
+      }
+    }
+
+    return this.dbToApiCombineArchiveLog(res);
   }
 
-  public async getLog(id: string): Promise<CombineArchiveLog | null> {
-    const log = await this.logModel.findOne({ simId: id }).exec();
-    if (log) {
-      return log.log;
-    } else {
-      return null;
+  public async getLog(runId: string, includeOutput=true): Promise<LeanDocument<ApiCombineArchiveLog>> {
+    const projection: any = {
+      'log.sedDocuments.outputs._type': 0,
+    };
+    if (!includeOutput) {
+      projection['log.output'] = 0;
+      projection['log.sedDocuments.output'] = 0;
+      projection['log.sedDocuments.tasks.output'] = 0;
+      projection['log.sedDocuments.outputs.output'] = 0;      
     }
+
+    const log = await this.logModel
+      .findOne({ simId: runId }, projection)
+      .lean()
+      .exec();
+
+    if (!log) {
+      throw new NotFoundException(`No log exists for simulation run ${runId}`);
+    }
+
+    return log.log;
+  }
+
+  public async replaceLog(runId: string, apiLog: ApiCombineArchiveLog): Promise<ApiCombineArchiveLog> {
+    const log = await this.logModel.findOne({ simId: runId }).exec();
+
+    if (!log) {
+      throw new NotFoundException(`No log exists for simulation run ${runId}`);
+    }
+
+    log.overwrite({
+      simId: runId,
+      log: this.apiToDbCombineArchiveLog(apiLog),
+    });
+    const res = await log.save();
+    return this.dbToApiCombineArchiveLog(res);
+  }
+
+  public async deleteLog(runId: string): Promise<ApiCombineArchiveLog> {
+    const projection: any = {
+      'log.sedDocuments.outputs._type': 0,
+    };
+    const log = await this.logModel
+      .findOne({ simId: runId }, projection)
+      .lean()
+      .exec();
+
+    if (!log) {
+      throw new NotFoundException(`No log exists for simulation run ${runId}`);
+    }
+    const deleted = await this.logModel
+      .findOneAndDelete({ simId: runId })
+      .exec();
+
+    return log.log;
+  }
+
+  public validateLog(apiLog: ApiCombineArchiveLog): Promise<void> {
+    const log = new this.validateModel(this.apiToDbCombineArchiveLog(apiLog));
+    return log.validate();
+  }
+
+  private apiToDbCombineArchiveLog(apiLog: any): any {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+    if (Array.isArray(apiLog.sedDocuments)) {
+      dbLog.sedDocuments = apiLog.sedDocuments.map(this.apiToDbSedDocumentLog.bind(this));
+    }
+    return dbLog;
+  }
+
+  private apiToDbSedDocumentLog(apiLog: any): any {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+
+    if (Array.isArray(apiLog.tasks)) {
+      dbLog.tasks = apiLog.tasks.map(this.apiToDbSedTaskLog.bind(this));
+    }
+
+    if (Array.isArray(apiLog.outputs)) {
+      dbLog.outputs = apiLog.outputs.map(this.apiToDbSedOutputLog.bind(this)) as (DbSedReportLog | DbSedPlot2DLog | DbSedPlot3DLog)[];
+    }
+
+    return dbLog;
+  }
+
+  private apiToDbSedTaskLog(apiLog: any): any {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+    if (Array.isArray(apiLog.simulatorDetails)) {
+      dbLog.simulatorDetails = apiLog.simulatorDetails.map(this.apiToDbSimulatorDetail.bind(this));
+    }
+    return dbLog;
+  }
+
+  private apiToDbSimulatorDetail(apiLog: any): any {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    return dbLog;
+  }
+
+  private apiToDbSedOutputLog(apiLog: any): any
+  {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    if ('dataSets' in apiLog) {
+      return this.apiToDbSedReportLog(apiLog);
+    } else if ('curves' in apiLog) {
+      return this.apiToDbSedPlot2DLog(apiLog);
+    } else if ('surfaces' in apiLog) {
+      return this.apiToDbSedPlot3DLog(apiLog);
+    } else {
+      throw new BadRequestException('A SED output log is invalid');
+    }
+  }
+
+  private apiToDbSedReportLog(apiLog: any): any {
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog._type = DbSedReportLog.name;
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+    if (Array.isArray(apiLog.dataSets)) {
+      dbLog.dataSets = apiLog.dataSets.map(this.apiToDbSedOutputElementLog.bind(this));
+    }
+    return dbLog;
+  }
+
+  private apiToDbSedPlot2DLog(apiLog: any): any {
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog._type = DbSedPlot2DLog.name;
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+    if (Array.isArray(apiLog.curves)) {
+      dbLog.curves = apiLog.curves.map(this.apiToDbSedOutputElementLog.bind(this));
+    }return dbLog;
+  }
+
+  private apiToDbSedPlot3DLog(apiLog: any): any {
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    dbLog._type = DbSedPlot3DLog.name;
+    dbLog.exception = this.apiToDbException(apiLog.exception);
+    dbLog.skipReason = this.apiToDbException(apiLog.skipReason);
+    if (Array.isArray(apiLog.surfaces)) {
+      dbLog.surfaces = apiLog.surfaces.map(this.apiToDbSedOutputElementLog.bind(this));
+    }
+    return dbLog;
+  }
+
+  private apiToDbSedOutputElementLog(apiLog: any): any {
+    if (!(apiLog instanceof Object)) {
+      return apiLog;
+    }
+
+    const dbLog: any = {};
+    Object.assign(dbLog, apiLog);
+    return dbLog;
+  }
+
+  private apiToDbException(apiException: any): any {
+    if (!(apiException instanceof Object)) {
+      return apiException;
+    }
+
+    const dbException:any = {}; 
+    Object.assign(dbException, apiException);
+    return dbException;
+  }
+
+  private dbToApiCombineArchiveLog(dbRunLog: SimulationRunLog): ApiCombineArchiveLog {
+    const dbLog = dbRunLog.toObject().log;
+
+    dbLog?.sedDocuments?.forEach((sedDocumentLog): void => {
+      sedDocumentLog?.outputs?.forEach((outputLog): void => {
+        if ('_type' in (outputLog as any)) {
+          delete (outputLog as any)._type;
+        }
+      });
+    });
+
+    return dbLog as ApiCombineArchiveLog;
   }
 }

--- a/apps/api/src/results/results.service.ts
+++ b/apps/api/src/results/results.service.ts
@@ -36,7 +36,7 @@ export class ResultsService {
     simId: string,
     datasetId: string,
   ): Promise<undefined | (string[] | number[] | boolean[])[]> {
-    // The index feild will be needed when we are doing slicing of the data so this will need to change
+    // The index field will be needed when we are doing slicing of the data so this will need to change
     // TODO update the hsds client to use the correct name "value" not "values"
     return ((await this.results.getDatasetValues(simId, datasetId)) as any)
       ?.value;

--- a/apps/api/tsconfig.spec.json
+++ b/apps/api/tsconfig.spec.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "../../dist/out-tsc",
     "module": "commonjs",
-    "types": ["jest", "node"]
+    "types": ["jest", "node"],
+    "resolveJsonModule": true
   },
   "include": ["**/*.spec.ts", "**/*.d.ts", "../../declarations.d.ts"]
 }

--- a/apps/simulators-api/src/main.ts
+++ b/apps/simulators-api/src/main.ts
@@ -3,7 +3,7 @@
  * This is only a minimal backend to get started.
  */
 
-import { Logger, INestApplication } from '@nestjs/common';
+import { Logger, INestApplication, ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app/app.module';
 import {
@@ -20,6 +20,7 @@ import {
 import { Resolver } from '@stoplight/json-ref-resolver';
 import * as toJsonSchema from '@openapi-contrib/openapi-schema-to-json-schema';
 import { json } from 'body-parser';
+import { BiosimulationsValidationExceptionFactory } from '@biosimulations/shared/exceptions';
 
 function setupOpenApi(
   app: INestApplication,
@@ -188,6 +189,16 @@ async function bootstrap() {
 
   const limit = configService.get('server.limit');
   app.use(json({ limit }));
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      exceptionFactory: BiosimulationsValidationExceptionFactory,
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   await app.listen(port, () => {
     Logger.log('Listening at http://localhost:' + port + '/');

--- a/apps/simulators-api/src/simulators/simulators.controller.ts
+++ b/apps/simulators-api/src/simulators/simulators.controller.ts
@@ -276,12 +276,12 @@ export class SimulatorsController {
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
     description:
-      'The specifications of the simulation tool are invalid. See https://api.biosimulators.org for examples and documentation.',
+      'The specifications of the simulation tool are invalid. See https://biosimulators.org/conventions and https://api.biosimulators.org for examples and documentation.',
   })
   @ApiConflictResponse({
     type: ErrorResponseDocument,
     description:
-      'The version of the simulation tool could not be saved because the database already includes this version of this tool. Please use the `PUT` method to modify versions of simulation tools. Please see https://api.biosimulators.org for more information.',
+      'The version of the simulation tool could not be saved because the database already includes this version of this tool. Please use the `PUT` method to modify versions of simulation tools. Please see https://biosimulators.org/conventions and https://api.biosimulators.org for more information.',
   })
   @ApiUnauthorizedResponse({
     type: ErrorResponseDocument,
@@ -314,10 +314,10 @@ export class SimulatorsController {
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
     description:
-      'The specifications of the simulation tool are invalid. See https://api.biosimulators.org for examples and documentation.',
+      'The specifications of the simulation tool are invalid. See https://biosimulators.org/conventions and https://api.biosimulators.org for examples and documentation.',
   })
   @ApiNoContentResponse({
-    description: 'The specifications of teh simulation tool are valid',
+    description: 'The specifications of the simulation tool are valid',
   })
   @HttpCode(204)
   async validateSimulator(@Body() doc: Simulator) {
@@ -361,7 +361,7 @@ export class SimulatorsController {
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
     description:
-      'The specifications of the simulation tool are invalid. See https://api.biosimulators.org for examples and documentation.',
+      'The specifications of the simulation tool are invalid. See https://biosimulators.org/conventions and https://api.biosimulators.org for examples and documentation.',
   })
   @ApiUnauthorizedResponse({
     type: ErrorResponseDocument,

--- a/apps/simulators-api/src/simulators/simulators.service.ts
+++ b/apps/simulators-api/src/simulators/simulators.service.ts
@@ -72,19 +72,7 @@ export class SimulatorsService {
   public async new(doc: APISimulator): Promise<Simulator> {
     const sim = new this.simulator(doc);
     let res: Simulator;
-    try {
-      res = (await sim.save()).toJSON({ versionKey: false }) as Simulator;
-    } catch (e) {
-      if (e.name == 'MongoError' && e.code == 11000) {
-        throw new ConflictException(
-          `Simulator with id: ${e?.keyValue?.id}, version: ${e?.keyValue?.version} already exists`,
-        );
-      } else {
-        // Will be caught by other filters
-        console.log(e);
-        throw e;
-      }
-    }
+    res = (await sim.save()).toJSON({ versionKey: false }) as Simulator;
     return res;
   }
 

--- a/apps/simulators-api/src/simulators/simulators.service.ts
+++ b/apps/simulators-api/src/simulators/simulators.service.ts
@@ -1,6 +1,5 @@
 import {
   Injectable,
-  ConflictException,
   NotFoundException,
   InternalServerErrorException,
 } from '@nestjs/common';
@@ -71,8 +70,7 @@ export class SimulatorsService {
 
   public async new(doc: APISimulator): Promise<Simulator> {
     const sim = new this.simulator(doc);
-    let res: Simulator;
-    res = (await sim.save()).toJSON({ versionKey: false }) as Simulator;
+    const res: Simulator = (await sim.save()).toJSON({ versionKey: false }) as Simulator;
     return res;
   }
 

--- a/apps/simulators/src/app/conventions/simulation-logs/simulation-logs.component.html
+++ b/apps/simulators/src/app/conventions/simulation-logs/simulation-logs.component.html
@@ -233,7 +233,7 @@
             <a href="https://pypi.org/project/capturer/" target="_blank"
               ><biosimulations-icon icon="link"></biosimulations-icon></a
           ></b>
-          is a Python library for capturing standard ouput and standard error
+          is a Python library for capturing standard output and standard error
           streams.
         </li>
       </ul>

--- a/libs/datamodel/api/src/lib/common/url.ts
+++ b/libs/datamodel/api/src/lib/common/url.ts
@@ -1,6 +1,6 @@
 import { Url as IUrl, UrlType } from '@biosimulations/datamodel/common';
 import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, IsUrl } from 'class-validator';
+import { IsEnum, IsString, IsUrl, IsOptional } from 'class-validator';
 export class Url implements IUrl {
   @IsUrl({ require_valid_protocol: true, require_protocol: true })
   @ApiProperty({
@@ -10,6 +10,7 @@ export class Url implements IUrl {
   })
   public url!: string;
 
+  @IsOptional()
   @IsString()
   @ApiProperty({
     type: String,

--- a/libs/datamodel/api/src/lib/common/url.ts
+++ b/libs/datamodel/api/src/lib/common/url.ts
@@ -1,14 +1,16 @@
 import { Url as IUrl, UrlType } from '@biosimulations/datamodel/common';
 import { ApiProperty } from '@nestjs/swagger';
-
+import { IsEnum, IsString, IsUrl } from 'class-validator';
 export class Url implements IUrl {
+  @IsUrl({ require_valid_protocol: true, require_protocol: true })
   @ApiProperty({
     type: String,
     format: 'url',
     example: 'http://tellurium.analogmachine.org/',
   })
-  url!: string;
+  public url!: string;
 
+  @IsString()
   @ApiProperty({
     type: String,
     nullable: true,
@@ -16,8 +18,9 @@ export class Url implements IUrl {
     default: null,
     example: 'Home page',
   })
-  title!: string | null;
+  public title!: string | null;
 
+  @IsEnum(UrlType)
   @ApiProperty({ type: String, enum: UrlType })
-  type!: UrlType;
+  public type!: UrlType;
 }

--- a/libs/datamodel/api/src/lib/core/simulationRunLog.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRunLog.ts
@@ -1,6 +1,6 @@
 import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
 
-import {  
+import {
   CombineArchiveLog as ICombineArchiveLog,
   SedDocumentLog as ISedDocumentLog,
   SedTaskLog as ISedTaskLog,
@@ -146,9 +146,9 @@ export class SedTaskLog implements ISedTaskLog {
   duration!: number | null;
 
   @ApiProperty({
-    type: String, 
+    type: String,
     description: 'KiSAO id of the simulation algorithm that was executed',
-    example: 'KISAO_0000019', 
+    example: 'KISAO_0000019',
     nullable: true
   })
   algorithm!: string | null;

--- a/libs/datamodel/api/src/lib/core/simulationRunLog.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRunLog.ts
@@ -1,7 +1,19 @@
 import { ApiProperty, getSchemaPath } from '@nestjs/swagger';
-import { SimulationRunLogStatus as Status } from '@biosimulations/datamodel/common';
 
-export class Exception {
+import {  
+  CombineArchiveLog as ICombineArchiveLog,
+  SedDocumentLog as ISedDocumentLog,
+  SedTaskLog as ISedTaskLog,
+  SimulatorDetail as ISimulatorDetail,
+  SedReportLog as ISedReportLog,
+  SedPlot2DLog as ISedPlot2DLog,
+  SedPlot3DLog as ISedPlot3DLog,
+  SedOutputElementLog as ISedOutputElementLog,
+  SimulationRunLogStatus,
+  Exception as IException,
+} from '@biosimulations/datamodel/common';
+
+export class Exception implements IException {
   @ApiProperty({ type: String, example: 'FileNotFoundError' })
   category!: string;
 
@@ -9,20 +21,20 @@ export class Exception {
   message!: string;
 }
 
-export class SedOutputElementLog {
+export class SedOutputElementLog implements ISedOutputElementLog{
   @ApiProperty({ type: String })
   id!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 }
 
-export class SedReportLog {
+export class SedReportLog implements ISedReportLog {
   @ApiProperty({ type: String })
   id!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -45,12 +57,12 @@ export class SedReportLog {
   dataSets!: SedOutputElementLog[] | null;
 }
 
-export class SedPlot2DLog {
+export class SedPlot2DLog implements ISedPlot2DLog {
   @ApiProperty({ type: String })
   id!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -73,12 +85,12 @@ export class SedPlot2DLog {
   curves!: SedOutputElementLog[] | null;
 }
 
-export class SedPlot3DLog {
+export class SedPlot3DLog implements ISedPlot3DLog {
   @ApiProperty({ type: String })
   id!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -101,7 +113,7 @@ export class SedPlot3DLog {
   surfaces!: SedOutputElementLog[] | null;
 }
 
-export class SimulatorDetail {
+export class SimulatorDetail implements ISimulatorDetail {
   @ApiProperty({ type: String, example: 'arguments' })
   key!: string;
 
@@ -109,12 +121,12 @@ export class SimulatorDetail {
   value!: any;
 }
 
-export class SedTaskLog {
+export class SedTaskLog implements ISedTaskLog {
   @ApiProperty({ type: String })
   id!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -133,19 +145,24 @@ export class SedTaskLog {
   @ApiProperty({ type: Number, example: 10.5, nullable: true })
   duration!: number | null;
 
-  @ApiProperty({ type: String, example: 'KISAO_0000019', nullable: true })
+  @ApiProperty({
+    type: String, 
+    description: 'KiSAO id of the simulation algorithm that was executed',
+    example: 'KISAO_0000019', 
+    nullable: true
+  })
   algorithm!: string | null;
 
   @ApiProperty({ type: [SimulatorDetail], nullable: true })
   simulatorDetails!: SimulatorDetail[] | null;
 }
 
-export class SedDocumentLog {
+export class SedDocumentLog implements ISedDocumentLog {
   @ApiProperty({ type: String })
   location!: string;
 
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -181,9 +198,9 @@ export class SedDocumentLog {
   outputs!: (SedReportLog | SedPlot2DLog | SedPlot3DLog)[] | null;
 }
 
-export class CombineArchiveLog {
-  @ApiProperty({ type: String, enum: Status })
-  status!: Status;
+export class CombineArchiveLog implements ICombineArchiveLog {
+  @ApiProperty({ type: String, enum: SimulationRunLogStatus })
+  status!: SimulationRunLogStatus;
 
   @ApiProperty({ type: Exception, nullable: true })
   exception!: Exception | null;
@@ -209,6 +226,7 @@ export class CombineArchiveLog {
 export class CreateSimulationRunLogBody {
   @ApiProperty()
   simId!: string;
+
   @ApiProperty()
   log!: CombineArchiveLog;
 }

--- a/libs/datamodel/api/src/lib/core/simulator.ts
+++ b/libs/datamodel/api/src/lib/core/simulator.ts
@@ -19,6 +19,7 @@ import {
   IsNotEmpty,
   IsString,
   ValidateNested,
+  IsOptional,
 } from 'class-validator';
 import {
   Image,
@@ -73,6 +74,7 @@ export class Simulator implements ISimulator {
   })
   urls!: Url[];
 
+  @IsOptional()
   @ValidateNested()
   @Type(() => Image)
   @ApiProperty({
@@ -81,6 +83,7 @@ export class Simulator implements ISimulator {
   })
   image!: Image | null;
 
+  @IsOptional()
   @Allow()
   @ApiProperty({
     nullable: true,
@@ -88,6 +91,7 @@ export class Simulator implements ISimulator {
   })
   cli!: Cli | null;
 
+  @IsOptional()
   @Allow()
   @ApiProperty({
     nullable: true,
@@ -103,6 +107,7 @@ export class Simulator implements ISimulator {
   @ApiProperty({ type: ExternalReferences })
   references!: ExternalReferences;
 
+  @IsOptional()
   @Allow()
   @ApiProperty({ type: SpdxOntologyId, nullable: true })
   license!: SpdxOntologyId | null;

--- a/libs/datamodel/api/src/lib/core/simulator.ts
+++ b/libs/datamodel/api/src/lib/core/simulator.ts
@@ -13,7 +13,13 @@ import {
   ISimulator,
 } from '@biosimulations/datamodel/common';
 import { ApiProperty } from '@nestjs/swagger';
-
+import {
+  Allow,
+  IsArray,
+  IsNotEmpty,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
 import {
   Image,
   Cli,
@@ -21,11 +27,15 @@ import {
   Algorithm,
   BiosimulatorsMeta,
 } from '../simulators';
+import { Type } from 'class-transformer';
 
 export class Simulator implements ISimulator {
+  @Allow()
   @ApiProperty({ type: BiosimulatorsMeta })
   biosimulators!: BiosimulatorsMeta;
 
+  @IsString()
+  @IsNotEmpty()
   @ApiProperty({
     type: String,
     example: 'tellurium',
@@ -33,15 +43,21 @@ export class Simulator implements ISimulator {
   })
   id!: string;
 
+  @IsString()
+  @IsNotEmpty()
   @ApiProperty({ type: String, example: 'tellurium' })
   name!: string;
 
+  @IsString()
+  @IsNotEmpty()
   @ApiProperty({
     type: String,
     example: '2.1.6',
   })
   version!: string;
 
+  @IsString()
+  @IsNotEmpty()
   @ApiProperty({
     type: String,
     example:
@@ -49,58 +65,73 @@ export class Simulator implements ISimulator {
   })
   description!: string;
 
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Url)
   @ApiProperty({
     type: [Url],
   })
   urls!: Url[];
 
+  @ValidateNested()
+  @Type(() => Image)
   @ApiProperty({
     nullable: true,
     type: Image,
   })
   image!: Image | null;
 
+  @Allow()
   @ApiProperty({
     nullable: true,
     type: Cli,
   })
   cli!: Cli | null;
 
+  @Allow()
   @ApiProperty({
     nullable: true,
     type: PythonApi,
   })
   pythonApi!: PythonApi | null;
 
+  @Allow()
   @ApiProperty({ type: [Person] })
   authors!: Person[];
 
+  @Allow()
   @ApiProperty({ type: ExternalReferences })
   references!: ExternalReferences;
 
+  @Allow()
   @ApiProperty({ type: SpdxOntologyId, nullable: true })
   license!: SpdxOntologyId | null;
 
+  @Allow()
   @ApiProperty({ type: [Algorithm] })
   algorithms!: Algorithm[];
 
+  @Allow()
   @ApiProperty({
     type: [String],
     enum: SoftwareInterfaceType,
   })
   interfaceTypes!: SoftwareInterfaceType[];
 
+  @Allow()
   @ApiProperty({
     type: [String],
     enum: OperatingSystemType,
   })
   supportedOperatingSystemTypes!: OperatingSystemType[];
 
+  @Allow()
   @ApiProperty({
     type: [LinguistOntologyId],
   })
   supportedProgrammingLanguages!: LinguistOntologyId[];
 
+  @Allow()
   @ApiProperty({
     type: [Funding],
   })

--- a/libs/datamodel/api/src/lib/simulators/image.ts
+++ b/libs/datamodel/api/src/lib/simulators/image.ts
@@ -4,12 +4,13 @@ import { EdamOntologyIdVersion } from '../common';
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsEnum,
-  IsHash,
   IsNotEmpty,
   IsString,
   ValidateNested,
+  IsOptional,
 } from 'class-validator';
 import { Type } from 'class-transformer';
+import { IsImageDigest } from '@biosimulations/datamodel/utils';
 
 export class Image implements IImage {
   @IsString()
@@ -22,8 +23,7 @@ export class Image implements IImage {
   public url!: string;
 
   @IsNotEmpty()
-  // TODO remove sha256 prefix from hash
-  //@IsHash('sha256')
+  @IsImageDigest()
   @ApiProperty({
     type: String,
     description: 'Repository digest for the image',
@@ -41,6 +41,7 @@ export class Image implements IImage {
   })
   public format!: EdamOntologyIdVersion;
 
+  @IsOptional()
   @IsEnum(OperatingSystemType)
   @ApiProperty({
     type: String,

--- a/libs/datamodel/api/src/lib/simulators/image.ts
+++ b/libs/datamodel/api/src/lib/simulators/image.ts
@@ -2,15 +2,28 @@ import { IImage, OperatingSystemType } from '@biosimulations/datamodel/common';
 import { EdamOntologyIdVersion } from '../common';
 
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEnum,
+  IsHash,
+  IsNotEmpty,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class Image implements IImage {
+  @IsString()
+  @IsNotEmpty()
   @ApiProperty({
     type: String,
     description: 'URL for the image',
     example: 'ghcr.io/virtualcell/biosimulators_vcell:latest',
   })
-  url!: string;
+  public url!: string;
 
+  @IsNotEmpty()
+  // TODO remove sha256 prefix from hash
+  //@IsHash('sha256')
   @ApiProperty({
     type: String,
     description: 'Repository digest for the image',
@@ -18,19 +31,22 @@ export class Image implements IImage {
       'sha256:5d1595553608436a2a343f8ab7e650798ef5ba5dab007b9fe31cd342bf18ec81',
     pattern: '^sha256:[a-z0-9]{64,64}$',
   })
-  digest!: string;
+  public digest!: string;
 
+  @ValidateNested()
+  @Type(() => EdamOntologyIdVersion)
   @ApiProperty({
     type: EdamOntologyIdVersion,
     description: 'Format of the image',
   })
-  format!: EdamOntologyIdVersion;
+  public format!: EdamOntologyIdVersion;
 
+  @IsEnum(OperatingSystemType)
   @ApiProperty({
     type: String,
     enum: OperatingSystemType,
     nullable: true,
     description: 'Operating system in the image',
   })
-  operatingSystemType!: OperatingSystemType | null;
+  public operatingSystemType!: OperatingSystemType | null;
 }

--- a/libs/datamodel/utils/src/index.ts
+++ b/libs/datamodel/utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/datamodel-utils';
+export * from './lib/isImageDigest';

--- a/libs/datamodel/utils/src/lib/isImageDigest.spec.ts
+++ b/libs/datamodel/utils/src/lib/isImageDigest.spec.ts
@@ -1,0 +1,21 @@
+import { IsImageDigestConstraint } from './isImageDigest';
+
+describe('isImageDigest', () => {
+  it('Should Accept valid digests', () => {
+    const value =
+      'sha256:1234567890123456789012345678901234567890123456789012345678901234';
+    expect(new IsImageDigestConstraint().validate(value)).toBe(true);
+  });
+
+  it('Should reject invalid digests', () => {
+    const value =
+      'sha256:1234567890abcdef1234567890abcdef1234567890cdef1234567890abcdef';
+    expect(new IsImageDigestConstraint().validate(value)).toBe(false);
+  });
+
+  it('Should reject digest without prefix', () => {
+    const value =
+      '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
+    expect(new IsImageDigestConstraint().validate(value)).toBe(false);
+  });
+});

--- a/libs/datamodel/utils/src/lib/isImageDigest.ts
+++ b/libs/datamodel/utils/src/lib/isImageDigest.ts
@@ -8,7 +8,7 @@ import {
 } from 'class-validator';
 
 export function IsImageDigest(validationOptions?: ValidationOptions) {
-  return function (object: Object, propertyName: string) {
+  return function (object: object, propertyName: string) {
     registerDecorator({
       name: 'isImageDigest',
       target: object.constructor,

--- a/libs/datamodel/utils/src/lib/isImageDigest.ts
+++ b/libs/datamodel/utils/src/lib/isImageDigest.ts
@@ -1,0 +1,35 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+  isHash,
+  ValidatorConstraint,
+  ValidatorConstraintInterface,
+} from 'class-validator';
+
+export function IsImageDigest(validationOptions?: ValidationOptions) {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'isImageDigest',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: validationOptions,
+      validator: IsImageDigestConstraint,
+    });
+  };
+}
+
+@ValidatorConstraint({ name: 'isImageDigest' })
+export class IsImageDigestConstraint implements ValidatorConstraintInterface {
+  public validate(value: any, args?: ValidationArguments): boolean {
+    const isString = value && typeof value === 'string';
+    const hasPrefix = value.startsWith('sha256:');
+    const hash = hasPrefix ? value.substring(7) : value;
+    const isValidHash = isHash(hash, 'sha256');
+    return isString && isValidHash && hasPrefix;
+  }
+
+  public defaultMessage(validationArguments?: ValidationArguments): string {
+    return 'An image digest must be a valid sha256 hash with the "sha256:" prefix';
+  }
+}

--- a/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
@@ -1,13 +1,16 @@
 import { HttpStatus, ValidationError } from '@nestjs/common';
 import { BiosimulationsException } from './exception';
-
+import { inspect } from 'util';
 export const BiosimulationsValidationExceptionFactory = (
   errors: ValidationError[],
 ): BiosimulationsException => {
-  // TODO handle all errors, not just first one
+  // TODO handle multiple errors
+  // TODO parse the validation error to create readable error messages
+  // Need to recursively parse the errors and children, get the path names, and the eror message for each
   const err = errors[0];
-  const message =
-    'Parameter or property "' + err.property + '" failed validation';
+  const message = `Parameter or property '${
+    err.property
+  }''  with value ${inspect(err.value)} failed validation`;
 
   const bioSimErr = new BiosimulationsException(
     HttpStatus.BAD_REQUEST,
@@ -17,7 +20,7 @@ export const BiosimulationsValidationExceptionFactory = (
     undefined,
     err.property,
     undefined,
-    { ...err },
+    [...errors],
   );
 
   return bioSimErr;

--- a/libs/shared/exceptions/filters/src/lib/default.filter.ts
+++ b/libs/shared/exceptions/filters/src/lib/default.filter.ts
@@ -27,7 +27,7 @@ export class DefaultFilter implements ExceptionFilter {
       'message' in exception
     ) {
       status = exception.status;
-      title = exception.error || exception.message;
+      title = exception.message;
       detail = exception.message;
 
       if (status === 413) {

--- a/libs/shared/exceptions/filters/src/lib/filters/Mongo/MongoError.ts
+++ b/libs/shared/exceptions/filters/src/lib/filters/Mongo/MongoError.ts
@@ -27,7 +27,7 @@ export class MongoErrorFilter implements ExceptionFilter {
       case 11000: {
         const error = makeErrorObject(
           HttpStatus.CONFLICT,
-          'Key Conflcit',
+          'Key Conflict',
           `The value for a unique key was already present in the database`,
           undefined,
           undefined,

--- a/libs/shared/exceptions/filters/src/lib/filters/Mongo/MongoError.ts
+++ b/libs/shared/exceptions/filters/src/lib/filters/Mongo/MongoError.ts
@@ -23,10 +23,12 @@ export class MongoErrorFilter implements ExceptionFilter {
     const response = ctx.getResponse<Response>();
     const errors: ErrorObject[] = [];
     const code = err.code;
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
     switch (code) {
       case 11000: {
+        status = HttpStatus.CONFLICT;
         const error = makeErrorObject(
-          HttpStatus.CONFLICT,
+          status,
           'Key Conflict',
           `The value for a unique key was already present in the database`,
           undefined,
@@ -41,7 +43,7 @@ export class MongoErrorFilter implements ExceptionFilter {
       }
       default: {
         const error = makeErrorObject(
-          HttpStatus.INTERNAL_SERVER_ERROR,
+          status,
           'Database Error',
           err.message,
           undefined,
@@ -57,6 +59,6 @@ export class MongoErrorFilter implements ExceptionFilter {
 
     const responseError: ErrorResponseDocument = { error: errors };
     this.logger.log(responseError);
-    response.status(HttpStatus.CONFLICT).json(responseError);
+    response.status(status).json(responseError);
   }
 }

--- a/libs/shared/exceptions/filters/src/lib/filters/Mongo/validation-exception.filter.ts
+++ b/libs/shared/exceptions/filters/src/lib/filters/Mongo/validation-exception.filter.ts
@@ -43,11 +43,11 @@ export class ValidationExceptionFilter implements ExceptionFilter {
 
     const responseError: ErrorResponseDocument = { error: errors };
     this.logger.log(responseError);
-    /* Return a 500 error since this is a validation error at the dataabase level
-     * It is the developers/api responsibility to make sure data sent to the database is valid
+    /* Return a 500 error since this is a validation error at the database level
+     * It is the developers/API responsibility to make sure data sent to the database is valid
      * If the user provides a bad input, this should be caught before trying to save to the database,
-     * in the api validation layer. That layer should return a 400 error.
-     * This is a fallback for when the api validation layer misses something, and should be corrected.
+     * in the API validation layer. That layer should return a 400 error.
+     * This is a fallback for when the API validation layer misses something, and should be corrected.
      * */
 
     response.status(HttpStatus.INTERNAL_SERVER_ERROR).json(responseError);


### PR DESCRIPTION
closes #2048 
closes #3370

@bilalshaikh42 a few issues still need to be addressed:

## Log validation errors are reported with code 500
Example:
```
{
  "error": [
    {
      "status": "500",
      "title": "Database CastError",
      "detail": "Cast to Number failed for value \"x\" (type string) at path \"duration\"",
      "source": {
        "pointer": "/duration"
      }
    }
  ]
}
```

## Delete all simulators executes successfully, but raises a 500 error
```
{
  "error": [
    {
      "status": "500",
      "title": "Operation Failed",
      "detail": "\"Operation Failed\""
    }
  ]
}
```

## The simulators API appears to be missing similar validation handling to the API
The simulators API doesn't have this:
```
app.useGlobalPipes(
    new ValidationPipe({
      exceptionFactory: BiosimulationsValidationExceptionFactory,
      transform: true,
      transformOptions: {
        enableImplicitConversion: true,
      },
    }),
  );
```