### PR TITLE
refactor(dispatch-service): improved error handling, error messages

### DIFF
--- a/apps/api/src/metadata/metadata.controller.ts
+++ b/apps/api/src/metadata/metadata.controller.ts
@@ -211,7 +211,7 @@ export class MetadataController {
     const metadata = await this.service.getMetadata(runId);
 
     if (!metadata) {
-      throw new NotFoundException(`Metadata with id ${runId} not found`);
+      throw new NotFoundException(`Metadata could not be found for simulation run '${runId}'.`);
     }
     const simId = metadata.simulationRun;
     const data = metadata.metadata;

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -94,7 +94,7 @@ export class ProjectsController {
     if (proj) {
       return this.returnProject(proj);
     }
-    throw new NotFoundException(`Project with id ${projectId} not found`);
+    throw new NotFoundException(`Project with id ${projectId} not found.`);
   }
 
   @ApiOperation({
@@ -210,7 +210,7 @@ export class ProjectsController {
     if (proj) {
       return this.returnProject(proj);
     }
-    throw new NotFoundException(`Project with id ${projectId} not found`);
+    throw new NotFoundException(`Project with id ${projectId} not found.`);
   }
 
   // @Delete()

--- a/apps/api/src/results/results.service.ts
+++ b/apps/api/src/results/results.service.ts
@@ -67,13 +67,13 @@ export class ResultsService {
         return file.Body;
       } else {
         throw new NotFoundException(
-          `Results could not be found for run '${runId}'.`,
+          `Results could not be found for simulation run '${runId}'.`,
         );
       }
     } catch (error) {
       if (error.statusCode === HttpStatus.NOT_FOUND) {
         throw new NotFoundException(
-          `Results could not be found for run '${runId}'.`,
+          `Results could not be found for simulation run '${runId}'.`,
         );
       } else {
         throw error;

--- a/apps/api/src/simulation-run/simulation-run.controller.ts
+++ b/apps/api/src/simulation-run/simulation-run.controller.ts
@@ -342,7 +342,7 @@ export class SimulationRunController {
       permission ? null : (run.email = null);
       return this.makeSimulationRun(run);
     } else {
-      throw new NotFoundException(`No simulation run with id ${runId}`);
+      throw new NotFoundException(`No simulation run with id '${runId}'.`);
     }
   }
 
@@ -390,7 +390,7 @@ export class SimulationRunController {
     @Param('runId') runId: string,
     @Body() body: UpdateSimulationRun,
   ): Promise<SimulationRun> {
-    this.logger.log(`Patch called for ${runId} with ${JSON.stringify(body)}`);
+    this.logger.log(`Patch called for simulation run '${runId}' with ${JSON.stringify(body)}`);
     const run = await this.service.update(runId, body);
     return this.makeSimulationRun(run);
   }

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -204,7 +204,7 @@ export class SimulationRunService {
       .exec();
     if (project) {
       throw new BadRequestException(
-        `Run '${id}' cannot be deleted because it has been published as project '${project.id}'.`,
+        `Simulation run '${id}' cannot be deleted because it has been published as project '${project.id}'.`,
       );
     }
 

--- a/apps/api/src/specifications/specifications.controller.ts
+++ b/apps/api/src/specifications/specifications.controller.ts
@@ -89,7 +89,7 @@ export class SpecificationsController {
     const specs = await this.service.getSpecificationsBySimulation(runId);
     if (specs.length === 0) {
       throw new NotFoundException(
-        `No specifications found for simulation ${runId}`,
+        `No specifications could be found for simulation run '${runId}'.`,
       );
     }
     return specs.map(this.returnSpec);
@@ -134,7 +134,7 @@ export class SpecificationsController {
     const spec = await this.service.getSpecification(runId, experimentLocation);
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for experiment '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return this.returnSpec(spec);
@@ -194,7 +194,7 @@ export class SpecificationsController {
     );
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${modelId} at location ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for model '${modelId}' at location '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return spec;
@@ -254,7 +254,7 @@ export class SpecificationsController {
     );
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${simulationId} at location ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for simulation '${simulationId}' at location '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return spec;
@@ -314,7 +314,7 @@ export class SpecificationsController {
     );
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${taskId} at location ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for task '${taskId}' at location '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return spec;
@@ -374,7 +374,7 @@ export class SpecificationsController {
     );
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${dataGeneratorId} at location ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for data generator '${dataGeneratorId}' at location '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return spec;
@@ -434,7 +434,7 @@ export class SpecificationsController {
     );
     if (!spec) {
       throw new NotFoundException(
-        `Specification with id ${outputId} at location ${experimentLocation} for simulation ${runId} not found`,
+        `Specifications could not be found for output '${outputId}' at location '${experimentLocation}' for simulation run '${runId}'.`,
       );
     }
     return spec;

--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -65,7 +65,7 @@ export class HpcService {
 
     // eslint-disable-next-line max-len
     const sbatchFilename = `${simDirname}/${runId}.sbatch`;
-    const command = `mkdir ${simDirname} && echo "${sbatchString}" > ${sbatchFilename} && chmod +x ${sbatchFilename} && sbatch --job-name="Simulation-run-${runId}" ${sbatchFilename}`;
+    const command = `mkdir ${simDirname} && echo "${sbatchString}" > ${sbatchFilename} && chmod +x ${sbatchFilename} && sbatch ${sbatchFilename}`;
 
     const res = this.sshService.execStringCommand(command);
 

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -46,6 +46,9 @@ export class SbatchService {
     const homeDir = this.configService.get('hpc.homeDir');
     const storageBucket = this.configService.get('storage.bucket');
     let storageEndpoint = this.configService.get('storage.endpoint');
+    const hsdsBasePath = this.configService.get('data.basePath');
+    const hsdsUsername = this.configService.get('data.username');
+    const hsdsPassword = this.configService.get('data.password');
 
     const simulatorImage = `docker://ghcr.io/biosimulators/${simulator}:${simulatorVersion}`;
 
@@ -152,7 +155,7 @@ echo -e '${cyan}============================================= Executing COMBINE 
 srun --job-name="Execute-project" singularity run --tmpdir /local --bind ${workDirname}:/root "${allEnvVarsString}" ${simulatorImage} -i '/root/${combineArchiveFilename}' -o '/root'
 echo -e ''
 echo -e '${cyan}=================================================== Saving results ==================================================${nc}'
-srun --job-name="Save-outputs-to-HSDS" hsload --verbose reports.h5 '${simulationRunResultsHsdsPath}'
+srun --job-name="Save-outputs-to-HSDS" hsload --endpoint ${hsdsBasePath} --username ${hsdsUsername} --password ${hsdsPassword} --verbose reports.h5 '${simulationRunResultsHsdsPath}'
 echo -e ''
 echo -e '${cyan}================================================== Zipping outputs ==================================================${nc}'
 srun --job-name="Zip-outputs" zip '${outputArchiveS3Subpath}' reports.h5 log.yml plots.zip job.output

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -190,7 +190,7 @@ export PYTHONWARNINGS="ignore"; srun --job-name="Save-outputs-to-S3" aws --no-ve
     const modulePath = this.configService.get('hpc.module.path');
     const moduleInitScript = this.configService.get('hpc.module.initScript');
     
-    const slurmPartition = this.configService.get('hpc.slurm.partition');  
+    const slurmPartition = this.configService.get('hpc.slurm.partition');
     const slurmQos = this.configService.get('hpc.slurm.qos');
     
     const singularityModule = this.configService.get('hpc.singularity.module');

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -177,10 +177,14 @@ export PYTHONWARNINGS="ignore"; srun --job-name="Save-outputs-to-S3" aws --no-ve
   }
 
   /** Generate SLURM script to pull a Docker image and convert it to a Singularity image
+   * @param simulator id of the simulator
+   * @param simulatorVersion version of the simulator
    * @param dockerImageUrl URL for the Docker image
    * @param forceOverwrite whether to overwrite an existing Singularity image file, if it exists
    */
   public generateImageUpdateSbatch(
+    simulator: string,
+    simulatorVersion: string,
     dockerImageUrl: string,
     forceOverwrite: boolean,
   ): string {
@@ -206,7 +210,7 @@ export PYTHONWARNINGS="ignore"; srun --job-name="Save-outputs-to-S3" aws --no-ve
     const memory = this.configService.get('hpc.buildSingularityImage.memory');
 
     const template = `#!/bin/bash
-#SBATCH --job-name=Build-simulator-${data.simulator}-${data.version}
+#SBATCH --job-name=Build-simulator-${simulator}-${simulatorVersion}
 #SBATCH --time=${maxTime}
 #SBATCH --chdir=${singularityPullFolder}
 #SBATCH --partition=${slurmPartition}

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -40,7 +40,7 @@ export class CompleteProcessor {
     const projectOwner = data.projectOwner;
 
     this.logger.debug(
-      `Simulation ${id} finished. Saving files, specifications, results, logs, metadata ...`,
+      `Simulation run '${id}' finished. Saving files, specifications, results, logs, metadata ...`,
     );
 
     const processingSteps = [
@@ -136,12 +136,12 @@ export class CompleteProcessor {
     if (errors.length === 0) {
       status = SimulationRunStatus.SUCCEEDED;
       statusReason = 'The simulation run was successfully proccessed.';
-      updateStatusMessage = `Updated status of simulation ${id} to ${status}`;
+      updateStatusMessage = `Updated status of simulation run '${id}' to '${status}'.`;
     } else {
       status = SimulationRunStatus.FAILED;
       statusReason = 'The simulation run was not successfully proccessed.';
       statusReason += '\n\nErrors:\n  * ' + errors.join('\n  * ');
-      updateStatusMessage = `Updated status of simulation run '${id}' to ${status} due to one or more processing errors:\n  * ${errorsDetails.join(
+      updateStatusMessage = `Updated status of simulation run '${id}' to '${status}' due to one or more processing errors:\n  * ${errorsDetails.join(
         '\n  * ',
       )}`;
     }
@@ -183,7 +183,7 @@ export class CompleteProcessor {
       .createLog(id, true, extraStdLog, logPostSucceeded)
       .catch((run) =>
         this.logger.error(
-          `Log for simulation run '${id}' could not be updated`,
+          `Log for simulation run '${id}' could not be updated.`,
         ),
       );
 
@@ -213,12 +213,12 @@ export class CompleteProcessor {
             .toPromise()
             .then((project) =>
               this.logger.log(
-                `Updated project ${projectId} for simulation ${id}`,
+                `Updated project '${projectId}' for simulation '${id}'.`,
               ),
             )
             .catch((err) =>
               this.logger.log(
-                `Project ${projectId} could not be updated with simulation ${id}`,
+                `Project '${projectId}' could not be updated with simulation '${id}'.`,
               ),
             );
         })
@@ -229,12 +229,12 @@ export class CompleteProcessor {
               .toPromise()
               .then((project) =>
                 this.logger.log(
-                  `Created project ${projectId} for simulation ${id}`,
+                  `Created project '${projectId}' for simulation '${id}'.`,
                 ),
               )
               .catch((err) =>
                 this.logger.log(
-                  `Project ${projectId} could not be created with simulation run '${id}'.`,
+                  `Project '${projectId}' could not be created with simulation run '${id}'.`,
                 ),
               );
           } else {

--- a/apps/dispatch-service/src/file/file.service.ts
+++ b/apps/dispatch-service/src/file/file.service.ts
@@ -33,7 +33,7 @@ export class FileService {
   }
 
   public async processFiles(id: string): Promise<void> {
-    this.logger.log(`Processing files for ${id}`);
+    this.logger.log(`Processing files for simulation run '${id}'.`);
     const url = this.endpoints.getRunDownloadEndpoint(id, true);
 
     const files: Observable<ProjectFile[]> = this.combine

--- a/apps/dispatch-service/src/images/images.controller.ts
+++ b/apps/dispatch-service/src/images/images.controller.ts
@@ -25,7 +25,7 @@ export class ImagesController {
     const force = data.force;
     this.logger.log('Sending command to update ' + url);
     const sbatch = this.sbatchService.generateImageUpdateSbatch(url, force);
-    const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch updateImage.sbatch`;
+    const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch -job-name="Update-simulator-${data.simulator}-${data.version}" updateImage.sbatch`;
     const out = await this.sshSerivce.execStringCommand(command);
 
     if (out.stderr != '') {

--- a/apps/dispatch-service/src/images/images.controller.ts
+++ b/apps/dispatch-service/src/images/images.controller.ts
@@ -24,7 +24,7 @@ export class ImagesController {
     const homeDir = this.configService.get('hpc.homeDir');
     const force = data.force;
     this.logger.log('Sending command to update ' + url);
-    const sbatch = this.sbatchService.generateImageUpdateSbatch(url, force);
+    const sbatch = this.sbatchService.generateImageUpdateSbatch(data.simulator, data.version, url, force);
     const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch updateImage.sbatch`;
     const out = await this.sshSerivce.execStringCommand(command);
 

--- a/apps/dispatch-service/src/images/images.controller.ts
+++ b/apps/dispatch-service/src/images/images.controller.ts
@@ -25,7 +25,7 @@ export class ImagesController {
     const force = data.force;
     this.logger.log('Sending command to update ' + url);
     const sbatch = this.sbatchService.generateImageUpdateSbatch(url, force);
-    const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch -job-name="Update-simulator-${data.simulator}-${data.version}" updateImage.sbatch`;
+    const command = `echo "${sbatch}" > updateImage.sbatch && chmod +x updateImage.sbatch && sbatch updateImage.sbatch`;
     const out = await this.sshSerivce.execStringCommand(command);
 
     if (out.stderr != '') {

--- a/apps/dispatch-service/src/metadata/metadata.service.ts
+++ b/apps/dispatch-service/src/metadata/metadata.service.ts
@@ -49,7 +49,7 @@ export class MetadataService {
     const combineMetadata: BioSimulationsCombineArchiveElementMetadata[] =
       res.data;
 
-    this.logger.log(`Extracted metadata for ${id}`);
+    this.logger.log(`Extracted metadata for simulation run '${id}'.`);
     //this.logger.error(JSON.stringify(combineMetadata))
 
     const metadata: ArchiveMetadata[] = combineMetadata
@@ -63,7 +63,7 @@ export class MetadataService {
         },
       )
       .map(this.convertMetadata, this);
-    this.logger.log(`Converted metadata for ${id}`);
+    this.logger.log(`Converted metadata for simulation run '${id}'.`);
     const postMetadata: SimulationRunMetadataInput = {
       id: id,
       metadata,
@@ -73,10 +73,10 @@ export class MetadataService {
 
     const metadataPostObserver = {
       next: (res: SimulationRunMetadata) => {
-        this.logger.log(`Posted metadata for ${id}`);
+        this.logger.log(`Posted metadata for simulation run '${id}'.`);
       },
       error: (err: AxiosError) => {
-        this.logger.error(`Failed to post metadata for ${id}`);
+        this.logger.error(`Failed to post metadata for simulation run '${id}'.`);
         this.logger.error(err?.response?.data);
         // Its important to throw this error so that the calling service is aware posting metadata failed
         throw err;

--- a/apps/dispatch-service/src/sedml/sedml.service.ts
+++ b/apps/dispatch-service/src/sedml/sedml.service.ts
@@ -27,7 +27,7 @@ export class SedmlService {
   }
 
   public async processSedml(id: string): Promise<void> {
-    this.logger.log(`Processing SED-ML file for  ${id}`);
+    this.logger.log(`Processing SED-ML document for simulation run '${id}'.`);
     const url = this.endpoints.getRunDownloadEndpoint(id, true);
     const req = this.combine.getSedMlSpecs(undefined, url);
     const sedml = req.pipe(
@@ -35,7 +35,7 @@ export class SedmlService {
       pluck('contents'),
       map(this.getSpecsFromArchiveContent.bind(this, id)),
       mergeMap((sedmlSpecs: SimulationRunSedDocumentInput[]) => {
-        return this.submit.postSpecs(id, sedmlSpecs);
+        return this.submit.postSpecs(sedmlSpecs);
       }),
     );
 

--- a/apps/simulators-api/src/simulators/simulators.service.ts
+++ b/apps/simulators-api/src/simulators/simulators.service.ts
@@ -88,7 +88,7 @@ export class SimulatorsService {
 
     if (!sim) {
       throw new NotFoundException(
-        `No simulation tool has id '${id}' and version '${version}'`,
+        `No simulation tool has id '${id}' and version '${version}'.`,
       );
     }
     // Preserve the original date
@@ -105,7 +105,7 @@ export class SimulatorsService {
 
     if (!sim) {
       throw new NotFoundException(
-        `No simulation tool has id '${id}' and version '${version}'`,
+        `No simulation tool has id '${id}' and version '${version}'.`,
       );
     }
     const res: DeleteResult = await this.simulator
@@ -124,7 +124,7 @@ export class SimulatorsService {
   public async deleteMany(id: string): Promise<void> {
     let numVersions = await this.simulator.count({ id }).exec();
     if (numVersions === 0) {
-      throw new NotFoundException(`No simulation tool has id '${id}'`);
+      throw new NotFoundException(`No simulation tool has id '${id}'.`);
     }
 
     const res = await this.simulator.deleteMany({ id: id }).exec();

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -49,7 +49,6 @@ export class SimulationRunService {
   }
 
   public postSpecs(
-    id: string,
     specs: SimulationRunSedDocumentInput[],
   ): Observable<SimulationRunSedDocument[]> {
     const endpoint = this.endpoints.getSpecificationsEndpoint();

--- a/libs/config/nest/src/lib/biosimulations-hpc-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-hpc-config.ts
@@ -31,7 +31,7 @@ export default registerAs('hpc', () => {
       cpus: process.env.HPC_BUILD_SINGULARITY_IMAGE_CPUS,
       memory: process.env.HPC_BUILD_SINGULARITY_IMAGE_MEMORY,
     },
-    fileStorage: process.env.FILE_STORAGE,    
+    fileStorage: process.env.FILE_STORAGE,
   };
 
   return config;

--- a/libs/config/nest/src/lib/biosimulations-hpc-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-hpc-config.ts
@@ -10,9 +10,28 @@ export default registerAs('hpc', () => {
       username: process.env.HPC_SSH_USERNAME,
       privateKey: process.env.HPC_SSH_PRIVATE_KEY,
     },
-    homeDir: process.env.HPC_HOME_DIR || '/home/FCAM/crbmapi',
-    fileStorage: process.env.FILE_STORAGE,
     hpcBaseDir: process.env.HPC_BASE_DIR,
+    homeDir: process.env.HPC_HOME_DIR,
+    executablesPath: process.env.HPC_EXECUTABLES_PATH,
+    module: {
+      path: process.env.HPC_MODULE_PATH,
+      initScript: process.env.HPC_MODULE_INIT_SCRIPT,
+    },
+    slurm: {
+      partition: process.env.HPC_SLURM_PARTITION,
+      qos: process.env.HPC_SLURM_QOS,
+    },
+    singularity: {
+      module: process.env.HPC_SINGULARITY_MODULE,
+      cacheDir: process.env.HPC_SINGULARITY_CACHE_DIR,
+      pullFolder: process.env.HPC_SINGULARITY_PULL_FOLDER,
+    },
+    buildSingularityImage: {
+      maxTime: process.env.HPC_BUILD_SINGULARITY_IMAGE_MAX_TIME,
+      cpus: process.env.HPC_BUILD_SINGULARITY_IMAGE_CPUS,
+      memory: process.env.HPC_BUILD_SINGULARITY_IMAGE_MEMORY,
+    },
+    fileStorage: process.env.FILE_STORAGE,    
   };
 
   return config;

--- a/libs/config/nest/src/lib/biosimulations-server-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-server-config.ts
@@ -10,9 +10,9 @@ export default registerAs('server', () => {
 
   const host = process.env.HOST || urls[app];
 
-  const port = process.env.PORT || 3333;
+  const port = parseInt(process.env.SERVER_PORT);
 
-  const limit = process.env.LIMIT || '50mb';
+  const limit = process.env.SERVER_PAYLOAD_LIMIT;
   const config = {
     env,
     app,

--- a/libs/config/nest/src/lib/biosimulations-server-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-server-config.ts
@@ -10,7 +10,7 @@ export default registerAs('server', () => {
 
   const host = process.env.HOST || urls[app];
 
-  const port = parseInt(process.env.SERVER_PORT);
+  const port = process.env.SERVER_PORT ? parseInt(process.env.SERVER_PORT) : undefined;
 
   const limit = process.env.SERVER_PAYLOAD_LIMIT;
   const config = {

--- a/libs/config/nest/src/lib/biosimulations-storage-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-storage-config.ts
@@ -2,13 +2,12 @@ import { registerAs } from '@nestjs/config';
 
 export default registerAs('storage', () => {
   const config = {
-    endpoint: process.env.STORAGE_ENDPOINT || 'http://s3low.scality.uchc.edu',
+    endpoint: process.env.STORAGE_ENDPOINT,
+    externalEndpoint: process.env.STORAGE_EXTERNAL_ENDPOINT,
     accessKey: process.env.STORAGE_ACCESS_KEY,
     secret: process.env.STORAGE_SECRET,
-    bucket: process.env.STORAGE_BUCKET || 'biosimdev',
-    publicEndpoint:
-      process.env.STORAGE_PUBLIC_ENDPOINT ||
-      'https://files-dev.biosimulations.org/s3/',
+    bucket: process.env.STORAGE_BUCKET,
+    publicEndpoint: process.env.STORAGE_PUBLIC_ENDPOINT,
   };
   return config;
 });


### PR DESCRIPTION
- [x] Make unzip an `srun` command
- [x] Improve error handling
  - Assigned names to `srun` and `sbatch` calls
  - Check the state of all `srun` jobs
  - Use names to report clearer error messages
- [x] Correct handling of HSDS endpoints and credentials
  - Previously `hsload` was using configuration in `.hscfg`
  - This was disconnected from the configuration in the secrets repo
  - Different configuration for dev vs prod was not handled. Errors were masked because both were using the same configuration.
- [x] Correct payload limit for API
- [x] Organize configuration for HPC
- [x] Remove configuration hard coded in `libs/config/nest/src/lib/`
- [x] Image error and log messages 
