### PR TITLE
refactor(analytics): remove analytics setup from index.html to analytics module

### DIFF
--- a/apps/dispatch/src/index.html
+++ b/apps/dispatch/src/index.html
@@ -197,26 +197,6 @@
       }
     </script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-G3CVBC0V5N"
-    ></script>
-
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-
-      gtag('js', new Date());
-
-      // This should not be changed!! The analytics service will enable analytics only once it is consented by the user. Import the analytics module into the app.
-      gtag('consent', 'default', {
-        analytics_storage: 'denied',
-        advertising_storage: 'denied',
-      });
-    </script>
     <meta
       name="description"
       content="Web application for simulating dynamical models of biological systems and visualizing their results"

--- a/apps/platform/src/index.html
+++ b/apps/platform/src/index.html
@@ -171,26 +171,6 @@
       }
     </script>
 
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-G3CVBC0V5N"
-    ></script>
-
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-
-      gtag('js', new Date());
-
-      // This should not be changed!! The analytics service will enable analytics only once it is consented by the user. Import the analytics module into the app.
-      gtag('consent', 'default', {
-        analytics_storage: 'denied',
-        advertising_storage: 'denied',
-      });
-    </script>
     <meta
       name="description"
       content="Web application for sharing dynamical models of biological systems and visualizing their results"
@@ -222,16 +202,6 @@
     <link rel="icon" type="image/x-icon" href="favicon.svg" />
   </head>
   <body>
-    <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-TPK23P5"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <biosimulations-root></biosimulations-root>
     <noscript
       >Please enable JavaScript to continue using this application.</noscript

--- a/apps/simulators/src/index.html
+++ b/apps/simulators/src/index.html
@@ -170,26 +170,7 @@
         "logo": "https://static.biosimulations.org/biosimulators-logo/logo-github.png"
       }
     </script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-G3CVBC0V5N"
-    ></script>
 
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-
-      gtag('js', new Date());
-
-      // This should not be changed!! The analytics service will enable analytics only once it is consented by the user. Import the analytics module into the app.
-      gtag('consent', 'default', {
-        analytics_storage: 'denied',
-        advertising_storage: 'denied',
-      });
-    </script>
     <meta
       name="description"
       content="Registry of containerized biosimulation tools with consistent command-line interfaces that enhance the reproducibility and reusability of biomodels."


### PR DESCRIPTION
this prevents needed to set the index.html for each app seperately. Also handles the initilization
based on the id of each app instead of needed to do that from index