### PR TITLE
refactor(config): removed todo for authorization URL

### DIFF
--- a/libs/config/nest/src/lib/biosimulations-auth-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-auth-config.ts
@@ -1,7 +1,6 @@
 import { registerAs } from '@nestjs/config';
 
 export default registerAs('auth', () => {
-  // TODO add authorization URL based on the app
   const config = {
     auth0_domain: process.env.AUTH0_DOMAIN,
     api_audience: process.env.API_AUDIENCE,


### PR DESCRIPTION
Closes #3640

The domain is already configurable and the authorization URL is built from this, same as the Auth0 libraries do.