### PR TITLE
fix(dispatch): fix displaying of data in cases where simulation fails and metadaa is not present

### DIFF
--- a/apps/platform/src/app/projects/view/view.component.ts
+++ b/apps/platform/src/app/projects/view/view.component.ts
@@ -33,7 +33,7 @@ export class ViewComponent implements OnInit {
   public loaded$!: Observable<boolean>;
 
   private id!: string;
-  public projectMetadata$!: Observable<ProjectMetadata | undefined>;
+  public projectMetadata$!: Observable<ProjectMetadata | null>;
   public simulationRun$!: Observable<SimulationRunMetadata>;
 
   public projectFiles$!: Observable<File[]>;

--- a/libs/api/angular-client/src/lib/simulation-run/simulation-run.service.ts
+++ b/libs/api/angular-client/src/lib/simulation-run/simulation-run.service.ts
@@ -111,7 +111,7 @@ export class SimulationRunService {
 
     let observable = this.cachedRunObservables[endpoint];
     if (!observable) {
-      observable = this.httpClient.get<any>(endpoint).pipe(shareReplay(1));
+      observable = this.httpClient.get<T>(endpoint).pipe(shareReplay(1));
       if (cache) {
         this.cachedRunObservables[endpoint] = observable;
       }

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -123,10 +123,10 @@ export class ViewService {
   public getFormattedProjectMetadata(
     simulationRunSummary: SimulationRunSummary,
     owner?: Account,
-  ): ProjectMetadata | undefined {
+  ): ProjectMetadata | null {
     const metadata = simulationRunSummary.metadata;
     if (!metadata) {
-      return undefined;
+      return null;
     }
 
     // Check for undefined metadata for all fields


### PR DESCRIPTION
if the run failed and did not contain any metadata, then the view service returned undefined. This
was indistinguishable from cases where the metadata had not yet loaded, causing the view to display a
spinner. Instead, it now returns null, which lets the view know that the data is loaded, it is just
not present, and display the appropriate error

fix #3705

**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* Adds ABC (closes #X)
* Adds XYZ (closes #X)

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* Fixes ABC (closes #X)
* Fixes XYZ (closes #X)

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* Corrects typos in documentation
* Changes theme of documentation

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* Added test for ABC
* Added test for XYZ

**Additional information**
Please describe any information needed to review this PR.
