### PR TITLE
refactor(api): correct organization and imports of modules and services

### DIFF
--- a/apps/api/src/files/files.module.ts
+++ b/apps/api/src/files/files.module.ts
@@ -14,5 +14,6 @@ import { FilesService } from './files.service';
   ],
   controllers: [FilesController],
   providers: [FilesService],
+  exports: [FilesService],
 })
 export class FilesModule {}

--- a/apps/api/src/files/files.service.spec.ts
+++ b/apps/api/src/files/files.service.spec.ts
@@ -2,7 +2,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { FileModel } from './files.model';
 import { FilesService } from './files.service';
-import { SharedStorageService } from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import { ConfigService } from '@nestjs/config';
 
 describe('FilesService', () => {
@@ -19,7 +19,7 @@ describe('FilesService', () => {
       providers: [
         FilesService,
         { provide: getModelToken(FileModel.name), useValue: {} },
-        { provide: SharedStorageService, useClass: mockStorage },
+        { provide: SimulationStorageService, useClass: mockStorage },
         ConfigService,
       ],
     }).compile();

--- a/apps/api/src/files/files.service.ts
+++ b/apps/api/src/files/files.service.ts
@@ -9,7 +9,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { DeleteResult } from 'mongodb';
 import { FileModel } from './files.model';
-import { SharedStorageService } from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import { Endpoints } from '@biosimulations/config/common';
 import { ConfigService } from '@nestjs/config';
 
@@ -20,7 +20,7 @@ export class FilesService {
 
   public constructor(
     @InjectModel(FileModel.name) private model: Model<FileModel>,
-    private storage: SharedStorageService,
+    private storage: SimulationStorageService,
     private configService: ConfigService,
   ) {
     const env = configService.get('server.env');
@@ -101,9 +101,7 @@ export class FilesService {
       );
     }
 
-    await this.storage.deleteObject(
-      this.endpoints.getSimulationRunOutputS3Path(file.id),
-    );
+    await this.storage.deleteSimulationRunFile(runId, fileLocation);
 
     const res: DeleteResult = await this.model
       .deleteOne({ id: file.id })

--- a/apps/api/src/logs/logs.module.ts
+++ b/apps/api/src/logs/logs.module.ts
@@ -21,5 +21,6 @@ import { LogsService } from './logs.service';
   ],
 
   providers: [LogsService],
+  exports: [LogsService],
 })
 export class LogsModule {}

--- a/apps/api/src/metadata/metadata.module.ts
+++ b/apps/api/src/metadata/metadata.module.ts
@@ -25,5 +25,6 @@ import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
       { name: SimulationRunModel.name, schema: SimulationRunModelSchema },
     ]),
   ],
+  exports: [MetadataService],
 })
 export class MetadataModule {}

--- a/apps/api/src/projects/projects.module.ts
+++ b/apps/api/src/projects/projects.module.ts
@@ -1,80 +1,38 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { ProjectsService } from './projects.service';
 import { ProjectsController } from './projects.controller';
 import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
 import { MongooseModule } from '@nestjs/mongoose';
 import { ProjectModel, ProjectModelSchema } from './project.model';
 
-import { SimulationRunService } from '../simulation-run/simulation-run.service';
-import {
-  SimulationRunModel,
-  SimulationRunModelSchema,
-} from '../simulation-run/simulation-run.model';
-import { HttpModule } from '@nestjs/axios';
 import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
 
-import { FilesService } from '../files/files.service';
-import { FileModel, FileModelSchema } from '../files/files.model';
-
-import { SpecificationsService } from '../specifications/specifications.service';
-import {
-  SpecificationsModel,
-  SpecificationsModelSchema,
-} from '../specifications/specifications.model';
-
-import { LogsService } from '../logs/logs.service';
-import { SimulationRunLog, SimulationRunLogSchema } from '../logs/logs.model';
-
-import { ResultsService } from '../results/results.service';
 import { HSDSClientModule } from '@biosimulations/hsds/client';
 
