### PR TITLE
feat(combine-api): add dynamic module for combine api-client

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -14,6 +14,7 @@
     "auth-nest": "libs/auth/nest",
     "combine-api": "apps/combine-api",
     "combine-api-client": "libs/combine/api-client",
+    "combine-nest-client": "libs/combine/nest-client",
     "config-angular": "libs/config/angular",
     "config-common": "libs/config/common",
     "config-nest": "libs/config/nest",

--- a/libs/combine/api-client/src/lib/.openapi-generator-ignore
+++ b/libs/combine/api-client/src/lib/.openapi-generator-ignore
@@ -21,3 +21,4 @@
 #docs/*.md
 # Then explicitly reverse the ignore rule for a single file:
 #!docs/README.md
+

--- a/libs/combine/nest-client/.babelrc
+++ b/libs/combine/nest-client/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/combine/nest-client/.eslintrc.json
+++ b/libs/combine/nest-client/.eslintrc.json
@@ -1,0 +1,33 @@
+{
+  "extends": [
+    "../../../.eslintrc.json"
+  ],
+  "ignorePatterns": [
+    "!**/*"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.ts",
+        "*.tsx"
+      ],
+      "rules": {}
+    },
+    {
+      "files": [
+        "*.js",
+        "*.jsx"
+      ],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/combine/nest-client/README.md
+++ b/libs/combine/nest-client/README.md
@@ -1,0 +1,10 @@
+# combine-nest-client
+
+This library was generated with [Nx](https://nx.dev).
+
+
+## Running unit tests
+
+Run `nx test combine-nest-client` to execute the unit tests via [Jest](https://jestjs.io).
+
+

--- a/libs/combine/nest-client/jest.config.js
+++ b/libs/combine/nest-client/jest.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  displayName: 'combine-nest-client',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/libs/combine/nest-client',
+};

--- a/libs/combine/nest-client/project.json
+++ b/libs/combine/nest-client/project.json
@@ -1,0 +1,34 @@
+{
+  "root": "libs/combine/nest-client",
+  "sourceRoot": "libs/combine/nest-client/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": [
+        "{options.outputFile}"
+      ],
+      "options": {
+        "lintFilePatterns": [
+          "libs/combine/nest-client/**/*.ts"
+        ]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": [
+        "coverage/libs/combine/nest-client"
+      ],
+      "options": {
+        "jestConfig": "libs/combine/nest-client/jest.config.js",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": [
+    "shared:true",
+    "scope:combine",
+    "platform:server",
+    "type:client"
+  ]
+}

--- a/libs/combine/nest-client/src/index.ts
+++ b/libs/combine/nest-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/combine-nest-client.module';

--- a/libs/combine/nest-client/src/lib/combine-nest-client.module.ts
+++ b/libs/combine/nest-client/src/lib/combine-nest-client.module.ts
@@ -1,0 +1,84 @@
+import {
+  Module,
+  Global,
+  DynamicModule,
+  Provider,
+  Abstract,
+  Type,
+} from '@nestjs/common';
+import {
+  Configuration as CombineAPIConfiguration,
+  ApiModule,
+} from '@biosimulations/combine-api-client';
+
+export { CombineAPIConfiguration };
+export interface CombineAPIConnectionOptions {
+  username: string;
+  password: string;
+  basePath: string;
+  withCredentials?: boolean;
+}
+export type CombineAPIConnectionOptionsFactory = (
+  ...args: any[]
+) => CombineAPIConfiguration;
+
+export interface CombineAPIConnectionAsyncOptions {
+  imports: any[];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  inject: (string | symbol | Function | Type<any> | Abstract<any>)[];
+  useFactory: CombineAPIConnectionOptionsFactory;
+}
+
+import { ConfigService } from '@nestjs/config';
+@Global()
+@Module({
+  controllers: [],
+  providers: [],
+  exports: [ApiModule],
+})
+export class CombineNestClientModule {
+  public static async forRootAsync(
+    options: CombineAPIConnectionAsyncOptions,
+  ): Promise<DynamicModule> {
+    const imports = options.imports || [];
+    const dynamicImports = await this.getImports(options);
+    const finalImports = imports.concat(dynamicImports);
+
+    const providers = await this.getProviders(options);
+    return {
+      module: CombineNestClientModule,
+      providers: providers,
+      imports: finalImports,
+    };
+  }
+  private static async getImports(
+    options: CombineAPIConnectionAsyncOptions,
+  ): Promise<DynamicModule[]> {
+    return [
+      ...options.imports,
+      {
+        module: ApiModule,
+        providers: [
+          {
+            provide: CombineAPIConfiguration,
+            useFactory: options.useFactory,
+            inject: [ConfigService],
+          },
+        ],
+      },
+    ];
+  }
+  private static async getProviders(
+    options: CombineAPIConnectionAsyncOptions,
+  ): Promise<Provider<CombineAPIConfiguration>[]> {
+    {
+      return [
+        {
+          provide: CombineAPIConfiguration,
+          useFactory: options.useFactory,
+          inject: options.inject || [],
+        },
+      ];
+    }
+  }
+}

--- a/libs/combine/nest-client/tsconfig.json
+++ b/libs/combine/nest-client/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  }
+}

--- a/libs/combine/nest-client/tsconfig.lib.json
+++ b/libs/combine/nest-client/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": [
+      "node"
+    ],
+    "target": "es6",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "exclude": [
+    "**/*.spec.ts"
+  ],
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/libs/combine/nest-client/tsconfig.spec.json
+++ b/libs/combine/nest-client/tsconfig.spec.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/*.spec.js",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -53,6 +53,9 @@
         "dist/libs/combine/api-client",
         "libs/combine/api-client/src/index.ts"
       ],
+      "@biosimulations/combine-nest-client": [
+        "libs/combine/nest-client/src/index.ts"
+      ],
       "@biosimulations/config/angular": [
         "libs/config/angular/src/index.ts"
       ],


### PR DESCRIPTION
adds a dyamic module that selects the basepath for the combine api client based on the current
environment.

closes #3180
