### PR TITLE
refactor(dispatch-service): cleaned up and documented methods

### DIFF
--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -42,10 +42,10 @@ export class HpcService {
   ): Promise<{
     stdout: string;
     stderr: string;
-  }> {    
+  }> {
     const simDirname = `${this.configService.get('hpc.hpcBaseDir')}/${runId}`;
 
-    const sbatchString = this.sbatchService.generateSbatch(      
+    const sbatchString = this.sbatchService.generateSbatch(
       runId,
       simulator,
       simulatorVersion,
@@ -59,7 +59,7 @@ export class HpcService {
     );
 
     // eslint-disable-next-line max-len
-    const sbatchFilename = `${simDirname}/${runId}.sbatch`;    
+    const sbatchFilename = `${simDirname}/${runId}.sbatch`;
     const command = `mkdir ${simDirname} && echo "${sbatchString}" > ${sbatchFilename} && chmod +x ${sbatchFilename} && sbatch ${sbatchFilename}`;
 
     const res = this.sshService.execStringCommand(command);
@@ -67,7 +67,7 @@ export class HpcService {
     return res.catch((err) => {
       console.error(`The job for simulation run '${runId}' could not be submitted.`);
       return {
-        stdout: '', 
+        stdout: '',
         stderr: `The job for simulation run '${runId}' could not be submitted: ${err}`,
       };
     });

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -121,7 +121,6 @@ export class SbatchService {
       false,
     );
 
-    // TODO Remove the no check flag
     const template = `#!/bin/bash
 #SBATCH --job-name=${runId}_Biosimulations
 #SBATCH --time=${maxTimeFormatted}
@@ -169,7 +168,10 @@ export PYTHONWARNINGS="ignore"; srun aws --no-verify-ssl --endpoint-url ${endpoi
    * @param dockerImageUrl URL for the Docker image
    * @param forceOverwrite whether to overwrite an existing Singularity image file, if it exists
    */
-  public generateImageUpdateSbatch(dockerImageUrl: string, forceOverwrite: boolean): string {
+  public generateImageUpdateSbatch(
+    dockerImageUrl: string,
+    forceOverwrite: boolean,
+  ): string {
     const homeDir = this.configService.get('hpc.homeDir');
     const singularityImageName = dockerImageUrl
       .split('docker://ghcr.io/biosimulators/')[1]
@@ -196,7 +198,9 @@ echo "Building On:"
 hostname
 echo "Using Singularity"
 singularity --version
-singularity -v pull --tmpdir /local ${forceOverwrite ? '--force' : ''} ${dockerImageUrl}`;
+singularity -v pull --tmpdir /local ${
+      forceOverwrite ? '--force' : ''
+    } ${dockerImageUrl}`;
     return template;
   }
 }

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -18,7 +18,7 @@ export class SbatchService {
 
   private logger = new Logger(SbatchService.name);
 
-  /** Generate a SLURM script to execute a COMBINE/OMEX archive  
+  /** Generate a SLURM script to execute a COMBINE/OMEX archive
    * @param runId id of the simulation run
    * @param simulator BioSimulators id of the simulation tool (e.g., `tellurium`)
    * @param simulatorVersion version of the simulation tool (e.g., `2.2.1`)
@@ -31,7 +31,7 @@ export class SbatchService {
    * @param workDirname absolute path to a directory which should be used as the working directory
    *        for exeucting the COMBINE/OMEX archive, including where outputs should be saved
    */
-  public generateSbatch(    
+  public generateSbatch(
     runId: string,
     simulator: string,
     simulatorVersion: string,
@@ -166,7 +166,7 @@ export PYTHONWARNINGS="ignore"; srun aws --no-verify-ssl --endpoint-url ${endpoi
   }
 
   /** Generate SLURM script to pull a Docker image and convert it to a Singularity image
-   * @param dockerImageUrl URL for the Docker image 
+   * @param dockerImageUrl URL for the Docker image
    * @param forceOverwrite whether to overwrite an existing Singularity image file, if it exists
    */
   public generateImageUpdateSbatch(dockerImageUrl: string, forceOverwrite: boolean): string {

--- a/apps/dispatch-service/src/images/images.controller.ts
+++ b/apps/dispatch-service/src/images/images.controller.ts
@@ -22,8 +22,8 @@ export class ImagesController {
   async refreshImage(data: ImageMessagePayload) {
     const url = data.url;
     const homeDir = this.configService.get('hpc.homeDir');
-    const force = data.force ? '--force' : '';
-    this.logger.log('sending command to update' + data.url);
+    const force = data.force;
+    this.logger.log('Sending command to update ' + url);
     const sbatch = this.sbatchService.generateImageUpdateSbatch(url, force);
     const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch updateImage.sbatch`;
     const out = await this.sshSerivce.execStringCommand(command);


### PR DESCRIPTION
Closes #1904

@bilalshaikh42
- [ ] Does this address what you intended in #1904? I think the concerns are well-separated now, and its fine to keep the services as separate modules.
- [ ] Do we still need `srun aws --no-verify-ssl`?