### PR TITLE
feat(api): add check for data service to status check

### DIFF
--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -13,6 +13,7 @@ import { ConfigService } from '@nestjs/config';
 import { Endpoints } from '@biosimulations/config/common';
 import { BullHealthIndicator } from './bullHealthCheck';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { AxiosResponse } from 'axios';
 
 @Controller('health')
 @ApiTags('Health')
@@ -57,6 +58,7 @@ export class HealthController {
       this.s3Check,
       this.simulatorsCheck,
       this.hpcCheck,
+      this.hsdsCheck,
     ]);
   }
 
@@ -80,6 +82,16 @@ export class HealthController {
   @HealthCheck()
   public messagingCheck(): Promise<HealthCheckResult> {
     return this.health.check([this.natsCheck, this.bullCheck]);
+  }
+
+  @Get('/dataService')
+  @ApiOperation({
+    summary: 'Check whether the data service is operational',
+    description: 'Check whether the data service is operational',
+  })
+  @HealthCheck()
+  public dataServiceCheck(): Promise<HealthCheckResult> {
+    return this.health.check([this.hsdsCheck]);
   }
 
   private simulatorsCheck: HealthIndicatorFunction = () =>
@@ -118,4 +130,10 @@ export class HealthController {
         port: this.config.get('hpc.ssh.port'),
       },
     });
+
+  private hsdsCheck: HealthIndicatorFunction = () =>
+    this.http.pingCheck(
+      'Data Service',
+      this.endpoints.getDataServiceHealthEndpoint(),
+    );
 }

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -13,7 +13,6 @@ import { ConfigService } from '@nestjs/config';
 import { Endpoints } from '@biosimulations/config/common';
 import { BullHealthIndicator } from './bullHealthCheck';
 import { ApiTags, ApiOperation } from '@nestjs/swagger';
-import { AxiosResponse } from 'axios';
 
 @Controller('health')
 @ApiTags('Health')

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -9,17 +9,22 @@ import { environment } from '@biosimulations/shared/environments';
  */
 
 export class Endpoints {
+  // Back end services
   private api: string;
   private simulatorsApi: string;
   private combineApi: string;
   private storageEndpoint: string;
-  private simulationRunsS3Path: string;
-  private simulationRunContentS3Subpath: string;
-  private simulationRunResultsHsdsPath: string;
+  private dataService: string;
+
+  // Front end apps
   private simulatorsApp: string;
   private dispatchApp: string;
   private platformApp: string;
 
+  // Backend subpaths
+  private simulationRunResultsHsdsPath: string;
+  private simulationRunContentS3Subpath: string;
+  private simulationRunsS3Path: string;
   private simulationRuns: string;
   private simulationRunResults: string;
   private simulationRunLogs: string;
@@ -46,6 +51,7 @@ export class Endpoints {
         this.simulatorsApp = 'https://biosimulators.dev';
         this.dispatchApp = 'https://run.biosimulations.dev';
         this.platformApp = 'https://biosimulations.dev';
+        this.dataService = 'https://data.biosimulations.dev';
         break;
 
       case 'dev':
@@ -56,6 +62,7 @@ export class Endpoints {
         this.simulatorsApp = 'https://biosimulators.dev';
         this.dispatchApp = 'https://run.biosimulations.dev';
         this.platformApp = 'https://biosimulations.dev';
+        this.dataService = 'https://data.biosimulations.dev';
         break;
 
       case 'stage':
@@ -66,6 +73,7 @@ export class Endpoints {
         this.simulatorsApp = 'https://biosimulators.dev';
         this.dispatchApp = 'https://run.biosimulations.dev';
         this.platformApp = 'https://biosimulations.dev';
+        this.dataService = 'https://data.biosimulations.dev';
         break;
 
       case 'prod':
@@ -76,6 +84,7 @@ export class Endpoints {
         this.simulatorsApp = 'https://biosimulators.org';
         this.dispatchApp = 'https://run.biosimulations.org';
         this.platformApp = 'https://biosimulations.org';
+        this.dataService = 'https://data.biosimulations.org';
         break;
     }
 
@@ -121,6 +130,13 @@ export class Endpoints {
     return `${api}/ontologies${ontologyId}${termId}`;
   }
 
+  /**
+   * Get URL for health check for data service
+   * @returns The URL of the health check
+   **/
+  public getDataServiceHealthEndpoint(): string {
+    return `${this.dataService}/info`;
+  }
   /**
    *
    * @returns The endpoint prefix for the ontologies

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -136,7 +136,7 @@ export class ViewService {
       abstract: metadata?.abstract,
       creators: (metadata?.creators || []).map(
         (creator: LabeledIdentifier): Creator => {
-          let icon: string = 'link';
+          let icon = 'link';
           if (creator.uri) {
             if (
               creator.uri.match(


### PR DESCRIPTION
added a ping check for the data service to the api. This won't be able to determine if there is a
misconfiguration of the data service that causes results to be unretrievable unless we can hardcode
in some example results for testing.

closes #3649

**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* Adds ABC (closes #X)
* Adds XYZ (closes #X)

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* Fixes ABC (closes #X)
* Fixes XYZ (closes #X)

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* Corrects typos in documentation
* Changes theme of documentation

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* Added test for ABC
* Added test for XYZ

**Additional information**
Please describe any information needed to review this PR.
