### PR TITLE
refactor: add support for github flavored markdown

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -13,6 +13,11 @@ https?://(?:(?:www\.|)youtube\.com|youtu.be)/(?:channel/|embed/|playlist\?list=|
 <\s*youtube\s+id=['"][-a-zA-Z0-9?_]*['"]
 \bimg\.youtube\.com/vi/[-a-zA-Z0-9?&=_]*
 
+#Github Links 
+https?://(?:(?:www\.|)github\.com)/[-a-zA-Z0-9?&=_]*
+https?://(?:(?:github\.|)github\.com)/[-a-zA-Z0-9?&=_]*
+
+
 # Google Docs
 /docs\.google\.com/[a-z]+/d/(?:e/|)[0-9a-zA-Z_-]+/?
 # Google Drive

--- a/docs/concepts/conventions/simulation-project-metadata.md
+++ b/docs/concepts/conventions/simulation-project-metadata.md
@@ -26,7 +26,10 @@ We recommend that COMBINE/OMEX archives be annotated using the predicates and ob
     - Object: Literal string
 - Description (long summary):
     - Predicate: `http://dublincore.org/specifications/dublin-core/dcmi-terms/description`
-    - Object: String formatted using [original-flavored markdown](https://daringfireball.net/projects/markdown/)
+    - Object: String formatted using [original-flavored markdown](https://daringfireball.net/projects/markdown/) or [GitHub flavored markdown](https://github.github.com/gfm/)
+    !!! warning
+        Support for  [GitHub flavored markdown](https://github.github.com/gfm/) is available, with some limitations. 
+        For information about compatibility issues you can view the discussion on the underlying parser's repository [here](https://github.com/markedjs/marked/discussions/1202).
 - Keyword:
     - Predicate: `http://prismstandard.org/namespaces/basic/2.0/keyword`
     - Object: Literal string

--- a/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
+++ b/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
@@ -35,7 +35,7 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
       markedOptions: {
         provide: MarkedOptions,
         useValue: {
-          gfm: false,
+          gfm: true, // Github-flavored markdown see (https://github.com/biosimulations/biosimulations/issues/3963)
         },
       },
     }),


### PR DESCRIPTION
add support for gfm and update docs to point to limitations as per #3963

closes #3963