-import { MetadataService } from '../metadata/metadata.service';
-import {
-  SimulationRunMetadataModel,
-  SimulationRunMetadataSchema,
-} from '../metadata/metadata.model';
-
-import { OntologyApiService } from '@biosimulations/ontology/api';
-import { ManagementService as AccountManagementService } from '@biosimulations/account/management';
+import { AccountManagementModule } from '@biosimulations/account/management';
+import { SimulationRunModule } from '../simulation-run/simulation-run.module';
+import { MetadataModule } from '../metadata/metadata.module';
+import { LogsModule } from '../logs/logs.module';
+import { FilesModule } from '../files/files.module';
+import { SpecificationsModule } from '../specifications/specifications.module';
 
 @Module({
   imports: [
     BiosimulationsAuthModule,
-    HttpModule,
     SharedNatsClientModule,
+    forwardRef(() => SimulationRunModule),
+    LogsModule,
+    MetadataModule,
+    FilesModule,
+    SpecificationsModule,
+    AccountManagementModule,
     MongooseModule.forFeature([
-      { name: SimulationRunModel.name, schema: SimulationRunModelSchema },
       { name: ProjectModel.name, schema: ProjectModelSchema },
-      {
-        name: SimulationRunMetadataModel.name,
-        schema: SimulationRunMetadataSchema,
-      },
-      {
-        name: FileModel.name,
-        schema: FileModelSchema,
-      },
-      {
-        name: SpecificationsModel.name,
-        schema: SpecificationsModelSchema,
-      },
-      {
-        name: SimulationRunLog.name,
-        schema: SimulationRunLogSchema,
-      },
     ]),
     HSDSClientModule,
   ],
-  providers: [
-    ProjectsService,
-    SimulationRunService,
-    FilesService,
-    SpecificationsService,
-    LogsService,
-    ResultsService,
-    MetadataService,
-    OntologyApiService,
-    AccountManagementService,
-  ],
+  providers: [ProjectsService],
   controllers: [ProjectsController],
+  exports: [ProjectsService],
 })
 export class ProjectsModule {}

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -93,7 +93,7 @@ export class ProjectsService implements OnModuleInit {
   }
 
   public async getCount(): Promise<number> {
-    return await this.model.count();
+    return this.model.count();
   }
   /** Save a project to the database
    *

--- a/apps/api/src/results/results.controller.spec.ts
+++ b/apps/api/src/results/results.controller.spec.ts
@@ -7,7 +7,7 @@
 import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
 import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
 import { SimulationHDFService } from '@biosimulations/hsds/client';
-import { SharedStorageService } from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import { CacheModule } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ResultsController } from './results.controller';
@@ -47,7 +47,7 @@ describe('ResultsController', () => {
           useClass: MockStorageService,
         },
         {
-          provide: SharedStorageService,
+          provide: SimulationStorageService,
           useClass: MockStorageService,
         },
       ],

--- a/apps/api/src/results/results.module.ts
+++ b/apps/api/src/results/results.module.ts
@@ -26,5 +26,6 @@ import { HSDSClientModule } from '@biosimulations/hsds/client';
   ],
   providers: [ResultsService],
   controllers: [ResultsController],
+  exports: [ResultsService],
 })
 export class ResultsModule {}

--- a/apps/api/src/results/results.service.spec.ts
+++ b/apps/api/src/results/results.service.spec.ts
@@ -4,7 +4,7 @@
  * @copyright BioSimulations Team, 2020
  * @license MIT
  */
