### PR TITLE
feat(dispatch,platform,ui): enabled descriptions of projects to use markdown formatting

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -102,6 +102,7 @@ csv
 cvode
 Cybern
 danv
+daringfireball
 dbrnz
 dcmi
 dcterms

--- a/apps/dispatch/project.json
+++ b/apps/dispatch/project.json
@@ -48,7 +48,10 @@
           "apps/dispatch/src/sitemap.xml"
         ],
         "styles": ["libs/shared/styles/src/index.scss"],
-        "scripts": ["node_modules/plotly.js/dist/plotly.min.js"],
+        "scripts": [
+          "node_modules/marked/lib/marked.js",
+          "node_modules/plotly.js/dist/plotly.min.js"
+        ],
         "stylePreprocessorOptions": {
           "includePaths": [
             "libs/shared/styles/src/lib",

--- a/docs/concepts/conventions/simulation-project-metadata.md
+++ b/docs/concepts/conventions/simulation-project-metadata.md
@@ -26,7 +26,7 @@ We recommend that COMBINE/OMEX archives be annotated using the predicates and ob
     - Object: Literal string
 - Description (long summary):
     - Predicate: `http://dublincore.org/specifications/dublin-core/dcmi-terms/description`
-    - Object: Literal string
+    - Object: String formatted using [original-flavored markdown](https://daringfireball.net/projects/markdown/)
 - Keyword:
     - Predicate: `http://prismstandard.org/namespaces/basic/2.0/keyword`
     - Object: Literal string

--- a/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
+++ b/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
@@ -24,19 +24,14 @@ export type LabeledIdentifierIsUrl = Omit<LabeledIdentifier, 'uri'> & {
   uri: ValueIsUrl | null;
 };
 
-export interface Attribute {
-  icon: BiosimulationsIcon;
-  title: string;
-  values?: LabeledIdentifierIsUrl[];
-}
-
 export interface ProjectMetadata {
   thumbnails: string[];
   title: string;
   abstract?: string;
   creators: Creator[];
   description?: string;
-  attributes: Attribute[];
+  topAttributes: List[];
+  bottomAttributes: List[];
 }
 
 export interface ListItem {

--- a/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
+++ b/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
@@ -30,8 +30,8 @@ export interface ProjectMetadata {
   abstract?: string;
   creators: Creator[];
   description?: string;
-  topAttributes: List[];
-  bottomAttributes: List[];
+  biology: List[];
+  provenance: List[];
 }
 
 export interface ListItem {

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -379,9 +379,7 @@ export class ViewService {
               },
             );
 
-            const methods: ListItem[] = [];
-
-            Array.from(simulationTypes)
+            const simulationTypeItems = Array.from(simulationTypes)
               .map((simulationType: string): ListItem => {
                 return {
                   title: 'Simulation',
@@ -407,7 +405,7 @@ export class ViewService {
                 task.simulation.algorithm;
             });
 
-            Object.values(kisaoIdSimulationAlgorithmMap)
+            const algorithmItems = Object.values(kisaoIdSimulationAlgorithmMap)
               .map((algorithm): ListItem => {
                 return {
                   title: 'Algorithm',
@@ -423,6 +421,8 @@ export class ViewService {
                   numeric: true,
                 });
               });
+
+            const methods: ListItem[] = simulationTypeItems.concat(algorithmItems);
 
             const formats: ListItem[] = [];
             formats.push({

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -259,7 +259,7 @@ export class ViewService {
       );
     }
     contributors = contributors.concat(metadata?.contributors?.flatMap(this.labeledIdentifierToListItem.bind(this, 'Curator', 'author')) || []);
-    contributors = contributors.concat(metadata?.funders?.flatMap(this.labeledIdentifierToListItem.bind(this, 'Funder', 'funding')) || []);    
+    contributors = contributors.concat(metadata?.funders?.flatMap(this.labeledIdentifierToListItem.bind(this, 'Funder', 'funding')) || []);
     formattedMetadata.bottomAttributes.push({
       title: 'Contributors',
       items: contributors,
@@ -312,7 +312,7 @@ export class ViewService {
         } else {
           return [];
         }
-      }) 
+      })
       || [];
     formattedMetadata.topAttributes.push({
       title: 'Other',
@@ -1343,7 +1343,7 @@ export class ViewService {
     }
   }
 
-  private labeledIdentifierToListItem(    
+  private labeledIdentifierToListItem(
     title: string,
     icon: BiosimulationsIcon,
     labeledIdentifier: LabeledIdentifier,
@@ -1367,11 +1367,11 @@ export class ViewService {
     if (value) {
       return [{
         value: value,
-        url: uriIsUrl 
-          ? labeledIdentifier?.uri 
+        url: uriIsUrl
+          ? labeledIdentifier?.uri
           : null,
         title,
-        icon, 
+        icon,
       }];
     } else {
       return [];

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -679,7 +679,7 @@ export class ViewService {
         format: 'JavaScript Object Notation (JSON) in BioSimulators schema',
         formatUrl: this.endpoints.getApiBaseUrl(true),
         master: false,
-        size: null,
+        size: 'N/A',
         icon: 'report',
         url: this.endpoints.getRunResultsEndpoint(
           true,
@@ -719,7 +719,7 @@ export class ViewService {
         format: 'YAML in BioSimulators log schema',
         formatUrl: this.appRoutes.getConventionsView('simulation-logs'),
         master: false,
-        size: null,
+        size: 'N/A',
         icon: 'logs',
         url: this.endpoints.getSimulationRunLogsEndpoint(
           true,

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -10,8 +10,7 @@
   <div
     *ngIf="project && project?.thumbnails?.length"
     class="thumbnails-column ragged-column"
-    fxFlex="22rem"
-    fxFlex.lt-sm="100%"
+    fxFlex.lt-md="100%"
   >
     <biosimulations-carousel [images]="project.thumbnails">
     </biosimulations-carousel>
@@ -56,7 +55,12 @@
   <!-- End summary/text data-->
 
   <!-- Simulation information -->
-  <div class="simulation-column ragged-column" *ngIf="project?.biology?.length || simulationRun?.length || project?.provenance?.length">
+  <div 
+    *ngIf="project?.biology?.length || simulationRun?.length || project?.provenance?.length"
+    class="simulation-column ragged-column"    
+    fxFlex="22rem"
+    fxFlex.lt-md="100%"
+  >
     <!-- project metadata -->
     <ng-container
       *ngTemplateOutlet="

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -51,64 +51,62 @@
       <div class="description" *ngIf="project.description">
         {{ project.description }}
       </div>
-
-      <!-- attributes -->
-      <div class="attributes" *ngIf="project?.attributes?.length">
-        <ng-container *ngFor="let attribute of project?.attributes">
-          <ng-container *ngFor="let value of attribute.values">
-            <div>
-              <biosimulations-icon
-                [icon]="attribute.icon"
-              ></biosimulations-icon>
-            </div>
-            <div>
-              <b>{{ attribute.title }}:</b>{{ ' ' }}
-              <a
-                *ngIf="value.uri?.isUrl; else noUrl"
-                [href]="value.uri?.value"
-                rel="noopener"
-                target="_blank"
-                >{{ value.label || value.uri?.value }}</a
-              >
-              <ng-template #noUrl>
-                {{ value.label || value.uri?.value }}
-                <span *ngIf="value.label && value.uri?.value"
-                  >{{ ' ' }}({{ value.uri?.value }})</span
-                >
-              </ng-template>
-            </div>
-          </ng-container>
-        </ng-container>
-      </div>
     </biosimulations-text-page-content-section>
   </div>
   <!-- End summary/text data-->
 
   <!-- Simulation information -->
-  <div class="simulation-column ragged-column" *ngIf="simulationRun">
-    <biosimulations-text-page-side-bar-section
-      *ngFor="let section of simulationRun"
-      [heading]="section.title"
-    >
-      <table class="icon-list">
-        <tr *ngFor="let item of section.items">
-          <th>
-            <biosimulations-icon [icon]="item.icon"></biosimulations-icon>
-          </th>
-          <td>
-            <b>{{ item.title }}:</b>{{ ' ' }}
-            <a
-              [href]="item.url"
-              rel="noopener"
-              target="_blank"
-              *ngIf="item.url; else noHref"
-              >{{ item.value }}</a
-            >
-            <ng-template #noHref>{{ item.value }}</ng-template>
-          </td>
-        </tr>
-      </table>
-    </biosimulations-text-page-side-bar-section>
+  <div class="simulation-column ragged-column" *ngIf="project?.topAttributes?.length || simulationRun?.length || project?.bottomAttributes?.length">
+    <!-- project metadata -->
+    <ng-container
+      *ngTemplateOutlet="
+        sectionsTemplate;
+        context: { sections: project?.topAttributes || [] }
+      "
+    ></ng-container>
+
+    <!-- simulation run metadata -->
+    <ng-container
+      *ngTemplateOutlet="
+        sectionsTemplate;
+        context: { sections: simulationRun || []}
+      "
+    ></ng-container>
+
+    <!-- project metadata -->
+    <ng-container
+      *ngTemplateOutlet="
+        sectionsTemplate;
+        context: { sections: project?.bottomAttributes || [] }
+      "
+    ></ng-container>
+
+    <!-- template -->
+    <ng-template #sectionsTemplate let-sections="sections">
+      <biosimulations-text-page-side-bar-section
+        *ngFor="let section of sections"
+        [heading]="section.title"
+      >
+        <table class="icon-list">
+          <tr *ngFor="let item of section.items">
+            <th>
+              <biosimulations-icon [icon]="item.icon"></biosimulations-icon>
+            </th>
+            <td>
+              <b>{{ item.title }}:</b>{{ ' ' }}
+              <a
+                [href]="item.url"
+                rel="noopener"
+                target="_blank"
+                *ngIf="item.url; else noHref"
+                >{{ item.value }}</a
+              >
+              <ng-template #noHref>{{ item.value }}</ng-template>
+            </td>
+          </tr>
+        </table>
+      </biosimulations-text-page-side-bar-section>
+    </ng-template>
   </div>
   <!-- End simulation information -->
 </div>

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -47,9 +47,7 @@
       </ul>
 
       <!-- description -->
-      <div class="description" *ngIf="project.description">
-        {{ project.description }}
-      </div>
+      <markdown [data]="project.description" class="description" *ngIf="project.description"></markdown>
     </biosimulations-text-page-content-section>
   </div>
   <!-- End summary/text data-->

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -56,12 +56,12 @@
   <!-- End summary/text data-->
 
   <!-- Simulation information -->
-  <div class="simulation-column ragged-column" *ngIf="project?.topAttributes?.length || simulationRun?.length || project?.bottomAttributes?.length">
+  <div class="simulation-column ragged-column" *ngIf="project?.biology?.length || simulationRun?.length || project?.provenance?.length">
     <!-- project metadata -->
     <ng-container
       *ngTemplateOutlet="
         sectionsTemplate;
-        context: { sections: project?.topAttributes || [] }
+        context: { sections: project?.biology || [] }
       "
     ></ng-container>
 
@@ -77,7 +77,7 @@
     <ng-container
       *ngTemplateOutlet="
         sectionsTemplate;
-        context: { sections: project?.bottomAttributes || [] }
+        context: { sections: project?.provenance || [] }
       "
     ></ng-container>
 

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
@@ -1,5 +1,6 @@
 @use '@angular/material' as mat;
 @import 'biosimulations-colors';
+@import 'biosimulations-typography';
 
 .thumbnails-column {
   display: flex;
@@ -29,30 +30,57 @@ biosimulations-carousel {
   .creators {
     font-style: italic;
     margin-block-start: 0;
-    margin-block-end: 0.5em;
+    margin-block-end: 0.5rem;
   }
 
   .description {
-    margin-block-start: 0.5em;
-    margin-block-end: 0.5em;
-  }
+    margin-block-start: 0.5rem;
+    margin-block-end: 0.5rem;
 
-  .attributes {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-column-gap: 0.25rem;
-    grid-row-gap: 0.125rem;
-    margin-block-start: 0.5em;
+    ::ng-deep {
+      h1, h2, h3, h4, h5, h6 {
+        background: none;
+        padding: 0;
+        margin: 0;        
+      }
 
-    div:nth-child(odd) {
-      display: flex;
-      justify-content: center;
-    }
+      h1 {
+        @include mat-typography-level-to-styles($fontConfig, subheading-2);
+        font-weight: 500;
+        border-bottom: 1px solid mat.get-color-from-palette($theme-primary);        
+        margin-block-start: 1rem;
+        margin-block-end: 0.25rem;
+      }
 
-    a {
-      color: $dark-primary-text;
-      &:hover {
-        text-decoration: underline;
+      h2 {
+        @include mat-typography-level-to-styles($fontConfig, subheading-1);
+        font-weight: 500;
+        border-bottom: 1px dashed mat.get-color-from-palette($theme-primary);     
+        margin-block-start: 1rem;
+        margin-block-end: 0.25rem;
+      }
+
+      h3 {
+        @include mat-typography-level-to-styles($fontConfig, body-2);
+        font-weight: 500;
+        margin-block-start: 1rem;
+      }
+
+      h4 {
+        @include mat-typography-level-to-styles($fontConfig, body-2);
+        font-weight: 500;
+        margin-block-start: 0.5rem;
+      }
+
+      h5 {
+        @include mat-typography-level-to-styles($fontConfig, body-1);      
+        margin-block-start: 0.5rem;
+      }
+
+      h6 {
+        @include mat-typography-level-to-styles($fontConfig, body-1);
+        font-style: italic;
+        margin-block-start: 0.5rem;
       }
     }
   }

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.spec.ts
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { SharedUiModule } from '@biosimulations/shared/ui';
+import { MarkdownModule, MarkdownService } from 'ngx-markdown';
 
 import { MetadataComponent } from './metadata.component';
 
@@ -11,7 +12,12 @@ describe('MetadataComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [MetadataComponent],
-      imports: [BiosimulationsIconsModule, SharedUiModule],
+      imports: [
+        BiosimulationsIconsModule,
+        SharedUiModule,
+        MarkdownModule.forRoot(),
+      ],
+      providers: [MarkdownService],
     }).compileComponents();
   });
 

--- a/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
+++ b/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
@@ -16,6 +16,8 @@ import { DesignHeatmap2DVisualizationComponent } from './design-heatmap-2d-viz/d
 import { DesignLine2DVisualizationComponent } from './design-line-2d-viz/design-line-2d-viz.component';
 import { RenderVisualizationComponent } from './render-viz/render-viz.component';
 import { ApiClientModule } from '@biosimulations/angular-api-client';
+import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
+
 @NgModule({
   imports: [
     CommonModule,
@@ -29,6 +31,14 @@ import { ApiClientModule } from '@biosimulations/angular-api-client';
     MatButtonModule,
     BiosimulationsIconsModule,
     ApiClientModule,
+    MarkdownModule.forRoot({ 
+      markedOptions: {
+        provide: MarkedOptions,
+        useValue: {
+          gfm: false,
+        },
+      },
+    })
   ],
   exports: [
     MetadataComponent,

--- a/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
+++ b/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
@@ -31,7 +31,7 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
     MatButtonModule,
     BiosimulationsIconsModule,
     ApiClientModule,
-    MarkdownModule.forRoot({ 
+    MarkdownModule.forRoot({
       markedOptions: {
         provide: MarkedOptions,
         useValue: {


### PR DESCRIPTION
closes #3943 

- [x] Organize structured metadata
- [x] Set max width for structured metadata
- [x] Render markdown-formatted descriptions
  - [x] style headings appropriately, or demote headings
- [x] Update documentation to note that descriptions can be encoded in original-flavored markdown