### PR TITLE
feat(dispatch,platform): displayed metadata about individual files

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -102,7 +102,6 @@ csv
 cvode
 Cybern
 danv
-daringfireball
 dbrnz
 dcmi
 dcterms
@@ -176,6 +175,7 @@ Garny
 gdpr
 geneontology
 Gennari
+GFM
 ghcr
 gillespie
 gillespy
@@ -363,7 +363,6 @@ opencor
 openlinksw
 opensourcebrain
 orcid
-orgs
 osde
 pahle
 Paulev

--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -222,7 +222,7 @@ export class ProjectsService implements OnModuleInit {
       })
       .sort()
       .join(',');
-    const cacheKey = `Project:Summaries:${projectIds}`;
+    const cacheKey = `Project:Summaries:${projectIds}:${SimulationRunService.summaryVersion}`;
     return this.getWithCache<ProjectSummary[]>(
       cacheKey,
       this._getProjectSummaries.bind(this, projects),
@@ -307,7 +307,7 @@ export class ProjectsService implements OnModuleInit {
     }
 
     const updated = project.updated.toISOString();
-    const cacheKey = `Project:Summary:${id}:${updated}`;
+    const cacheKey = `Project:Summary:${id}:${updated}:${SimulationRunService.summaryVersion}`;
     return this.getWithCache<ProjectSummary>(
       cacheKey,
       this._getProjectSummary.bind(this, project),
@@ -434,6 +434,8 @@ export class ProjectsService implements OnModuleInit {
     return undefined;
   }
 
+  private static accountVersion = 1;
+
   /** Get information about an account from Auth0
    * @param auth0Id: Auth0 user or client id
    */
@@ -494,7 +496,7 @@ export class ProjectsService implements OnModuleInit {
    * @param auth0Id: Auth0 user or client id
    */
   private async getAccount(auth0Id: string): Promise<Account> {
-    const cacheKey = `Account:info:${auth0Id}`;
+    const cacheKey = `Account:info:${auth0Id}:${ProjectsService.accountVersion}`;
     return this.getWithCache<Account>(
       cacheKey,
       this._getAccount.bind(this, auth0Id),

--- a/apps/api/src/results/results.controller.ts
+++ b/apps/api/src/results/results.controller.ts
@@ -10,6 +10,7 @@
 import {
   CacheInterceptor,
   CacheTTL,
+  CacheKey,
   Controller,
   Get,
   Param,
@@ -39,6 +40,8 @@ import { ErrorResponseDocument } from '@biosimulations/datamodel/api';
 export class ResultsController {
   public constructor(private service: ResultsService) {}
 
+  private static runResultsVersion = 1;
+
   @ApiOperation({
     summary: 'Get the results of all of the outputs of a simulation run',
     description:
@@ -67,6 +70,7 @@ export class ResultsController {
   })
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(0)
+  @CacheKey(`:runId/${ResultsController.runResultsVersion}`)
   public async getResults(
     @Param('runId') runId: string,
     @Query('includeData', ParseBoolPipe) includeData = false,
@@ -117,6 +121,8 @@ export class ResultsController {
     res.send();
   }
 
+  private static outputResultsVersion = 1;
+
   @ApiOperation({
     summary:
       'Get the results of an output (plot or report) of a simulation run',
@@ -153,6 +159,7 @@ export class ResultsController {
   })
   @UseInterceptors(CacheInterceptor)
   @CacheTTL(0)
+  @CacheKey(`:runId/:experimentLocationAndOutputId/${ResultsController.outputResultsVersion}`)
   public async getResultReport(
     @Param('runId') runId: string,
     @Param('experimentLocationAndOutputId')

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -1284,8 +1284,8 @@ export class SimulationRunService {
     if (rawMetadataResult.succeeded && rawMetadataResult.value) {
       summary.metadata = rawMetadataResult.value.metadata.map((rawMetadatum: ArchiveMetadata) => {
         const uriSlashPos = rawMetadatum.uri.search('/');
-        const uri = uriSlashPos === -1 
-          ? '.' 
+        const uri = uriSlashPos === -1
+          ? '.'
           : rawMetadatum.uri.substring(uriSlashPos + 1);
 
         return {

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -438,11 +438,13 @@ export class SimulationRunService {
     );
   }
 
+  public static summaryVersion = 1;
+
   public async getRunSummary(
     id: string,
     raiseErrors = false,
   ): Promise<SimulationRunSummary> {
-    const cacheKey = `SimulationRun:summary:${raiseErrors}:${id}`;
+    const cacheKey = `SimulationRun:summary:${raiseErrors}:${id}:${SimulationRunService.summaryVersion}`;
     const cachedValue = (await this.cacheManager.get(
       cacheKey,
     )) as SimulationRunSummary | null;

--- a/apps/dispatch-service/src/metadata/metadata.service.ts
+++ b/apps/dispatch-service/src/metadata/metadata.service.ts
@@ -134,7 +134,7 @@ export class MetadataService {
         combineMetadata.contributors?.map(this.convertMetadataValue, this) ||
         [],
       license: [this.convertMetadataValue(combineMetadata.license)],
-      created: combineMetadata.created || '',
+      created: combineMetadata.created || undefined,
       modified: combineMetadata.modified || [],
       other:
         combineMetadata.other?.map((data: BioSimulationsCustomMetadata) => {

--- a/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
+++ b/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
@@ -165,7 +165,7 @@ export class PublishComponent implements OnInit, OnDestroy {
         }),
         catchError((error: HttpErrorResponse): Observable<undefined> => {
           if (!environment.production) {
-            console.log(error);
+            console.error(error);
           }
 
           this.snackBar.open(

--- a/apps/dispatch/src/app/components/simulations/view/view.component.html
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.html
@@ -106,7 +106,7 @@
           heading="Project"
           *ngIf="projectFiles$ | async as files"
         >
-          <biosimulations-project-files [files]="files" [usesMaster]="false">
+          <biosimulations-project-files [files]="files" [usesMaster]="false" [usesMetadata]="false">
           </biosimulations-project-files>
         </biosimulations-text-page-content-section>
 
@@ -114,7 +114,7 @@
           heading="Project contents"
           *ngIf="files$ | async as files"
         >
-          <biosimulations-project-files [files]="files" [usesMaster]="true">
+          <biosimulations-project-files [files]="files" [usesMaster]="true" [usesMetadata]="true">
           </biosimulations-project-files>
         </biosimulations-text-page-content-section>
 
@@ -122,7 +122,7 @@
           heading="Simulation outputs"
           *ngIf="outputs$ | async as files"
         >
-          <biosimulations-project-files [files]="files" [usesMaster]="false">
+          <biosimulations-project-files [files]="files" [usesMaster]="false" [usesMetadata]="false">
           </biosimulations-project-files>
         </biosimulations-text-page-content-section>
       </div>

--- a/apps/dispatch/src/app/components/simulations/view/view.component.ts
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatTabChangeEvent } from '@angular/material/tabs';
 import { Observable, of, combineLatest, map, pluck, mergeMap, iif } from 'rxjs';
-import { shareReplay, catchError } from 'rxjs/operators';
+import { shareReplay, catchError, concatAll } from 'rxjs/operators';
 import { SimulationRunStatus } from '@biosimulations/datamodel/common';
 import {
   ProjectMetadata,
@@ -134,7 +134,15 @@ export class ViewComponent implements OnInit {
       mergeMap((completed) =>
         iif(
           () => completed,
-          this.sharedViewService.getFormattedProjectContentFiles(id),
+          this.simulationRunService.getSimulationRunSummary(id).pipe(
+            map((simulationRunSummary) =>
+              this.sharedViewService.getFormattedProjectContentFiles(
+                simulationRunSummary,
+              ),
+            ),
+            concatAll(),
+            shareReplay(1),
+          ),
           of(null),
         ),
       ),

--- a/apps/platform/src/app/projects/browse/browse.component.ts
+++ b/apps/platform/src/app/projects/browse/browse.component.ts
@@ -2,13 +2,12 @@ import { Component, OnInit, AfterViewInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { BrowseService } from './browse.service';
-import { FormattedProjectSummary } from './browse.model';
+import { FormattedProjectSummary, LocationPredecessor } from './browse.model';
 import { Column, ColumnFilterType } from '@biosimulations/shared/ui';
 import { FormatService } from '@biosimulations/shared/services';
 import {
   LabeledIdentifier,
   DescribedIdentifier,
-  LocationPredecessor,
 } from '@biosimulations/datamodel/common';
 import { RowService } from '@biosimulations/shared/ui';
 import { ScrollService } from '@biosimulations/shared/angular';
@@ -444,20 +443,12 @@ export class BrowseComponent implements OnInit, AfterViewInit {
       getter: (project: FormattedProjectSummary): string[] => {
         const value = new Set(
           project.metadata.locationPredecessors
-            .flatMap(
-              (
-                locationPredecessor: LocationPredecessor,
-              ): LabeledIdentifier[] => {
-                if (locationPredecessor.location.endsWith('.sedml')) {
-                  return locationPredecessor.predecessors;
-                } else {
-                  return [];
-                }
-              },
-            )
-            .map((predecessor: LabeledIdentifier): string => {
-              return predecessor.uri?.startsWith('http://omex-library.org/') &&
-                predecessor.uri.indexOf('.omex/') !== -1
+            .filter((locationPredecessor: LocationPredecessor): boolean => {
+              return locationPredecessor.location.endsWith('.sedml');
+            })
+            .map((predecessor: LocationPredecessor): string => {
+              return predecessor.predecessor.uri?.startsWith('http://omex-library.org/') &&
+                predecessor.predecessor.uri.indexOf('.omex/') !== -1
                 ? 'Simulation generated from model'
                 : 'Other';
             }),

--- a/apps/platform/src/app/projects/browse/browse.model.ts
+++ b/apps/platform/src/app/projects/browse/browse.model.ts
@@ -1,7 +1,6 @@
 import {
   LabeledIdentifier,
   DescribedIdentifier,
-  LocationPredecessor,
   EnvironmentVariable,
   SimulationRunTaskSummary,
   SimulationRunOutputSummary,
@@ -24,6 +23,11 @@ export interface FormattedSimulationRunSummary {
   updated: Date;
 }
 
+export interface LocationPredecessor {
+  location: string;
+  predecessor: LabeledIdentifier;
+}
+
 export interface FormattedProjectMetadataSummary {
   abstract?: string;
   description?: string;
@@ -39,7 +43,7 @@ export interface FormattedProjectMetadataSummary {
   funders: LabeledIdentifier[];
   other: DescribedIdentifier[];
   locationPredecessors: LocationPredecessor[];
-  created: Date;
+  created?: Date;
   modified?: Date;
 }
 

--- a/apps/platform/src/app/projects/view/view.component.html
+++ b/apps/platform/src/app/projects/view/view.component.html
@@ -43,6 +43,7 @@
           id="content"
           [files]="files"
           [usesMaster]="false"
+          [usesMetadata]="false"
         >
         </biosimulations-project-files>
       </biosimulations-text-page-content-section>
@@ -55,6 +56,7 @@
           id="content"
           [files]="files"
           [usesMaster]="true"
+          [usesMetadata]="true"
         >
         </biosimulations-project-files>
       </biosimulations-text-page-content-section>
@@ -67,6 +69,7 @@
           id="content"
           [files]="files"
           [usesMaster]="false"
+          [usesMetadata]="false"
         >
         </biosimulations-project-files>
       </biosimulations-text-page-content-section>

--- a/apps/platform/src/app/projects/view/view.component.ts
+++ b/apps/platform/src/app/projects/view/view.component.ts
@@ -103,7 +103,7 @@ export class ViewComponent implements OnInit {
     this.files$ = projectSummary$.pipe(
       mergeMap((projectSummary) =>
         this.service.getFormattedProjectContentFiles(
-          projectSummary.simulationRun.id,
+          projectSummary.simulationRun,
         ),
       ),
       shareReplay(1),

--- a/docs/concepts/conventions/simulation-project-metadata.md
+++ b/docs/concepts/conventions/simulation-project-metadata.md
@@ -26,10 +26,9 @@ We recommend that COMBINE/OMEX archives be annotated using the predicates and ob
     - Object: Literal string
 - Description (long summary):
     - Predicate: `http://dublincore.org/specifications/dublin-core/dcmi-terms/description`
-    - Object: String formatted using [original-flavored markdown](https://daringfireball.net/projects/markdown/) or [GitHub flavored markdown](https://github.github.com/gfm/)
+    - Object: String formatted using [GitHub-flavored markdown](https://github.github.com/gfm/) (GFM)
     !!! warning
-        Support for  [GitHub flavored markdown](https://github.github.com/gfm/) is available, with some limitations. 
-        For information about compatibility issues you can view the discussion on the underlying parser's repository [here](https://github.com/markedjs/marked/discussions/1202).
+        BioSimulations uses [Marked](https://marked.js.org/) to render GFM. Marked supports most, but not all features of GFM. More information about Marked's support for GFM is available [here](https://github.com/markedjs/marked/discussions/1202).
 - Keyword:
     - Predicate: `http://prismstandard.org/namespaces/basic/2.0/keyword`
     - Object: Literal string

--- a/libs/datamodel/api/src/lib/common/archiveMetadata.ts
+++ b/libs/datamodel/api/src/lib/common/archiveMetadata.ts
@@ -2,7 +2,6 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import {
   ArchiveMetadata as IArchiveMetadata,
-  ArchiveMetadataSummary as IArchiveMetadataSummary,
 } from '@biosimulations/datamodel/common';
 import {
   IsString,
@@ -25,11 +24,9 @@ import {
   IDENTIFIERS,
   KEYWORDS,
   LabeledIdentifier,
-  LocationPredecessor,
   LICENCE,
   MODIFIED,
   PREDECESSORS,
-  LOCATION_PREDECESSORS,
   SEEALSO,
   SOURCES,
   SUCCESSORS,
@@ -38,19 +35,7 @@ import {
   FUNDERS,
 } from './commonDefinitions';
 
-type IArchiveMetadataType = Omit<IArchiveMetadata, 'created' | 'modified'> & {
-  created: string;
-  modified: string[];
-};
-type IArchiveMetadataSummaryType = Omit<
-  IArchiveMetadataSummary,
-  'created' | 'modified'
-> & {
-  created: string;
-  modified: string[];
-};
-
-export class ArchiveMetadata implements IArchiveMetadataType {
+export class ArchiveMetadata implements IArchiveMetadata {
   @ApiProperty({ type: 'string' })
   @IsString()
   uri!: string; // Should this be in the API
@@ -144,29 +129,21 @@ export class ArchiveMetadata implements IArchiveMetadataType {
 
   @ApiProperty(CREATED)
   @IsOptional()
+  @IsNotEmpty()
   @IsString()
-  created!: string;
+  created?: string;
 
   @ApiProperty(MODIFIED)
+  @IsOptional()
   @IsNotEmpty({ each: true })
   @IsString({ each: true })
   @IsArray()
-  modified: string[] = [];
+  modified?: string[];
 
   @ApiProperty({ type: [DescribedIdentifier] })
   @ValidateNested({ each: true })
   @Type(() => DescribedIdentifier)
   other: DescribedIdentifier[] = [];
-}
-
-export class ArchiveMetadataSummary
-  extends ArchiveMetadata
-  implements IArchiveMetadataSummaryType
-{
-  @ApiProperty(LOCATION_PREDECESSORS)
-  @ValidateNested({ each: true })
-  @Type(() => LocationPredecessor)
-  locationPredecessors: LocationPredecessor[] = [];
 }
 
 export class ArchiveMetadataContainer {

--- a/libs/datamodel/api/src/lib/common/commonDefinitions.ts
+++ b/libs/datamodel/api/src/lib/common/commonDefinitions.ts
@@ -2,11 +2,9 @@
 import {
   LabeledIdentifier as ILabeledIdentifier,
   DescribedIdentifier as IDescribedIdentifier,
-  LocationPredecessor as ILocationPredecessor,
 } from '@biosimulations/datamodel/common';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsString, IsOptional, ValidateNested } from 'class-validator';
-import { Type } from 'class-transformer';
+import { IsString, IsOptional } from 'class-validator';
 
 export class LabeledIdentifier implements ILabeledIdentifier {
   @ApiProperty({ type: String, nullable: true, required: false, default: null })
@@ -55,16 +53,11 @@ export class DescribedIdentifier
   attribute_label!: string | null;
 }
 
-export class LocationPredecessor implements ILocationPredecessor {
-  @ApiProperty({ type: String })
-  @IsString()
-  location!: string;
-
-  @ApiProperty({ type: [LabeledIdentifier] })
-  @ValidateNested({ each: true })
-  @Type(() => LabeledIdentifier)
-  predecessors!: LabeledIdentifier[];
-}
+export const URI = {
+  type: String,
+  description: 'URI for the subject of the metadata',
+  example: '.',
+};
 
 export const CREATORS = {
   type: [LabeledIdentifier],
@@ -227,26 +220,6 @@ export const PREDECESSORS = {
     {
       label: 'Balagaddé2008_E_coli_Predator_Prey',
       uri: 'http://identifiers.org/biomodels.db:BIOMD0000000296',
-    },
-  ],
-};
-
-export const LOCATION_PREDECESSORS = {
-  type: [LocationPredecessor],
-  description: 'Predecessors of individual files of the project',
-  externalDocs: {
-    description: 'Biomodels Model Qualifiers isDerivedFrom',
-    url: 'https://biomodels.net/model-qualifiers/isDerivedFrom',
-  },
-  example: [
-    {
-      location: 'simulation.sedml',
-      predecessors: [
-        {
-          label: 'Model',
-          uri: 'model.xml',
-        },
-      ],
     },
   ],
 };

--- a/libs/datamodel/api/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRun.ts
@@ -32,7 +32,7 @@ import {
 import {
   LabeledIdentifier,
   DescribedIdentifier,
-  LocationPredecessor,
+  URI,
   ABSTRACT,
   CITATIONS,
   CONTRIBUTORS,
@@ -45,7 +45,6 @@ import {
   LICENCE,
   MODIFIED,
   PREDECESSORS,
-  LOCATION_PREDECESSORS,
   SEEALSO,
   SOURCES,
   SUCCESSORS,
@@ -779,6 +778,9 @@ export class SimulationRunRunSummary implements ISimulationRunRunSummary {
 export class SimulationRunMetadataSummary
   implements ISimulationRunMetadataSummary
 {
+  @ApiProperty(URI)
+  uri!: string;
+
   @ApiPropertyOptional(TITLE)
   title?: string;
 
@@ -805,9 +807,6 @@ export class SimulationRunMetadataSummary
 
   @ApiProperty(PREDECESSORS)
   predecessors!: LabeledIdentifier[];
-
-  @ApiProperty(LOCATION_PREDECESSORS)
-  locationPredecessors!: LocationPredecessor[];
 
   @ApiProperty(SUCCESSORS)
   successors!: LabeledIdentifier[];
@@ -837,10 +836,10 @@ export class SimulationRunMetadataSummary
   other!: DescribedIdentifier[];
 
   @ApiProperty(CREATED)
-  created!: string;
+  created?: string;
 
   @ApiPropertyOptional(MODIFIED)
-  modified?: string;
+  modified?: string[];
 }
 
 export class SimulationRunSummary implements ISimulationRunSummary {
@@ -877,10 +876,10 @@ export class SimulationRunSummary implements ISimulationRunSummary {
   run!: SimulationRunRunSummary;
 
   @ApiPropertyOptional({
-    type: SimulationRunMetadataSummary,
+    type: [SimulationRunMetadataSummary],
     description: 'Summary of the metadata for the run',
   })
-  metadata?: SimulationRunMetadataSummary;
+  metadata?: SimulationRunMetadataSummary[];
 
   @ApiProperty({
     description: 'Timestamp when the simulation run was submitted',

--- a/libs/datamodel/common/src/lib/core/archiveMetadata.ts
+++ b/libs/datamodel/common/src/lib/core/archiveMetadata.ts
@@ -8,11 +8,6 @@ export interface DescribedIdentifier extends LabeledIdentifier {
   attribute_label: string | null;
 }
 
-export interface LocationPredecessor {
-  location: string;
-  predecessors: LabeledIdentifier[];
-}
-
 export interface ArchiveMetadata {
   uri: string;
   title?: string;
@@ -32,11 +27,7 @@ export interface ArchiveMetadata {
   contributors: LabeledIdentifier[];
   license?: LabeledIdentifier[];
   funders: LabeledIdentifier[];
-  created?: Date | string;
-  modified: Date[] | string[];
+  created?: string;
+  modified?: string[];
   other: DescribedIdentifier[];
-}
-
-export interface ArchiveMetadataSummary extends ArchiveMetadata {
-  locationPredecessors: LocationPredecessor[];
 }

--- a/libs/datamodel/common/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/common/src/lib/core/simulationRun.ts
@@ -10,7 +10,6 @@ import {
 import {
   LabeledIdentifier,
   DescribedIdentifier,
-  LocationPredecessor,
 } from './archiveMetadata';
 
 export enum SimulationRunStatus {
@@ -217,6 +216,7 @@ export interface SimulationRunRunSummary {
 }
 
 export interface SimulationRunMetadataSummary {
+  uri: string;
   title?: string;
   abstract?: string;
   description?: string;
@@ -226,7 +226,6 @@ export interface SimulationRunMetadataSummary {
   taxa: LabeledIdentifier[];
   encodes: LabeledIdentifier[];
   predecessors: LabeledIdentifier[];
-  locationPredecessors: LocationPredecessor[];
   successors: LabeledIdentifier[];
   seeAlso: LabeledIdentifier[];
   identifiers: LabeledIdentifier[];
@@ -236,8 +235,8 @@ export interface SimulationRunMetadataSummary {
   license?: LabeledIdentifier[];
   funders: LabeledIdentifier[];
   other: DescribedIdentifier[];
-  created: string;
-  modified?: string;
+  created?: string;
+  modified?: string[];
 }
 
 export interface SimulationRunSummary {
@@ -246,7 +245,7 @@ export interface SimulationRunSummary {
   tasks?: SimulationRunTaskSummary[];
   outputs?: SimulationRunOutputSummary[];
   run: SimulationRunRunSummary;
-  metadata?: SimulationRunMetadataSummary;
+  metadata?: SimulationRunMetadataSummary[];
   submitted: string;
   updated: string;
 }

--- a/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
+++ b/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
@@ -30,7 +30,7 @@ export interface ProjectMetadata {
   abstract?: string;
   creators: Creator[];
   description?: string;
-  biology: List[];
+  modelSimulation: List[];
   provenance: List[];
 }
 
@@ -135,6 +135,7 @@ export interface Directory {
   location: string;
   level: number;
   title: string;
+  metadata?: ProjectMetadata;
 }
 
 export interface File {
@@ -149,6 +150,7 @@ export interface File {
   master: boolean;
   url: string;
   size: string | null;
+  metadata?: ProjectMetadata;
 }
 
 export type Path = Directory | File;

--- a/libs/ontology/api/src/lib/ontology-api.controller.ts
+++ b/libs/ontology/api/src/lib/ontology-api.controller.ts
@@ -49,7 +49,7 @@ export class OntologyApiController {
     description:
       'The ids of the ontologies used by BioSimulations and BioSimulators were successfully retrieved',
     type: [String],
-  })  
+  })
   public async getList(): Promise<string[]> {
     const cacheKey = `${OntologyApiController.version}`;
 
@@ -62,7 +62,7 @@ export class OntologyApiController {
     });
   }
 
-  @Get(':ontologyId/info')  
+  @Get(':ontologyId/info')
   @ApiOperation({
     summary: 'Get information about an ontology',
     description:
@@ -98,7 +98,7 @@ export class OntologyApiController {
     });
   }
 
-  @Get(':ontologyId')  
+  @Get(':ontologyId')
   @ApiOperation({
     summary: 'Get the terms in an ontology',
     description: 'Get a list of the terms in an ontology',
@@ -133,7 +133,7 @@ export class OntologyApiController {
     });
   }
 
-  @Get(':ontologyId/:termId')  
+  @Get(':ontologyId/:termId')
   @ApiOperation({
     summary: 'Get a term in an ontology',
     description:

--- a/libs/shared/styles/src/lib/_global.scss
+++ b/libs/shared/styles/src/lib/_global.scss
@@ -36,7 +36,7 @@ ul:last-child {
 
 /* Page content */
 .partial-width {
-  max-width: 1200px;
+  max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
   overflow: auto;
@@ -1443,4 +1443,15 @@ sub {
   transition: width ease-in-out 1s;
   overflow: clip;
   width: 0;
+}
+
+/* dialogs */
+.mat-dialog-container {
+  padding: 2rem;
+}
+
+@media screen and (max-width: 959px) {
+  .mat-dialog-container {
+    padding: 1rem;
+  }
 }

--- a/libs/shared/ui/src/lib/table/table.component.ts
+++ b/libs/shared/ui/src/lib/table/table.component.ts
@@ -666,7 +666,9 @@ export class TableComponent implements OnInit, AfterViewInit {
       this.setColumnsToShow();
 
       if (openControlPanelId !== undefined) {
-        this.openControlPanelId = openControlPanelId;
+        setTimeout(() => {
+          this.openControlPanelId = openControlPanelId;
+        });
       }
     }
 

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -607,7 +607,7 @@ export class ViewService {
 
         simulationRunSummary?.metadata?.forEach((metadatum: SimulationRunMetadataSummary): void => {
           metadataMap[metadatum.uri] = this.formatMetadata(metadatum);
-        });        
+        });
 
         const root: { [path: string]: Path } = {};
 

--- a/libs/simulation-runs/ui/src/lib/files/files.component.html
+++ b/libs/simulation-runs/ui/src/lib/files/files.component.html
@@ -2,6 +2,8 @@
   <div class="head cell title">Name</div>
   <div class="head cell format">Format</div>
   <div class="head cell main">{{ usesMaster ? 'Main' : '' }}</div>
+  <div class="head cell metadata">{{ usesMetadata ? 'Metadata': '' }}</div>
+  <div class="head cell download">Download</div>
   <div class="head cell size">Size</div>
 
   <ng-container *ngFor="let path of files">
@@ -17,6 +19,18 @@
       </div>
       <div class="cell format">Directory</div>
       <div class="cell main"></div>
+      <div class="cell metadata">
+        <ng-container *ngIf="usesMetadata">
+          <button mat-icon-button
+            *ngIf="path?.metadata as metadata"
+            (click)="openMetadata(metadata)"
+            class="biosimulations-button text"
+          >
+            <biosimulations-icon icon="info"></biosimulations-icon>
+          </button>
+        </ng-container>
+      </div>
+      <div class="cell download"></div>
       <div class="cell size"></div>
     </ng-container>
 
@@ -29,14 +43,7 @@
         <div class="icon-container">
           <biosimulations-icon [icon]="path.icon"></biosimulations-icon>
         </div>
-        <a
-          [href]="path.url"
-          rel="noopener"
-          target="_blank"
-          *ngIf="path.url"
-          [download]="path.basename"
-          >{{ path.title }}</a
-        >
+        {{ path.title }}
       </div>
       <div class="cell format" [class.main-file]="path.master">
         <a
@@ -49,6 +56,29 @@
       </div>
       <div class="cell main" [class.main-file]="path.master">
         {{ path.master ? '&#10003;' : '' }}
+      </div>
+      <div class="cell metadata">
+        <ng-container *ngIf="usesMetadata">
+          <button mat-icon-button
+            *ngIf="path?.metadata as metadata"
+            (click)="openMetadata(metadata)"
+            class="biosimulations-button text"
+          >
+            <biosimulations-icon icon="info"></biosimulations-icon>
+          </button>
+        </ng-container>
+      </div>
+      <div class="cell download">
+        <a mat-icon-button
+          class="biosimulations-button text"
+          [href]="path.url"
+          rel="noopener"
+          target="_blank"
+          *ngIf="path.url"
+          [download]="path.basename"
+          >
+          <biosimulations-icon icon="download"></biosimulations-icon>
+        </a>
       </div>
       <div class="cell size" [class.main-file]="path.master">
         <div *ngIf="path.size">{{ path.size }}</div>

--- a/libs/simulation-runs/ui/src/lib/files/files.component.scss
+++ b/libs/simulation-runs/ui/src/lib/files/files.component.scss
@@ -1,5 +1,5 @@
 .clean-table {
-  grid-template-columns: 1fr 1fr 75px 75px;
+  grid-template-columns: repeat(2, 1fr) repeat(4, 80px);
 }
 
 .cell {
@@ -14,4 +14,12 @@
 
 .master-file {
   /* background: #efefef; */
+}
+
+.metadata, .download {
+  text-align: center;
+  .biosimulations-button {
+    position: relative;
+    top: -2px;
+  }
 }

--- a/libs/simulation-runs/ui/src/lib/files/files.component.spec.ts
+++ b/libs/simulation-runs/ui/src/lib/files/files.component.spec.ts
@@ -3,6 +3,11 @@ import { MatListModule } from '@angular/material/list';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { SharedUiModule } from '@biosimulations/shared/ui';
 import { FilesComponent } from './files.component';
+import {
+  MatDialogModule,
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog';
 
 describe('FilesComponent', () => {
   let component: FilesComponent;
@@ -11,7 +16,14 @@ describe('FilesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [FilesComponent],
-      imports: [BiosimulationsIconsModule, MatListModule, SharedUiModule],
+      imports: [BiosimulationsIconsModule, MatListModule, SharedUiModule, MatDialogModule],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: undefined,
+        },
+      ],
     }).compileComponents();
   });
 

--- a/libs/simulation-runs/ui/src/lib/files/files.component.ts
+++ b/libs/simulation-runs/ui/src/lib/files/files.component.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
-import { Path } from '@biosimulations/datamodel-simulation-runs';
+import { Path, ProjectMetadata } from '@biosimulations/datamodel-simulation-runs';
+import { MatDialog } from '@angular/material/dialog';
+import { MetadataDialogComponent } from '../metadata-dialog/metadata-dialog.component';
 
 @Component({
   selector: 'biosimulations-project-files',
@@ -13,5 +15,15 @@ export class FilesComponent {
   @Input()
   usesMaster = false;
 
-  constructor() {}
+  @Input()
+  usesMetadata = false;
+
+  constructor(private dialog: MatDialog) {}
+
+  openMetadata(metadata: ProjectMetadata): void {
+    this.dialog.open(MetadataDialogComponent, {
+      width: 'min(calc(1400px - 4rem), calc(100vw - 1.5rem))',
+      data: metadata,
+    });
+  }
 }

--- a/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.html
@@ -1,0 +1,2 @@
+<biosimulations-project-metadata [project]="metadata">
+</biosimulations-project-metadata>

--- a/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.spec.ts
+++ b/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.spec.ts
@@ -1,0 +1,50 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MatDialogModule,
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MetadataDialogComponent } from './metadata-dialog.component';
+import { MetadataComponent } from '../metadata/metadata.component';
+import { SharedUiModule } from '@biosimulations/shared/ui';
+import { ScrollService } from '@biosimulations/shared/angular';
+import { RouterTestingModule } from '@angular/router/testing';
+
+describe('MetadataDialogComponent', () => {
+  let component: MetadataDialogComponent;
+  let fixture: ComponentFixture<MetadataDialogComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MatDialogModule,
+        SharedUiModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        { provide: MatDialogRef, useValue: {} },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            title: '',
+          },
+        },
+        ScrollService,
+      ],
+      declarations: [
+        MetadataDialogComponent,
+        MetadataComponent,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MetadataDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.ts
+++ b/libs/simulation-runs/ui/src/lib/metadata-dialog/metadata-dialog.component.ts
@@ -1,0 +1,15 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { FilesComponent } from '../files/files.component';
+import { ProjectMetadata } from '@biosimulations/datamodel-simulation-runs';
+
+@Component({
+  templateUrl: 'metadata-dialog.component.html',
+  styleUrls: ['./metadata-dialog.component.scss'],
+})
+export class MetadataDialogComponent {
+  constructor(
+    private dialogRef: MatDialogRef<FilesComponent>,
+    @Inject(MAT_DIALOG_DATA) public metadata: ProjectMetadata,
+  ) {}
+}

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -1,16 +1,17 @@
 <div
   class="metadata"
   fxLayout="row"
-  fxLayout.lt-md="column"
+  fxLayout.lt-lg="column"
   fxLayoutAlign="space-between"
   fxLayoutGap="2rem"
-  fxLayoutGap.lt-md="1rem"
+  fxLayoutGap.lt-lg="1rem"
 >
   <!-- Begin thumbnails -->
   <div
     *ngIf="project && project?.thumbnails?.length"
     class="thumbnails-column ragged-column"
-    fxFlex.lt-md="100%"
+    fxFlex="22rem"
+    fxFlex.lt-lg="100%"
   >
     <biosimulations-carousel [images]="project.thumbnails">
     </biosimulations-carousel>
@@ -56,16 +57,16 @@
   </div>
   <!-- End summary/text data-->
 
-  <!-- Simulation information -->
+  <!-- Biology, simulation, & provenance information -->
   <div
     *ngIf="
       project?.biology?.length ||
       simulationRun?.length ||
       project?.provenance?.length
     "
-    class="simulation-column ragged-column"
+    class="attributes-column ragged-column"
     fxFlex="22rem"
-    fxFlex.lt-md="100%"
+    fxFlex.lt-lg="100%"
   >
     <!-- project metadata -->
     <ng-container

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.html
@@ -32,7 +32,7 @@
       <!-- TODO create ORCID people list component -->
       <ul
         class="creators comma-separated ampersand-separator"
-        *ngIf="project.creators.length"
+        *ngIf="project?.creators?.length"
       >
         <li *ngFor="let creator of project.creators">
           {{ creator.label }}{{ creator.uri ? ' ' : ''
@@ -60,7 +60,7 @@
   <!-- Biology, simulation, & provenance information -->
   <div
     *ngIf="
-      project?.biology?.length ||
+      project?.modelSimulation?.length ||
       simulationRun?.length ||
       project?.provenance?.length
     "
@@ -72,7 +72,7 @@
     <ng-container
       *ngTemplateOutlet="
         sectionsTemplate;
-        context: { sections: project?.biology || [] }
+        context: { sections: project?.modelSimulation || [] }
       "
     ></ng-container>
 

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
@@ -91,12 +91,23 @@ biosimulations-carousel {
   }
 }
 
-.simulation-column {
+.attributes-column {
   margin-top: -1rem;
 
   ::ng-deep biosimulations-text-page-section {
     .container {
       margin-top: 1rem;
+    }
+  }
+
+  table.icon-list {
+    max-width: 100%;
+    th {
+      width: 14px;
+    }
+    td {
+      max-width: calc(100% - 14px - 0.125rem - 1px);
+      word-break: break-all;
     }
   }
 }

--- a/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
+++ b/libs/simulation-runs/ui/src/lib/simulation-runs-ui.module.ts
@@ -9,6 +9,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { BiosimulationsIconsModule } from '@biosimulations/shared/icons';
 import { MetadataComponent } from './metadata/metadata.component';
+import { MetadataDialogComponent } from './metadata-dialog/metadata-dialog.component';
 import { FilesComponent } from './files/files.component';
 import { SelectVisualizationComponent } from './select-viz/select-viz.component';
 import { DesignHistogram1DVisualizationComponent } from './design-histogram-1d-viz/design-histogram-1d-viz.component';
@@ -17,6 +18,7 @@ import { DesignLine2DVisualizationComponent } from './design-line-2d-viz/design-
 import { RenderVisualizationComponent } from './render-viz/render-viz.component';
 import { ApiClientModule } from '@biosimulations/angular-api-client';
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
+import { MatDialogModule } from '@angular/material/dialog';
 
 @NgModule({
   imports: [
@@ -39,9 +41,11 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
         },
       },
     }),
+    MatDialogModule,
   ],
   exports: [
     MetadataComponent,
+    MetadataDialogComponent,
     FilesComponent,
     SelectVisualizationComponent,
     DesignHistogram1DVisualizationComponent,
@@ -51,6 +55,7 @@ import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
   ],
   declarations: [
     MetadataComponent,
+    MetadataDialogComponent,
     FilesComponent,
     SelectVisualizationComponent,
     DesignHistogram1DVisualizationComponent,


### PR DESCRIPTION
- Metadata storage and display; closes #3962 
  - [x] Add a column to the files tab of project views with buttons to open modal windows with metadata about individual files
  - [x] Reuse the existing metadata component inside these modal windows
  - [x] Remove metadata about other files displayed in the current component
  - [x] Interleave files with metadata
- Expire old metadata cache
  - [x] Add versioning for cache content
- Other
  - [x] Clarify documentation of support for GFM
  - [x] Add caching for look up of lists of ontology terms
  - [x] Fix width of column of metadata attributes
  - [x] Fix word breaking of metadata attribute column
  - [x] Fix setting open control panel in table component 