-import { SharedStorageService } from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import { SimulationHDFService } from '@biosimulations/hsds/client';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -42,7 +42,7 @@ describe('ResultsService', () => {
       providers: [
         ResultsService,
         {
-          provide: SharedStorageService,
+          provide: SimulationStorageService,
           useClass: MockStorageService,
         },
         {

--- a/apps/api/src/results/results.service.ts
+++ b/apps/api/src/results/results.service.ts
@@ -1,5 +1,5 @@
 import { Dataset, SimulationHDFService } from '@biosimulations/hsds/client';
-import { SharedStorageService } from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import {
   Injectable,
   Logger,
@@ -25,7 +25,7 @@ export class ResultsService {
   private endpoints: Endpoints;
 
   public constructor(
-    private storage: SharedStorageService,
+    private simStorage: SimulationStorageService,
     private results: SimulationHDFService,
     private configService: ConfigService,
   ) {
@@ -113,9 +113,8 @@ export class ResultsService {
 
   public async download(runId: string): Promise<S3.Body> {
     try {
-      const file = await this.storage.getObject(
-        this.endpoints.getSimulationRunOutputS3Path(runId),
-      );
+      const file = await this.simStorage.getSimulationRunOutputArchive(runId);
+
       if (file.Body) {
         return file.Body;
       } else {
@@ -148,9 +147,7 @@ export class ResultsService {
 
   public async deleteSimulationRunResults(runId: string): Promise<void> {
     await this.results.deleteDatasets(runId);
-    await this.storage.deleteObject(
-      this.endpoints.getSimulationRunOutputS3Path(runId),
-    );
+    await this.simStorage.deleteSimulationRunResults(runId);
   }
 
   private async parseDataset(

--- a/apps/api/src/simulation-run/simulation-run.module.ts
+++ b/apps/api/src/simulation-run/simulation-run.module.ts
@@ -8,7 +8,7 @@
  */
 
 import { BiosimulationsAuthModule } from '@biosimulations/auth/nest';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { HttpModule } from '@nestjs/axios';
 
 import { MongooseModule } from '@nestjs/mongoose';
@@ -21,59 +21,33 @@ import {
 import { SimulationRunService } from './simulation-run.service';
 import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
 
-import { FilesService } from '../files/files.service';
-import { FileModel, FileModelSchema } from '../files/files.model';
-
-import { SpecificationsService } from '../specifications/specifications.service';
-import {
-  SpecificationsModel,
-  SpecificationsModelSchema,
-} from '../specifications/specifications.model';
-
-import { LogsService } from '../logs/logs.service';
-import { SimulationRunLog, SimulationRunLogSchema } from '../logs/logs.model';
-
-import { ResultsService } from '../results/results.service';
 import { HSDSClientModule } from '@biosimulations/hsds/client';
 
-import { MetadataService } from '../metadata/metadata.service';
-import {
-  SimulationRunMetadataModel,
-  SimulationRunMetadataSchema,
-} from '../metadata/metadata.model';
-
+import { OntologyApiModule } from '@biosimulations/ontology/api';
+import { ResultsModule } from '../results/results.module';
+import { LogsModule } from '../logs/logs.module';
+import { SpecificationsModule } from '../specifications/specifications.module';
+import { FilesModule } from '../files/files.module';
+import { MetadataModule } from '../metadata/metadata.module';
+import { ProjectsModule } from '../projects/projects.module';
 import { ProjectModel, ProjectModelSchema } from '../projects/project.model';
-
-import { OntologyApiService } from '@biosimulations/ontology/api';
-
 @Module({
   controllers: [SimulationRunController],
   imports: [
     BiosimulationsAuthModule,
     HttpModule,
     SharedNatsClientModule,
+    ResultsModule,
+    OntologyApiModule,
+    LogsModule,
+    SpecificationsModule,
+    FilesModule,
+    MetadataModule,
+    forwardRef(() => ProjectsModule),
     MongooseModule.forFeature([
       { name: SimulationRunModel.name, schema: SimulationRunModelSchema },
-      {
-        name: SimulationRunMetadataModel.name,
-        schema: SimulationRunMetadataSchema,
-      },
-      {
-        name: FileModel.name,
-        schema: FileModelSchema,
-      },
-      {
-        name: SpecificationsModel.name,
-        schema: SpecificationsModelSchema,
-      },
-      {
-        name: SimulationRunLog.name,
-        schema: SimulationRunLogSchema,
-      },
-      {
-        name: ProjectModel.name,
-        schema: ProjectModelSchema,
-      },
+      // TODO remove this dependency, use the service to work with the project model
+      { name: ProjectModel.name, schema: ProjectModelSchema },
     ]),
     // Need to provide hash keys to allow use on cluster.
     //See https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#redis-cluster
@@ -83,14 +57,7 @@ import { OntologyApiService } from '@biosimulations/ontology/api';
     }),
     HSDSClientModule,
   ],
-  providers: [
-    SimulationRunService,
-    FilesService,
-    SpecificationsService,
-    LogsService,
-    ResultsService,
-    MetadataService,
-    OntologyApiService,
-  ],
+  providers: [SimulationRunService],
+  exports: [SimulationRunService],
 })
 export class SimulationRunModule {}

--- a/apps/api/src/simulation-run/simulation-run.module.ts
+++ b/apps/api/src/simulation-run/simulation-run.module.ts
@@ -30,9 +30,8 @@ import { SpecificationsModule } from '../specifications/specifications.module';
 import { FilesModule } from '../files/files.module';
 import { MetadataModule } from '../metadata/metadata.module';
 import { ProjectsModule } from '../projects/projects.module';
-import { ProjectModel, ProjectModelSchema } from '../projects/project.model';
+
 @Module({
-  controllers: [SimulationRunController],
   imports: [
     BiosimulationsAuthModule,
     HttpModule,
@@ -46,8 +45,6 @@ import { ProjectModel, ProjectModelSchema } from '../projects/project.model';
     forwardRef(() => ProjectsModule),
     MongooseModule.forFeature([
       { name: SimulationRunModel.name, schema: SimulationRunModelSchema },
-      // TODO remove this dependency, use the service to work with the project model
-      { name: ProjectModel.name, schema: ProjectModelSchema },
     ]),
     // Need to provide hash keys to allow use on cluster.
     //See https://github.com/OptimalBits/bull/blob/develop/PATTERNS.md#redis-cluster
@@ -57,6 +54,7 @@ import { ProjectModel, ProjectModelSchema } from '../projects/project.model';
     }),
     HSDSClientModule,
   ],
+  controllers: [SimulationRunController],
   providers: [SimulationRunService],
   exports: [SimulationRunService],
 })

--- a/apps/api/src/simulation-run/simulation-run.service.spec.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.spec.ts
@@ -6,11 +6,7 @@
  */
 import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
 import { SharedNatsClientModule } from '@biosimulations/shared/nats-client';
-import {
-  SharedStorageModule,
-  SharedStorageService,
-  SimulationStorageService,
-} from '@biosimulations/shared/storage';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 import { HttpModule } from '@nestjs/axios';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -19,55 +15,64 @@ import { SimulationRunModel } from './simulation-run.model';
 import { SimulationRunService } from './simulation-run.service';
 
 import { FilesService } from '../files/files.service';
-import { FileModel } from '../files/files.model';
 import { SpecificationsService } from '../specifications/specifications.service';
-import { SpecificationsModel } from '../specifications/specifications.model';
 import { ResultsService } from '../results/results.service';
 import { SimulationHDFService } from '@biosimulations/hsds/client';
 import { LogsService } from '../logs/logs.service';
-import { SimulationRunLog } from '../logs/logs.model';
+
 import { MetadataService } from '../metadata/metadata.service';
-import { SimulationRunMetadataModel } from '../metadata/metadata.model';
-import { ProjectModel } from '../projects/project.model';
 
 import { OntologyApiService } from '@biosimulations/ontology/api';
-import { CacheModule } from '@nestjs/common';
+import {
+  BadRequestException,
+  CacheModule,
+  NotFoundException,
+} from '@nestjs/common';
+import { ProjectsService } from '../projects/projects.service';
+import { Model } from 'mongoose';
+
+class mockFile {
+  data: any;
+  save: () => any;
+  constructor(body: any) {
+    this.data = body;
+    this.save = () => {
+      return this.data;
+    };
+  }
+}
+
+class mockStorage {
+  putObject() {}
+  getObject() {}
+}
+
+class mockSimService {
+  getDataSets(id: string) {
+    return;
+  }
+  getDataSetbyId(id: string) {}
+}
+
+class mockProjectsService {
+  getProjectIdBySimulationRunId(id: string) {
+    return 'projectId';
+  }
+  getCount() {
+    return 1;
+  }
+}
+
+class mockSimulationRunModel {
+  findOneAndDelete(model: any) {
+    return;
+  }
+}
 
 describe('SimulationRunService', () => {
   let service: SimulationRunService;
-
-  class mockFile {
-    data: any;
-    save: () => any;
-    constructor(body: any) {
-      this.data = body;
-      this.save = () => {
-        return this.data;
-      };
-    }
-  }
-
-  class mockStorage {
-    putObject() {}
-    getObject() {}
-  }
-
-  class mockModel {
-    constructor(private data: any) {}
-    static save = jest.fn().mockResolvedValue('test');
-    save = mockModel.save;
-    static find = jest.fn().mockResolvedValue({});
-    static findOne = jest.fn().mockResolvedValue({});
-    static findOneAndUpdate = jest.fn().mockResolvedValue({});
-    static deleteOne = jest.fn().mockResolvedValue(true);
-  }
-
-  class mockSimService {
-    getDataSets(id: string) {
-      return;
-    }
-    getDataSetbyId(id: string) {}
-  }
+  let projectsService: ProjectsService;
+  let simulationRunModel: Model<SimulationRunModel>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -81,38 +86,68 @@ describe('SimulationRunService', () => {
         SimulationRunService,
         {
           provide: getModelToken(SimulationRunModel.name),
-          useClass: mockFile,
+          useClass: mockSimulationRunModel,
         },
-        { provide: getModelToken(FileModel.name), useValue: {} },
-        { provide: getModelToken(SpecificationsModel.name), useValue: {} },
-        {
-          provide: getModelToken(SimulationRunLog.name),
-          useValue: mockModel,
-        },
-        {
-          provide: getModelToken(SimulationRunMetadataModel.name),
-          useValue: {},
-        },
-        { provide: getModelToken(ProjectModel.name), useValue: {} },
-        { provide: SharedStorageService, useClass: mockStorage },
+        { provide: ProjectsService, useClass: mockProjectsService },
         { provide: SimulationStorageService, useClass: mockStorage },
         {
           provide: SimulationHDFService,
           useClass: mockSimService,
         },
-        FilesService,
-        SpecificationsService,
-        ResultsService,
-        LogsService,
-        MetadataService,
-        OntologyApiService,
+        { provide: FilesService, useValue: {} },
+        { provide: SpecificationsService, useValue: {} },
+        { provide: ResultsService, useValue: {} },
+        { provide: MetadataService, useValue: {} },
+        { provide: LogsService, useValue: {} },
+        { provide: OntologyApiService, useValue: {} },
       ],
     }).compile();
 
     service = module.get<SimulationRunService>(SimulationRunService);
+    projectsService = module.get<ProjectsService>(ProjectsService);
+    simulationRunModel = module.get<Model<SimulationRunModel>>(
+      getModelToken(SimulationRunModel.name),
+    );
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('deleting simulation run should check for published projects', async () => {
+    let mock = jest
+      .spyOn(projectsService, 'getProjectIdBySimulationRunId')
+      .mockResolvedValue('projectId');
+
+    await expect(service.delete('simulationRunId')).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(mock).toHaveBeenCalled();
+  });
+
+  it('deleting all simulation runs should check for existing projects', async () => {
+    let mock = jest.spyOn(projectsService, 'getCount').mockResolvedValue(1);
+
+    await expect(service.deleteAll()).rejects.toThrow(BadRequestException);
+    expect(mock).toHaveBeenCalled();
+
+    mock = jest.spyOn(projectsService, 'getCount').mockResolvedValue(0);
+
+    // expect a type error bc we have not yet mocked the find function fully
+    await expect(service.deleteAll()).rejects.toThrow(TypeError);
+    expect(mock).toHaveBeenCalled();
+  });
+  it('deleting a non-existing simulation run should throw error', async () => {
+    const mock = jest
+      .spyOn(projectsService, 'getProjectIdBySimulationRunId')
+      .mockResolvedValue(undefined);
+
+    let dbMock = jest
+      .spyOn(simulationRunModel, 'findOneAndDelete')
+      .mockResolvedValue(null);
+    await expect(service.delete('simulationRunId')).rejects.toThrow(
+      NotFoundException,
+    );
+    expect(dbMock).toHaveBeenCalled();
   });
 });

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -27,7 +27,6 @@ import {
   SimulationRunModelType,
   SimulationProjectFile,
 } from './simulation-run.model';
-import { ProjectModel } from '../projects/project.model';
 import {
   UpdateSimulationRun,
   UploadSimulationRun,

--- a/apps/api/src/specifications/specifications.module.ts
+++ b/apps/api/src/specifications/specifications.module.ts
@@ -17,5 +17,6 @@ import { SpecificationsService } from './specifications.service';
     ]),
   ],
   providers: [SpecificationsService],
+  exports: [SpecificationsService],
 })
 export class SpecificationsModule {}

--- a/apps/dispatch-service/src/app/app.module.ts
+++ b/apps/dispatch-service/src/app/app.module.ts
@@ -46,7 +46,7 @@ import { Endpoints } from '@biosimulations/config/common';
       useFactory: (configService: ConfigService) => {
         const env = configService.get('server.env');
         const endpoints = new Endpoints(env);
-        const combineBaseUrl = endpoints.getCombineApiEndpoint(false);
+        const combineBaseUrl = endpoints.getCombineApiBaseUrl(false);
         return new CombineAPIConfiguration({
           basePath: combineBaseUrl,
         });

--- a/libs/config/common/jest.config.js
+++ b/libs/config/common/jest.config.js
@@ -9,4 +9,5 @@ module.exports = {
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'html'],
   coverageDirectory: '../../../coverage/libs/config/common',
   displayName: 'config-common',
+  setupFiles: ['./jest.env.ts'],
 };

--- a/libs/config/common/jest.env.ts
+++ b/libs/config/common/jest.env.ts
@@ -1,0 +1,10 @@
+process.env.API_URL = 'api';
+process.env.SIMULATORS_API_URL = 'simulatorsApi';
+process.env.COMBINE_API_URL = 'combineApi';
+process.env.STORAGE_URL = 'storage';
+process.env.DATA_SERVICE_URL = 'dataService';
+process.env.EXTERNAL_API_URL = 'externalApi';
+process.env.EXTERNAL_SIMULATORS_API_URL = 'externalSimulatorsApi';
+process.env.EXTERNAL_COMBINE_API_URL = 'externalCombineApi';
+process.env.EXTERNAL_STORAGE_URL = 'externalStorage';
+process.env.EXTERNAL_DATA_SERVICE_URL = 'externalDataService';

--- a/libs/config/common/src/lib/endpointLoader.ts
+++ b/libs/config/common/src/lib/endpointLoader.ts
@@ -27,212 +27,213 @@ export class EndpointLoader {
   public loadEndpoints(): LoadedEndpoints {
     const dynamicEndpoints = this.getDynamicEndpoints();
 
-    const defaultEndpoints: LoadedEndpoints = {
-      api: 'https://api.biosimulations.dev',
-      simulatorsApi: 'https://api.biosimulators.dev',
-      combineApi: 'https://combine.api.biosimulations.dev',
-      storageEndpoint: 'https://files-dev.biosimulations.org',
-      dataService: 'https://data.biosimulations.dev',
-      externalApi: 'https://api.biosimulations.dev',
-      externalSimulatorsApi: 'https://api.biosimulators.dev',
-      externalCombineApi: 'https://combine.api.biosimulations.dev',
-      externalStorageEndpoint: 'https://files-dev.biosimulations.org',
-      externalDataService: 'https://data.biosimulations.dev',
-      simulatorsApp: 'https://biosimulatiors.dev',
-      dispatchApp: 'https://run.biosimulations.dev',
-      platformApp: 'https://biosimulations.dev',
+    const endpointsTemplate: LoadedEndpoints = {
+      api: 'api',
+      simulatorsApi: 'simulatorsApi',
+      combineApi: 'combineApi',
+      storageEndpoint: 'storageEndpoint',
+      dataService: 'dataService',
+      externalApi: 'externalApi',
+      externalSimulatorsApi: 'exxternalSimulatorsApi',
+      externalCombineApi: 'externalCombineApi',
+      externalStorageEndpoint: 'externalStorageEndpoint',
+      externalDataService: 'externalDataService',
+      simulatorsApp: 'simulatorsApp',
+      dispatchApp: 'dispatchApp',
+      platformApp: ' platformApp',
     };
 
     switch (this.env) {
       case 'local':
-        defaultEndpoints.api = dynamicEndpoints?.api || 'http://localhost:3333';
+        endpointsTemplate.api =
+          dynamicEndpoints?.api || 'http://localhost:3333';
 
-        defaultEndpoints.simulatorsApi =
+        endpointsTemplate.simulatorsApi =
           dynamicEndpoints?.simulatorsApi || 'https://api.biosimulators.dev';
 
-        defaultEndpoints.combineApi =
+        endpointsTemplate.combineApi =
           dynamicEndpoints?.combineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.storageEndpoint =
+        endpointsTemplate.storageEndpoint =
           dynamicEndpoints?.storageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.simulatorsApp =
+        endpointsTemplate.simulatorsApp =
           dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
-        defaultEndpoints.dispatchApp =
+        endpointsTemplate.dispatchApp =
           dynamicEndpoints?.dispatchApp || 'https://run.biosimulations.dev';
 
-        defaultEndpoints.platformApp =
+        endpointsTemplate.platformApp =
           dynamicEndpoints?.platformApp || 'https://biosimulations.dev';
 
-        defaultEndpoints.dataService =
+        endpointsTemplate.dataService =
           dynamicEndpoints?.dataService || 'https://data.biosimulations.dev';
 
-        defaultEndpoints.externalApi =
+        endpointsTemplate.externalApi =
           dynamicEndpoints?.externalApi || 'https://api.biosimulations.dev';
 
-        defaultEndpoints.externalSimulatorsApi =
+        endpointsTemplate.externalSimulatorsApi =
           dynamicEndpoints?.externalSimulatorsApi ||
           'https://api.biosimulators.dev';
 
-        defaultEndpoints.externalCombineApi =
+        endpointsTemplate.externalCombineApi =
           dynamicEndpoints?.externalCombineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.externalStorageEndpoint =
+        endpointsTemplate.externalStorageEndpoint =
           dynamicEndpoints?.externalStorageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.externalDataService =
+        endpointsTemplate.externalDataService =
           dynamicEndpoints?.externalDataService ||
           'https://data.biosimulations.dev';
         break;
 
       case 'dev':
-        defaultEndpoints.api =
+        endpointsTemplate.api =
           dynamicEndpoints?.api || 'https://api.biosimulations.dev';
 
-        defaultEndpoints.simulatorsApi =
+        endpointsTemplate.simulatorsApi =
           dynamicEndpoints?.simulatorsApi || 'https://api.biosimulators.dev';
 
-        defaultEndpoints.combineApi =
+        endpointsTemplate.combineApi =
           dynamicEndpoints?.combineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.storageEndpoint =
+        endpointsTemplate.storageEndpoint =
           dynamicEndpoints?.storageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.simulatorsApp =
+        endpointsTemplate.simulatorsApp =
           dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
-        defaultEndpoints.dispatchApp =
+        endpointsTemplate.dispatchApp =
           dynamicEndpoints?.dispatchApp || 'https://run.biosimulations.dev';
 
-        defaultEndpoints.platformApp =
+        endpointsTemplate.platformApp =
           dynamicEndpoints?.platformApp || 'https://biosimulations.dev';
 
-        defaultEndpoints.dataService =
+        endpointsTemplate.dataService =
           dynamicEndpoints?.dataService || 'https://data.biosimulations.dev';
 
-        defaultEndpoints.externalApi =
+        endpointsTemplate.externalApi =
           dynamicEndpoints?.externalApi || 'https://api.biosimulations.dev';
 
-        defaultEndpoints.externalSimulatorsApi =
+        endpointsTemplate.externalSimulatorsApi =
           dynamicEndpoints?.externalSimulatorsApi ||
           'https://api.biosimulators.dev';
 
-        defaultEndpoints.externalCombineApi =
+        endpointsTemplate.externalCombineApi =
           dynamicEndpoints?.externalCombineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.externalStorageEndpoint =
+        endpointsTemplate.externalStorageEndpoint =
           dynamicEndpoints?.externalStorageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.externalDataService =
+        endpointsTemplate.externalDataService =
           dynamicEndpoints?.externalDataService ||
           'https://data.biosimulations.dev';
 
         break;
 
       case 'stage':
-        defaultEndpoints.api =
+        endpointsTemplate.api =
           dynamicEndpoints?.api || 'https://api.biosimulations.dev';
 
-        defaultEndpoints.simulatorsApi =
+        endpointsTemplate.simulatorsApi =
           dynamicEndpoints?.simulatorsApi || 'https://api.biosimulators.dev';
 
-        defaultEndpoints.combineApi =
+        endpointsTemplate.combineApi =
           dynamicEndpoints?.combineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.storageEndpoint =
+        endpointsTemplate.storageEndpoint =
           dynamicEndpoints?.storageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.simulatorsApp =
+        endpointsTemplate.simulatorsApp =
           dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
-        defaultEndpoints.dispatchApp =
+        endpointsTemplate.dispatchApp =
           dynamicEndpoints?.dispatchApp || 'https://run.biosimulations.dev';
 
-        defaultEndpoints.platformApp =
+        endpointsTemplate.platformApp =
           dynamicEndpoints?.platformApp || 'https://biosimulations.dev';
 
-        defaultEndpoints.dataService =
+        endpointsTemplate.dataService =
           dynamicEndpoints?.dataService || 'https://data.biosimulations.dev';
 
-        defaultEndpoints.externalApi =
+        endpointsTemplate.externalApi =
           dynamicEndpoints?.externalApi || 'https://api.biosimulations.dev';
 
-        defaultEndpoints.externalSimulatorsApi =
+        endpointsTemplate.externalSimulatorsApi =
           dynamicEndpoints?.externalSimulatorsApi ||
           'https://api.biosimulators.dev';
 
-        defaultEndpoints.externalCombineApi =
+        endpointsTemplate.externalCombineApi =
           dynamicEndpoints?.externalCombineApi ||
           'https://combine.api.biosimulations.dev';
 
-        defaultEndpoints.externalStorageEndpoint =
+        endpointsTemplate.externalStorageEndpoint =
           dynamicEndpoints?.externalStorageEndpoint ||
           'https://files-dev.biosimulations.org/s3';
 
-        defaultEndpoints.externalDataService =
+        endpointsTemplate.externalDataService =
           dynamicEndpoints?.externalDataService ||
           'https://data.biosimulations.dev';
         break;
 
       case 'prod':
-        defaultEndpoints.api =
+        endpointsTemplate.api =
           dynamicEndpoints?.api || 'https://api.biosimulations.org';
 
-        defaultEndpoints.simulatorsApi =
+        endpointsTemplate.simulatorsApi =
           dynamicEndpoints?.simulatorsApi || 'https://api.biosimulators.org';
 
-        defaultEndpoints.combineApi =
+        endpointsTemplate.combineApi =
           dynamicEndpoints?.combineApi ||
           'https://combine.api.biosimulations.org';
 
-        defaultEndpoints.storageEndpoint =
+        endpointsTemplate.storageEndpoint =
           dynamicEndpoints?.storageEndpoint ||
           'https://files.biosimulations.org/s3';
 
-        defaultEndpoints.simulatorsApp =
+        endpointsTemplate.simulatorsApp =
           dynamicEndpoints?.simulatorsApp || 'https://biosimulators.org';
 
-        defaultEndpoints.dispatchApp =
+        endpointsTemplate.dispatchApp =
           dynamicEndpoints?.dispatchApp || 'https://run.biosimulations.org';
 
-        defaultEndpoints.platformApp =
+        endpointsTemplate.platformApp =
           dynamicEndpoints?.platformApp || 'https://biosimulations.org';
 
-        defaultEndpoints.dataService =
+        endpointsTemplate.dataService =
           dynamicEndpoints?.dataService || 'https://data.biosimulations.org';
 
-        defaultEndpoints.externalApi =
+        endpointsTemplate.externalApi =
           dynamicEndpoints?.externalApi || 'https://api.biosimulations.org';
 
-        defaultEndpoints.externalSimulatorsApi =
+        endpointsTemplate.externalSimulatorsApi =
           dynamicEndpoints?.externalSimulatorsApi ||
           'https://api.biosimulators.org';
 
-        defaultEndpoints.externalCombineApi =
+        endpointsTemplate.externalCombineApi =
           dynamicEndpoints?.externalCombineApi ||
           'https://combine.api.biosimulations.org';
 
-        defaultEndpoints.externalStorageEndpoint =
+        endpointsTemplate.externalStorageEndpoint =
           dynamicEndpoints?.externalStorageEndpoint ||
           'https://files.biosimulations.org/s3';
 
-        defaultEndpoints.externalDataService =
+        endpointsTemplate.externalDataService =
           dynamicEndpoints?.externalDataService ||
           'https://data.biosimulations.org';
         break;
     }
-    return defaultEndpoints;
+    return endpointsTemplate;
   }
 
   private getDynamicEndpoints(): DynamicEndpoints | undefined {

--- a/libs/config/common/src/lib/endpoints.spec.ts
+++ b/libs/config/common/src/lib/endpoints.spec.ts
@@ -1,0 +1,65 @@
+import { Endpoints } from './endpoints';
+describe('Endpoints', () => {
+  let endpoints: Endpoints;
+  const { window } = global;
+
+  beforeAll(() => {
+    // @ts-ignore
+    delete global.window;
+  });
+
+  afterAll(() => {
+    global.window = window;
+  });
+
+  beforeEach(() => {
+    jest.resetModules(); // Most important - it clears the cache
+
+    const endpointsModule = require('./endpoints');
+
+    endpoints = new endpointsModule.Endpoints('prod');
+  });
+
+  it('Should be created', () => {
+    expect(endpoints).toBeDefined();
+  });
+
+  it('Should load correct environment', () => {
+    expect(endpoints.getPlatformAppHome()).toBe('https://biosimulations.org');
+  });
+
+  it('Should not  read environment variables in browser', () => {
+    global.window = window;
+    jest.resetModules(); // Most important - it clears the cache
+    const endpointsModule = require('./endpoints');
+    endpoints = new endpointsModule.Endpoints('prod');
+
+    expect(endpoints.getApiBaseUrl(true)).not.toBe('externalApi');
+    // @ts-ignore
+    delete global.window;
+  });
+
+  it('Should read environment variables for endpoint overrides', () => {
+    expect(endpoints.getApiBaseUrl(false)).toBe('api');
+    expect(endpoints.getSimulatorsApiBaseUrl(false)).toBe('simulatorsApi');
+    expect(endpoints.getCombineApiBaseUrl(false)).toBe('combineApi');
+    expect(endpoints.getStorageEndpointBaseUrl(false)).toBe('storage');
+    expect(endpoints.getDataServiceBaseUrl(false)).toBe('dataService');
+  });
+
+  it('Should return external endpoints when external flag is true', () => {
+    expect(endpoints.getApiBaseUrl(true)).toBe('externalApi');
+    expect(endpoints.getSimulatorsApiBaseUrl(true)).toBe(
+      'externalSimulatorsApi',
+    );
+    expect(endpoints.getCombineApiBaseUrl(true)).toBe('externalCombineApi');
+    expect(endpoints.getStorageEndpointBaseUrl(true)).toBe('externalStorage');
+    expect(endpoints.getDataServiceBaseUrl(true)).toBe('externalDataService');
+  });
+
+  it('Should return correct s3 filepath', () => {
+    expect(
+      endpoints.getSimulationRunContentFileS3Path('testSim', 'testFile'),
+    ).toBe('simulations/testSim/contents/testFile');
+  });
+});

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -33,15 +33,6 @@ export class Endpoints {
   private simulationRunResultsHsdsPath: string;
   private simulationRunContentS3Subpath: string;
   private simulationRunsS3Path: string;
-  //private simulationRuns: string;
-  //private simulationRunResults: string;
-  //private simulationRunLogs: string;
-  //private simulationRunMetadata: string;
-  //private simulators: string;
-  //private files: string;
-  //private combineFile: string;
-  //private specifications: string;
-  //private projects: string;
 
   private env: string;
   public constructor(env?: 'local' | 'dev' | 'stage' | 'prod') {
@@ -71,17 +62,6 @@ export class Endpoints {
     this.simulationRunsS3Path = 'simulations';
     this.simulationRunContentS3Subpath = 'contents';
     this.simulationRunResultsHsdsPath = 'results';
-
-    // this.simulationRunLogts = `${this.api}/logs`;
-    // this.simulationRunResults = `${this.api}/results`;
-    // this.simulationRunMetadata = `${this.api}/metadata`;
-    // this.simulationRuns = `${this.api}/runs`;
-    // this.specifications = `${this.api}/specifications`;
-    // this.files = `${this.api}/files`;
-
-    // this.simulators = `${this.simulatorsApi}/simulators`;
-    // this.combineFile = `${this.combineApi}/combine/file`;
-    // this.projects = `${this.api}/projects`;
   }
 
   // HEALTH CHECKS
@@ -277,14 +257,6 @@ export class Endpoints {
    */
   public getAddFileToCombineArchiveEndpoint(external: boolean): string {
     return this.getCombineFilesEndpointBaseUrl(external);
-  }
-
-  /**
-   * Create a URL for the route of the COMBINE API
-   * @returns A URL for extracting the inputs and outputs of models
-   */
-  public getCombineApiEndpoint(external: boolean): string {
-    return this.getCombineApiBaseUrl(external);
   }
 
   /**
@@ -540,7 +512,7 @@ export class Endpoints {
   ): string {
     return `${this.getSimulationRunS3Path(runId)}/${
       this.simulationRunContentS3Subpath
-    }/${location}`;
+    }/${fileLocation}`;
   }
 
   /**
@@ -653,12 +625,15 @@ export class Endpoints {
   public getSimulatorsApiBaseUrl(external: boolean): string {
     return external ? this.externalSimulatorsApi : this.simulatorsApi;
   }
-  private getDataServiceBaseUrl(external: boolean): string {
+  public getDataServiceBaseUrl(external: boolean): string {
     return external ? this.externalDataService : this.dataService;
   }
 
-  private getCombineApiBaseUrl(external: boolean): string {
+  public getCombineApiBaseUrl(external: boolean): string {
     return external ? this.externalCombineApi : this.combineApi;
+  }
+  public getStorageEndpointBaseUrl(external: boolean): string {
+    return external ? this.externalStorageEndpoint : this.storageEndpoint;
   }
 
   private getOntologiesEndpointBaseUrl(app: string, external: boolean): string {
@@ -711,9 +686,5 @@ export class Endpoints {
   private getCombineFilesEndpointBaseUrl(external: boolean): string {
     const api = this.getCombineApiBaseUrl(external);
     return `${api}/combine/file`;
-  }
-
-  private getStorageEndpointBaseUrl(external: boolean): string {
-    return external ? this.externalStorageEndpoint : this.storageEndpoint;
   }
 }

--- a/libs/shared/storage/src/lib/shared-storage.module.ts
+++ b/libs/shared/storage/src/lib/shared-storage.module.ts
@@ -32,6 +32,6 @@ import { SimulationStorageService } from './simulation-storage.service';
     }),
   ],
   providers: [SharedStorageService, SimulationStorageService],
-  exports: [SharedStorageService, SimulationStorageService],
+  exports: [SimulationStorageService],
 })
 export class SharedStorageModule {}

--- a/libs/shared/storage/src/lib/simulation-storage.service.ts
+++ b/libs/shared/storage/src/lib/simulation-storage.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { ManagedUpload } from 'aws-sdk/clients/s3';
+import S3, { ManagedUpload } from 'aws-sdk/clients/s3';
 import { SharedStorageService } from './shared-storage.service';
 import { Endpoints } from '@biosimulations/config/common';
 import { ConfigService } from '@nestjs/config';
@@ -17,6 +17,32 @@ export class SimulationStorageService {
   ) {
     const env = this.configService.get('server.env');
     this.endpoints = new Endpoints(env);
+  }
+
+  public async deleteSimulationRunResults(runId: string): Promise<void> {
+    await this.deleteSimulationArchive(runId);
+  }
+
+  public async deleteSimulationRunFile(
+    runId: string,
+    fileLocation: string,
+  ): Promise<void> {
+    const fileObject = this.endpoints.getSimulationRunContentFileS3Path(
+      runId,
+      fileLocation,
+    );
+    const output = await this.storage.deleteObject(fileObject);
+
+    // TODO check deletion worked
+  }
+
+  public async getSimulationRunOutputArchive(
+    runId: string,
+  ): Promise<S3.GetObjectOutput> {
+    const file = await this.storage.getObject(
+      this.endpoints.getSimulationRunOutputS3Path(runId),
+    );
+    return file;
   }
 
   public async extractSimulationArchive(file: string): Promise<any> {


### PR DESCRIPTION
services should only be provided by one module. Any services that need to be used across multiple
modules should be exported by the parent module. The module using the service should then import the
parent module. Circular dependencies can be handled by using the "forwardRef" method provided by
NestJS

