### PR TITLE
perf(api): don't return the log after creating

### DIFF
--- a/apps/api/src/logs/logs.controller.ts
+++ b/apps/api/src/logs/logs.controller.ts
@@ -155,7 +155,6 @@ export class LogsController {
   @permissions(scopes.logs.create.id)
   @ApiCreatedResponse({
     description: 'The logs for the simulation run were successfully saved',
-    type: CombineArchiveLog,
   })
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
@@ -169,9 +168,8 @@ export class LogsController {
   })
   public async createLog(
     @Body() body: CreateSimulationRunLogBody,
-  ): Promise<ICombineArchiveLog> {
+  ): Promise<void> {
     const log = await this.service.createLog(body?.simId, body?.log);
-    return log;
   }
 
   @ApiOperation({

--- a/apps/api/src/metadata/metadata.controller.ts
+++ b/apps/api/src/metadata/metadata.controller.ts
@@ -110,7 +110,6 @@ export class MetadataController {
   })
   @ApiCreatedResponse({
     description: 'The metadata was successfully saved to the database',
-    type: SimulationRunMetadata,
   })
   @Post()
   @ApiUnauthorizedResponse({
@@ -124,16 +123,10 @@ export class MetadataController {
   @permissions(scopes.metadata.create.id)
   public async makeMetadata(
     @Body() body: SimulationRunMetadataInput,
-  ): Promise<SimulationRunMetadata> {
+  ): Promise<void> {
     const input = { ...body, simulationRun: body.id };
-    const metadata = await this.service.createMetadata(input);
-    const data = metadata.metadata;
-    return new SimulationRunMetadata(
-      metadata.simulationRun,
-      data,
-      metadata.created,
-      metadata.updated,
-    );
+    await this.service.createMetadata(input);
+    return;
   }
 
   @ApiOperation({

--- a/apps/api/src/projects/projects.controller.ts
+++ b/apps/api/src/projects/projects.controller.ts
@@ -143,16 +143,15 @@ export class ProjectsController {
   })
   @ApiCreatedResponse({
     description: 'The simulation run was successfully published',
-    type: Project,
   })
   @OptionalAuth()
   public async createProject(
     @Body() project: ProjectInput,
     @Req() req: Request,
-  ): Promise<Project> {
+  ): Promise<void> {
     const user = req?.user as AuthToken;
-    const proj = await this.service.createProject(project, user);
-    return this.returnProject(proj);
+    await this.service.createProject(project, user);
+    return;
   }
 
   @Put(':projectId')

--- a/apps/api/src/specifications/specifications.controller.ts
+++ b/apps/api/src/specifications/specifications.controller.ts
@@ -459,13 +459,12 @@ export class SpecificationsController {
   })
   @ApiCreatedResponse({
     description: 'The simulation experiments were succcessfully saved',
-    type: [SimulationRunSedDocument],
   })
   public async createSpecification(
     @Body() specifications: SimulationRunSedDocumentInputsContainer,
-  ): Promise<SimulationRunSedDocument[]> {
-    const specs = await this.service.createSpecs(specifications.sedDocuments);
-    return specs.map(this.returnSpec);
+  ): Promise<void> {
+    await this.service.createSpecs(specifications.sedDocuments);
+    return;
   }
 
   private returnSpec(specs: SpecificationsModel): SimulationRunSedDocument {

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -227,7 +227,7 @@ export class CompleteProcessor {
             this.projectService
               .createProject(projectInput)
               .toPromise()
-              .then((project) =>
+              .then(() =>
                 this.logger.log(
                   `Created project '${projectId}' for simulation '${id}'.`,
                 ),

--- a/apps/dispatch-service/src/metadata/metadata.service.ts
+++ b/apps/dispatch-service/src/metadata/metadata.service.ts
@@ -4,7 +4,6 @@ import {
   SimulationRunMetadataInput,
   ArchiveMetadata,
   LabeledIdentifier,
-  SimulationRunMetadata,
 } from '@biosimulations/datamodel/api';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -72,7 +71,7 @@ export class MetadataService {
     const metadataReq = this.submit.postMetadata(id, postMetadata);
 
     const metadataPostObserver = {
-      next: (res: SimulationRunMetadata) => {
+      next: () => {
         this.logger.log(`Posted metadata for simulation run '${id}'.`);
       },
       error: (err: AxiosError) => {

--- a/apps/dispatch-service/src/sedml/sedml.service.ts
+++ b/apps/dispatch-service/src/sedml/sedml.service.ts
@@ -39,7 +39,7 @@ export class SedmlService {
       }),
     );
 
-    const sedmlString = await sedml.toPromise();
+    await sedml.toPromise();
   }
 
   private getSpecsFromArchiveContent(

--- a/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
+++ b/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
@@ -11,7 +11,7 @@ import {
   UnknownSimulation,
   isUnknownSimulation,
 } from '../../../datamodel';
-import { Project, ProjectInput } from '@biosimulations/datamodel/common';
+import { ProjectInput } from '@biosimulations/datamodel/common';
 import {
   FormBuilder,
   FormGroup,
@@ -137,12 +137,14 @@ export class PublishComponent implements OnInit, OnDestroy {
       return;
     }
 
+    const id = this.formGroup.controls.id.value;
     const pubSub = this.projectService
       .publishProject({
-        id: this.formGroup.controls.id.value,
+        id: id,
         simulationRun: this.uuid,
       })
       .pipe(
+        map((): true => true),
         catchError((error: HttpErrorResponse): Observable<undefined> => {
           if (!environment.production) {
             console.log(error);
@@ -161,9 +163,9 @@ export class PublishComponent implements OnInit, OnDestroy {
           return of<undefined>(undefined);
         }),
       )
-      .subscribe((project: Project | undefined): void => {
-        if (project) {
-          const url = this.endpoints.getProjectsView(project.id);
+      .subscribe((project: true | undefined): void => {
+        if (project !== undefined) {
+          const url = this.endpoints.getProjectsView(id);
           const tabWindowId = window.open('about:blank', '_blank');
           if (tabWindowId) {
             tabWindowId.location.href = url;

--- a/apps/simulators-api/src/simulators/simulators.controller.ts
+++ b/apps/simulators-api/src/simulators/simulators.controller.ts
@@ -274,7 +274,6 @@ export class SimulatorsController {
   @ApiCreatedResponse({
     description:
       'The version of the simulation tool was successfully saved to the database',
-    type: Simulator,
   })
   @ApiBadRequestResponse({
     type: ErrorResponseDocument,
@@ -296,8 +295,9 @@ export class SimulatorsController {
       'This account does not have permission to save specifications of simulation tools',
   })
   @permissions(scopes.simulators.create.id)
-  async create(@Body() doc: Simulator): Promise<Simulator> {
-    return this.service.new(doc);
+  async create(@Body() doc: Simulator): Promise<void> {
+    await this.service.new(doc);
+    return;
   }
 
   @Post('validate')

--- a/libs/api/angular-client/src/lib/project/project.service.ts
+++ b/libs/api/angular-client/src/lib/project/project.service.ts
@@ -51,10 +51,10 @@ export class ProjectService {
       );
   }
 
-  public publishProject(projectInput: ProjectInput): Observable<Project> {
+  public publishProject(projectInput: ProjectInput): Observable<void> {
     const url = this.endpoints.getProjectsEndpoint();
     const response = this.http
-      .post<Project>(url, projectInput, {
+      .post<void>(url, projectInput, {
         headers: { 'Content-Type': 'application/json' },
       })
       .pipe(shareReplay(1));

--- a/libs/api/nest-client/src/lib/project.service.ts
+++ b/libs/api/nest-client/src/lib/project.service.ts
@@ -36,9 +36,9 @@ export class ProjectService {
     );
   }
 
-  public createProject(project: ProjectInput): Observable<Project> {
+  public createProject(project: ProjectInput): Observable<void> {
     const endpoint = this.endpoints.getProjectsEndpoint();
-    return this.postAuthenticated<ProjectInput, Project>(endpoint, project);
+    return this.postAuthenticated<ProjectInput, void>(endpoint, project);
   }
 
   public updateProject(id: string, project: ProjectInput): Observable<Project> {

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -12,7 +12,6 @@ import { pluck, map, mergeMap, retry, catchError } from 'rxjs/operators';
 import { from, Observable, throwError } from 'rxjs';
 import {
   SimulationRunStatus,
-  SimulationRunSedDocument,
   SimulationRunSedDocumentInput,
   SimulationRunSedDocumentInputsContainer,
 } from '@biosimulations/datamodel/common';
@@ -21,7 +20,6 @@ import {
   ProjectFileInputsContainer,
   ProjectFile,
   SimulationRunMetadataInput,
-  SimulationRunMetadata,
 } from '@biosimulations/datamodel/api';
 import { retryBackoff } from 'backoff-rxjs';
 import { AxiosError } from 'axios';
@@ -43,26 +41,26 @@ export class SimulationRunService {
   public postMetadata(
     runId: string,
     metadata: SimulationRunMetadataInput,
-  ): Observable<SimulationRunMetadata> {
+  ): Observable<void> {
     this.logger.log(`Uploading metadata for simulation run '${runId}' ....`);
     const endpoint = this.endpoints.getSimulationRunMetadataEndpoint();
     return this.postAuthenticated<
       SimulationRunMetadataInput,
-      SimulationRunMetadata
+      void
     >(runId, endpoint, metadata);
   }
 
   public postSpecs(
     runId: string,
     specs: SimulationRunSedDocumentInput[],
-  ): Observable<SimulationRunSedDocument[]> {
+  ): Observable<void> {
     this.logger.log(
       `Uploading simulation experiment specifications (SED-ML) for simulation run '${runId}' ....`,
     );
     const endpoint = this.endpoints.getSpecificationsEndpoint();
     return this.postAuthenticated<
       SimulationRunSedDocumentInputsContainer,
-      SimulationRunSedDocument[]
+      void
     >(runId, endpoint, { sedDocuments: specs });
   }
 


### PR DESCRIPTION
The log is no longer returned from a post request. Intermittently, posting logs causes the API to
stop responding. This is accompanied by large size responses.

BREAKING CHANGE: The logs post endpoint no longer returns the log that was created. For that, use a
GET request after posting the log.

re #3609

**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* Adds ABC (closes #X)
* Adds XYZ (closes #X)

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* Fixes ABC (closes #X)
* Fixes XYZ (closes #X)

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* Corrects typos in documentation
* Changes theme of documentation

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* Added test for ABC
* Added test for XYZ

**Additional information**
Please describe any information needed to review this PR.
