### PR TITLE
fix(dispatch-service): add a temporary check for mistructured logs

### DIFF
--- a/apps/dispatch-service/src/app/results/log.service.ts
+++ b/apps/dispatch-service/src/app/results/log.service.ts
@@ -40,6 +40,17 @@ export class LogService {
       (await this.readStdLog(path)) + (extraStdLog ? extraStdLog : '');
 
     log.output = stdLog;
+    // accounts for a potential error in the logs where "type" is used instead of "category" (see #3482)
+    if (
+      log?.exception?.message &&
+      (log?.exception as any)?.type &&
+      !log?.exception?.category
+    ) {
+      log.exception.category = (log.exception as any)?.type;
+      delete (log.exception as any)?.type;
+    }
+    log.output = log?.exception?.message + '\n' + log.output;
+
     return log;
   }
 


### PR DESCRIPTION
see #3482. Add a check for logs that have a "type" for the exception instead of the required
"category"

workaround for #3482