### PR TITLE
refactor(dispatch,platform): switched simulators links to latest version

### DIFF
--- a/apps/dispatch/src/app/components/simulations/view/view.service.ts
+++ b/apps/dispatch/src/app/components/simulations/view/view.service.ts
@@ -54,7 +54,7 @@ export class ViewService {
       updated: FormatService.formatTime(new Date(simulation.updated)),
       simulatorUrl: this.appRoutes.getSimulatorsView(
         simulation.simulator,
-        simulation.simulatorVersion,
+        // simulation.simulatorVersion,
       ),
     };
   }

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -494,7 +494,7 @@ export class ViewService {
               icon: 'simulator',
               url: this.appRoutes.getSimulatorsView(
                 simulationRunSummary.run.simulator.id,
-                simulationRunSummary.run.simulator.version,
+                // simulationRunSummary.run.simulator.version,
               ),
             });
 


### PR DESCRIPTION
- Points users to latest (and likely best metadata) rather the specific version used a simulation run
- Ensures the link will be valid even if we delete the version of the simulator