### PR TITLE
refactor(dispatch-service): moved archive uploading to dispatch processor

### DIFF
--- a/apps/api/src/simulation-run/simulation-run.controller.ts
+++ b/apps/api/src/simulation-run/simulation-run.controller.ts
@@ -64,6 +64,7 @@ import { AuthToken } from '@biosimulations/auth/common';
 import { InjectQueue } from '@nestjs/bull';
 import { Queue } from 'bull';
 import { scopes } from '@biosimulations/auth/common';
+import { Readable } from 'stream';
 
 // hack to get typing to work see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/47780
 // eslint-disable-next-line unused-imports/no-unused-imports-ts
@@ -186,6 +187,9 @@ export class SimulationRunController {
     let run: SimulationRunModelReturnType;
     const user = req?.user as AuthToken;
     let projectId: string | undefined;
+    let archiveType: 'url' | 'file';
+    let urlOrFile: string | Buffer | Readable;
+    let fileSize: number | undefined;
 
     if (!contentType) {
       throw new UnsupportedMediaTypeException(
@@ -195,18 +199,23 @@ export class SimulationRunController {
       const parsedRun = this.getRunForFile(body);
       projectId = parsedRun?.projectId;
       this.checkPublishProjectPermission(user, projectId);
-      run = await this.service.createRunWithFile(
+      run = await this.service.createRun(
         parsedRun,
-        file.buffer,
-        file.size,
       );
+      archiveType = 'file';
+      urlOrFile = file.buffer;
+      fileSize = file.size;
     } else if (
       contentType?.startsWith('application/json') &&
       this.isUrlBody(body)
     ) {
       projectId = body?.projectId;
       this.checkPublishProjectPermission(user, projectId);
-      run = await this.service.createRunWithURL(body);
+      run = await this.service.createRun(body);
+      
+      archiveType = 'url';
+      urlOrFile = body.url;
+      fileSize = undefined;
     } else {
       throw new UnsupportedMediaTypeException(
         "The content type must be 'application/json' or 'multipart/form-data'.",
@@ -217,6 +226,9 @@ export class SimulationRunController {
     const message: DispatchJob = {
       runId: run.id,
       fileName: file?.originalname || 'input.omex',
+      archiveType: archiveType,
+      urlOrFile: urlOrFile,
+      fileSize: fileSize,
       simulator: run.simulator,
       version: run.simulatorVersion,
       cpus: run.cpus,

--- a/apps/api/src/simulation-run/simulation-run.model.ts
+++ b/apps/api/src/simulation-run/simulation-run.model.ts
@@ -37,10 +37,10 @@ export class SimulationRunModel extends Document implements SimulationRun {
 
   @Prop({
     type: String,
-    required: true,
+    required: false,
     validate: [isUrl],
   })
-  fileUrl!: string;
+  fileUrl?: string;
 
   @Prop({ type: String, required: true })
   name!: string;
@@ -68,14 +68,23 @@ export class SimulationRunModel extends Document implements SimulationRun {
   })
   statusReason: string | undefined;
 
-  @Prop()
-  runtime!: number;
+  @Prop({
+    type: Number,
+    required: false,
+  })
+  runtime?: number;
 
-  @Prop()
-  projectSize!: number;
+  @Prop({
+    type: Number,
+    required: false,
+  })
+  projectSize?: number;
 
-  @Prop()
-  resultsSize!: number;
+  @Prop({
+    type: Number,
+    required: false,
+  })
+  resultsSize?: number;
 
   @Prop({ type: String, required: true })
   simulator!: string;

--- a/apps/dispatch-service/src/app/submission/dispatch.processor.ts
+++ b/apps/dispatch-service/src/app/submission/dispatch.processor.ts
@@ -21,7 +21,7 @@ const ONE_GIGABYTE = 1000000000;
 
 @Processor(JobQueue.dispatch)
 export class DispatchProcessor {
-  private readonly logger = new Logger(DispatchProcessor.name);  
+  private readonly logger = new Logger(DispatchProcessor.name);
 
   public constructor(
     private httpService: HttpService,
@@ -137,7 +137,7 @@ export class DispatchProcessor {
     }
 
     // update the properties of the simulation run
-    this.logger.debug(`Updating the properties of simulation run '${data.runId}' ...`);    
+    this.logger.debug(`Updating the properties of simulation run '${data.runId}' ...`);
     const error = await this.simRunService.updateSimulationRunProject(data.runId, fileUrl, fileSize)
       .toPromise()
       .then(() => {
@@ -160,7 +160,7 @@ export class DispatchProcessor {
     }
 
     // submit job to HPC
-    this.logger.debug(`Submitting job for simulation run '${data.runId}' to HPC ...`);    
+    this.logger.debug(`Submitting job for simulation run '${data.runId}' to HPC ...`);
     const response = await this.hpcService.submitJob(
       data.runId,
       data.simulator,
@@ -190,7 +190,7 @@ export class DispatchProcessor {
     const slurmjobId = response.stdout.trim().split(' ').slice(-1)[0];
 
     // Initiate monitoring of the job
-    this.logger.debug(`Initiating monitoring for job '${slurmjobId}' for simulation run '${data.runId}' ...`);    
+    this.logger.debug(`Initiating monitoring for job '${slurmjobId}' for simulation run '${data.runId}' ...`);
 
     const monitorData: MonitorJob = {
       slurmJobId: slurmjobId.toString(),

--- a/apps/dispatch-service/src/app/submission/dispatch.processor.ts
+++ b/apps/dispatch-service/src/app/submission/dispatch.processor.ts
@@ -7,25 +7,160 @@ import {
 import { InjectQueue, Process, Processor } from '@nestjs/bull';
 import { Logger } from '@nestjs/common';
 import { Job, Queue } from 'bull';
-
+import { firstValueFrom } from 'rxjs';
 import { HpcService } from '../services/hpc/hpc.service';
 import { SimulationStatusService } from '../services/simulationStatus.service';
+import { HttpService } from '@nestjs/axios';
+import { AxiosError, AxiosResponse } from 'axios';
+import { Readable } from 'stream';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
+import { SimulationRunService } from '@biosimulations/api-nest-client';
+
+// 1 GB in bytes to be used as file size limits
+const ONE_GIGABYTE = 1000000000;
 
 @Processor(JobQueue.dispatch)
 export class DispatchProcessor {
-  private readonly logger = new Logger(DispatchProcessor.name);
+  private readonly logger = new Logger(DispatchProcessor.name);  
+
   public constructor(
+    private httpService: HttpService,
     private hpcService: HpcService,
     private simStatusService: SimulationStatusService,
-
+    private simRunService: SimulationRunService,
     @InjectQueue(JobQueue.monitor) private monitorQueue: Queue<MonitorJob>,
+    private simulationStorageService: SimulationStorageService,
   ) {}
+  
   @Process()
   private async handleSubmission(job: Job<DispatchJob>): Promise<void> {
     const data = job.data;
+    let file: Buffer | Readable;
+    let fileSize: number;
 
-    this.logger.debug(`Starting job for simulation run ${data.runId} ...`);
+    this.logger.debug(`Starting job for simulation run '${data.runId}' ...`);
 
+    // download archive if provided as URL
+    if (data.archiveType === 'url') {
+      this.logger.debug(`Downloading archive for simulation run '${data.runId}' ...`);
+      const url = data.urlOrFile as string;
+
+      let urlResponse: AxiosResponse<Readable> | null = null;
+      try {
+        urlResponse = await firstValueFrom(
+          this.httpService.get(url, {
+            responseType: 'stream',
+            maxContentLength: ONE_GIGABYTE,
+          }),
+        );
+      } catch (err) {
+        // if the error is bc file too bug, give this more specific error.
+        // Otherwiise, just let file be null, which will throw the more generic 400 below
+        if ((err as AxiosError).message.includes('maxContentLength')) {
+          const message = `Projects (COMBINE archives) are limited to 1 GB. The archive at ${url} is too large.`;
+          this.logger.error(message);
+          await this.simStatusService.updateStatus(
+            data.runId,
+            SimulationRunStatus.FAILED,
+            message,
+          );
+          return;
+        }
+      }
+
+      if (urlResponse) {
+        let size = 0;
+        const file_headers = urlResponse?.headers;
+        try {
+          size = Number(file_headers['content-length']);
+        } catch (err) {
+          size = 0;
+          this.logger.warn(err);
+        }
+        this.logger.error(urlResponse.data.isPaused());
+        file = urlResponse.data;
+        fileSize = size;
+      } else {
+        const message = `The project (COMBINE archive) could not be obtained from ${url}. Please check that the URL is accessible.`;
+        this.logger.error(message);
+        await this.simStatusService.updateStatus(
+          data.runId,
+          SimulationRunStatus.FAILED,
+          message,
+        );
+        return;
+      }
+    } else {
+      file = Buffer.from(data.urlOrFile as string);
+      fileSize = data.fileSize as number;
+    }
+
+    // save archive and individual files to S3 bucket
+    this.logger.debug(`Saving archive for simulation run '${data.runId}' to S3 bucket ...`);
+
+    let fileUrl: string;
+
+    try {
+      // upload archive
+      const s3file =
+        await this.simulationStorageService.uploadSimulationArchive(data.runId, file);
+      this.logger.debug(`Uploaded simulation archive to S3: ${s3file}`);
+      
+      // upload individual files
+      // - Could be merged with file post-processing
+      // - File size information could be collected here
+      // - Post-processing would just need to get the format of each file
+      const uploadedArchiveContents =
+        await this.simulationStorageService.extractSimulationArchive(data.runId);
+      
+      this.logger.debug(
+        `Uploaded archive contents: ${JSON.stringify(uploadedArchiveContents)}`,
+      );
+
+      fileUrl = encodeURI(s3file);
+    } catch (err: any) {
+      const details = `An error occurred in uploading the COMBINE archive for the simulation run: ${
+        err?.status || err?.statusCode
+      }: ${err?.message}.`;
+      this.logger.error(details);
+
+      const message = `An error occurred in uploading the COMBINE archive for the simulation run${
+        err instanceof Error && err.message ? ': ' + err?.message : ''
+      }.`;
+      this.logger.error(message);
+      await this.simStatusService.updateStatus(
+        data.runId,
+        SimulationRunStatus.FAILED,
+        message,
+      );
+      return;
+    }
+
+    // update the properties of the simulation run
+    this.logger.debug(`Updating the properties of simulation run '${data.runId}' ...`);    
+    const error = await this.simRunService.updateSimulationRunProject(data.runId, fileUrl, fileSize)
+      .toPromise()
+      .then(() => {
+        return undefined;
+      })
+      .catch((error: any) => {
+        return error;
+      });
+    if (error) {
+      const message = `An error occurred in updating the properties of the simulation run${
+        error instanceof Error && error.message ? ': ' + error?.message : ''
+      }.`;
+      this.logger.error(message);
+      await this.simStatusService.updateStatus(
+        data.runId,
+        SimulationRunStatus.FAILED,
+        message,
+      );
+      return;
+    }
+
+    // submit job to HPC
+    this.logger.debug(`Submitting job for simulation run '${data.runId}' to HPC ...`);    
     const response = await this.hpcService.submitJob(
       data.runId,
       data.simulator,
@@ -38,7 +173,7 @@ export class DispatchProcessor {
       data.fileName,
     );
 
-    if (response.stderr != '') {
+    if (response.stderr != '' || response.stdout === null) {
       // There was an error with submission of the job
       const message = `An error occurred in submitting an HPC job for simulation run '${data.runId}': ${response.stderr}`;
       this.logger.error(message);
@@ -47,20 +182,24 @@ export class DispatchProcessor {
         SimulationRunStatus.FAILED,
         message,
       );
-    } else if (response.stdout != null) {
-      // Get the Slurm id of the job
-      // Expected output of the response is " Submitted batch job <ID> /n"
-      const slurmjobId = response.stdout.trim().split(' ').slice(-1)[0];
-
-      const monitorData: MonitorJob = {
-        slurmJobId: slurmjobId.toString(),
-        runId: data.runId,
-        projectId: data.projectId,
-        projectOwner: data.projectOwner,
-        retryCount: 0,
-      };
-
-      this.monitorQueue.add(monitorData);
+      return;
     }
+
+    // Get the Slurm id of the job
+    // Expected output of the response is " Submitted batch job <ID> /n"
+    const slurmjobId = response.stdout.trim().split(' ').slice(-1)[0];
+
+    // Initiate monitoring of the job
+    this.logger.debug(`Initiating monitoring for job '${slurmjobId}' for simulation run '${data.runId}' ...`);    
+
+    const monitorData: MonitorJob = {
+      slurmJobId: slurmjobId.toString(),
+      runId: data.runId,
+      projectId: data.projectId,
+      projectOwner: data.projectOwner,
+      retryCount: 0,
+    };
+
+    this.monitorQueue.add(monitorData);
   }
 }

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -129,7 +129,7 @@ export class SimulationRunService {
         return this.http
           .patch<SimulationRun>(
             this.endpoints.getSimulationRunEndpoint(false, runId),
-            { 
+            {
               fileUrl: fileUrl,
               projectSize: projectSize,
             },

--- a/libs/api/nest-client/src/lib/simulation-run.service.ts
+++ b/libs/api/nest-client/src/lib/simulation-run.service.ts
@@ -119,6 +119,41 @@ export class SimulationRunService {
     return response;
   }
 
+  public updateSimulationRunProject(
+    runId: string,
+    fileUrl: string,
+    projectSize: number,
+  ): Observable<SimulationRun> {
+    return from(this.auth.getToken()).pipe(
+      map((token) => {
+        return this.http
+          .patch<SimulationRun>(
+            this.endpoints.getSimulationRunEndpoint(false, runId),
+            { 
+              fileUrl: fileUrl,
+              projectSize: projectSize,
+            },
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            },
+          )
+          .pipe(
+            catchError((error, caught) => {
+              this.logger.error(
+                `The S3 bucket URL and size of the COMBINE/OMEX arachive for simulation run '${runId}' could not be updated: ${error}`,
+              );
+              return caught;
+            }),
+            retry(5),
+            pluck('data'),
+          );
+      }),
+      mergeMap((value) => value),
+    );
+  }
+
   public updateSimulationRunResultsSize(
     runId: string,
     size: number,

--- a/libs/datamodel/api/src/lib/core/simulationRun.ts
+++ b/libs/datamodel/api/src/lib/core/simulationRun.ts
@@ -409,6 +409,31 @@ export class PatchSimulationRun {
 
   @ApiPropertyOptional({
     description:
+      'S3 bucket URL for the COMBINE/OMEX archive for the simulation run',
+    type: String,
+  })
+  @IsOptional()
+  @IsUrl({
+    require_protocol: true,
+    protocols: ['http', 'https'],
+  })
+  @IsNotEmpty()
+  @IsString()
+  fileUrl?: string;
+
+  @ApiPropertyOptional({
+    description:
+      'Size of the COMBINE/OMEX archive for the simulation run',
+    type: Number,
+    example: 11234,
+  })
+  @IsOptional()
+  @Min(0)
+  @IsInt()
+  projectSize?: number;
+
+  @ApiPropertyOptional({
+    description:
       'Size of the results (zip of reports and plots) for the simulation run',
     type: Number,
     example: 11234,

--- a/libs/messages/messages/src/lib/queues.ts
+++ b/libs/messages/messages/src/lib/queues.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-member-accessibility */
 
+import { Readable } from 'stream';
+
 import {
   EnvironmentVariable,
   Purpose,
@@ -27,6 +29,9 @@ export class DispatchJob {
   simulator!: string;
   version!: string;
   fileName!: string;
+  archiveType!: 'url' | 'file';
+  urlOrFile!: string | Buffer | Readable;
+  fileSize?: number;
   cpus!: number;
   memory!: number;
   maxTime!: number;

--- a/libs/shared/storage/src/lib/shared-storage.service.ts
+++ b/libs/shared/storage/src/lib/shared-storage.service.ts
@@ -11,7 +11,7 @@ import { promiseRetry } from './promise-retry/promise-retry';
 export class SharedStorageService {
   private BUCKET: string;
   private PUBLIC_ENDPOINT: string;
-  private S3_UPLOAD_TIMEOUT_TIME = 60000;
+  private S3_UPLOAD_TIMEOUT_TIME = 10 * 60 * 1000 // 10 minutes;
   private logger = new Logger(SharedStorageService.name);
   static RETRY_ERROR_CODES = [
     HttpStatus.REQUEST_TIMEOUT,
@@ -24,7 +24,7 @@ export class SharedStorageService {
     null,
   ];
   static NUM_RETRIES = 10;
-  static MIN_TIMEOUT = 100; // ms
+  static MIN_TIMEOUT = 100; // 100 ms
 
   public constructor(
     @InjectS3() private readonly s3: S3,


### PR DESCRIPTION
Addresses part of #3896

- [x] Move archive downloading and uploading from API to dispatch queue
   - [x] Pass URLs and file buffers to dispatch queue
   - [x] Move setting of fileUrl and size
- [x] Test
  - [x] URL
  - [x] File upload
- [x] Check that simulation run browse table is still receiving data as intended