### PR TITLE
refactor(dispatch): added re-trying for similar algorithms

### DIFF
--- a/libs/shared/angular/src/lib/retry/retry.service.ts
+++ b/libs/shared/angular/src/lib/retry/retry.service.ts
@@ -7,10 +7,15 @@ export class RetryStrategy {
     private maxAttempts = 7,
     private initialDelayMs = 1000,
     private scalingFactor = 2,
-    private includedStatusCodes: number[] = [
+    private includedStatusCodes: (number | undefined)[] = [
+      undefined,
+      HttpStatusCode.RequestTimeout,
       HttpStatusCode.InternalServerError,
+      HttpStatusCode.BadGateway,
+      HttpStatusCode.GatewayTimeout,
+      HttpStatusCode.ServiceUnavailable,
     ],
-    private excludedStatusCodes: number[] = [],
+    private excludedStatusCodes: (number | undefined)[] = [],
     private shouldErrorBeRetried: (error: HttpErrorResponse) => boolean = (
       error: HttpErrorResponse,
     ) => true,


### PR DESCRIPTION
Failures are due to long (few seconds) burn in time. Due to server-side caching in Python which stores the successful part of the computation, this is alleviating by simply retrying the request.

closes #3434 