### PR TITLE
refactor(dispatch-service): moved hsload to complete processor

### DIFF
--- a/apps/dispatch-service/src/app/app.module.ts
+++ b/apps/dispatch-service/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { MetadataService } from '../metadata/metadata.service';
 import { CombineWrapperService } from '../combineWrapper.service';
 import { FileService } from '../file/file.service';
 import { SedmlService } from '../sedml/sedml.service';
+import { SimulationResultsService } from '../simulation-results/simulation-results.service';
 import { ProjectService } from '@biosimulations/api-nest-client';
 import { Endpoints } from '@biosimulations/config/common';
 import { SharedStorageModule } from '@biosimulations/shared/storage';
@@ -100,6 +101,7 @@ import { SharedStorageModule } from '@biosimulations/shared/storage';
     CombineWrapperService,
     FileService,
     SedmlService,
+    SimulationResultsService,
     ProjectService,
   ],
 })

--- a/apps/dispatch-service/src/app/results/archiver.service.spec.ts
+++ b/apps/dispatch-service/src/app/results/archiver.service.spec.ts
@@ -2,35 +2,33 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ArchiverService } from './archiver.service';
 import { ConfigService } from '@nestjs/config';
 
-import { HttpService } from '@nestjs/axios';
 import { SimulationRunService } from '@biosimulations/api-nest-client';
-import { SshService } from '../services/ssh/ssh.service';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
 
 class MockSimulationService {
   updateSimulationRunResultsSize(id: string, size: number) {}
 }
 
-class MockSSHService {
-  updateSimulationRunResultsSize(id: string, size: number) {}
-}
 describe('ArchiverService', () => {
   let service: ArchiverService;
+
+  class mockStorage {
+    putObject() {}
+    getObject() {}
+    deleteObject() {}
+  }
 
   beforeEach(async () => {
     const mockHttp = {};
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ArchiverService,
-
-        {
-          provide: SshService,
-          useClass: MockSSHService,
-        },
-
         {
           provide: SimulationRunService,
           useClass: MockSimulationService,
         },
+        ConfigService,
+        { provide: SimulationStorageService, useClass: mockStorage },
       ],
     }).compile();
     service = module.get<ArchiverService>(ArchiverService);

--- a/apps/dispatch-service/src/app/results/archiver.service.ts
+++ b/apps/dispatch-service/src/app/results/archiver.service.ts
@@ -1,36 +1,55 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, InternalServerErrorException } from '@nestjs/common';
 
 import { SimulationRunService } from '@biosimulations/api-nest-client';
 import { catchError } from 'rxjs/operators';
-import { of } from 'rxjs';
 
-import { SshService } from '../services/ssh/ssh.service';
+import { SimulationStorageService } from '@biosimulations/shared/storage';
+import {
+  Endpoints,
+  FilePaths,
+} from '@biosimulations/config/common';
+import { ConfigService } from '@nestjs/config';
 
 @Injectable()
 export class ArchiverService {
   private logger = new Logger('ArchiverService');
+  private endpoints: Endpoints;
+  private filePaths: FilePaths;
 
   public constructor(
-    private sshService: SshService,
+    private configService: ConfigService,
     private service: SimulationRunService,
-  ) {}
-  // TODO include the output archive in the files endpoint and get size from there
+    private storage: SimulationStorageService,
+  ) {
+    const env = configService.get('server.env');
+    this.endpoints = new Endpoints(env);
+    this.filePaths = new FilePaths(env);
+  }
+
   public async updateResultsSize(id: string): Promise<void> {
-    const path = this.sshService.getSSHJobDirectory(id);
-    const archive = `${path}/${id}.zip`;
-    const command = `du -b ${archive} | cut -f1`;
-    this.sshService.execStringCommand(command).then((output) => {
-      this.service
-        .updateSimulationRunResultsSize(id, parseInt(output.stdout))
-        .pipe(
-          catchError((err, caught) => {
-            this.logger.error(
-              `The results size for simulation run '${id}' could not be updated: ${err}`,
-            );
-            return of(null);
-          }),
-        )
-        .subscribe();
-    });
+    this.logger.log(`Updating size of results for simulation run '${id}'.`);
+
+    const s3path = this.filePaths.getSimulationRunOutputArchivePath(id);
+    const properties = await this.storage.getFileProperties(s3path);
+    if (properties.ContentLength === undefined) {
+      const msg = `The results size for simulation run '${id}' could not be retrieved.`;
+      this.logger.error(msg);
+      throw new InternalServerErrorException(msg);
+    }
+
+    const runOrError = await this.service
+      .updateSimulationRunResultsSize(id, properties.ContentLength)
+      .pipe(
+        catchError((err, caught) => {
+          const msg = `The results size for simulation run '${id}' could not be updated: ${err}`;
+          this.logger.error(msg);
+          return msg;
+        }),
+      )
+      .toPromise();
+
+    if (typeof runOrError === 'string') {
+      throw new InternalServerErrorException(runOrError);
+    }
   }
 }

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -18,6 +18,7 @@ import { MetadataService } from '../../metadata/metadata.service';
 import { SimulationStatusService } from '../services/simulationStatus.service';
 import { FileService } from '../../file/file.service';
 import { SedmlService } from '../../sedml/sedml.service';
+import { SimulationResultsService } from '../../simulation-results/simulation-results.service';
 import { ProjectService } from '@biosimulations/api-nest-client';
 import { AxiosError } from 'axios';
 import { Observable } from 'rxjs';
@@ -38,6 +39,7 @@ export class CompleteProcessor {
     private metadataService: MetadataService,
     private fileService: FileService,
     private sedmlService: SedmlService,
+    private simulationResultsService: SimulationResultsService,
     private projectService: ProjectService,
   ) {}
 
@@ -83,6 +85,15 @@ export class CompleteProcessor {
         plural: true,
       },
       {
+        name: 'results of the simulation run',
+        result: this.simulationResultsService.processResults(runId),
+        required: true,
+        moreInfo:
+          'https://docs.biosimulations.org/concepts/conventions/simulation-run-reports/',
+        validator: undefined,
+        plural: true,
+      },
+      {
         name: 'log of the simulation run',
         result: this.logService.createLog(runId, false, '', false),
         required: true,
@@ -101,6 +112,8 @@ export class CompleteProcessor {
         plural: false,
       },
     ];
+
+    const iLogProcessingStep = 4;
 
     // Keep track of which processing step(s) failed
     const errors: string[] = [];
@@ -150,8 +163,8 @@ export class CompleteProcessor {
       ),
     );
 
-    const log = processingResults[3]?.value;
-    const logPostSucceeded = processingResults[3].succeeded;
+    const log = processingResults[iLogProcessingStep]?.value;
+    const logPostSucceeded = processingResults[iLogProcessingStep].succeeded;
     const runSuceededFromLog = this.getRunSuceededFromLog(log);
 
     /* calculate final status and reason */

--- a/apps/dispatch-service/src/file/file.service.ts
+++ b/apps/dispatch-service/src/file/file.service.ts
@@ -30,6 +30,7 @@ import { SimulationRunService } from '@biosimulations/api-nest-client';
 import sharp from 'sharp';
 import { SimulationStorageService } from '@biosimulations/shared/storage';
 import S3 from 'aws-sdk/clients/s3';
+import * as AWS from 'aws-sdk';
 
 interface ThumbnailSettledResult {
   thumbnail: string;
@@ -81,31 +82,39 @@ export class FileService {
                 file.location.path != '.',
             )
             .map((file: CombineArchiveManifestContent) => {
+              const fileS3Path =
+                this.filePaths.getSimulationRunContentFilePath(
+                  id,
+                  file.location.path,
+                );
               const fileUrl =
                 this.filePaths.getSimulationRunFileContentEndpoint(
                   false,
                   id,
                   file.location.path,
                 );
-              // This is a silly way to get the file size, but it works for now
-              const apiFile = this.httpService.head(fileUrl).pipe(
-                pluck('headers'),
-                pluck('content-length'),
-                map((size: string): ProjectFileInput => {
-                  const fileSize = parseInt(size) || 0;
-                  const fileObject: ProjectFileInput = {
+              const fileProperties: Promise<AWS.S3.HeadObjectOutput> = this.storage.getFileProperties(fileS3Path)
+                .catch((error: any) => {
+                  throw new InternalServerErrorException(`The size of '${file.location.path}' for simulation run '${id}' could not be retrieved: ${this.getErrorMessage(error)}`);
+                });
+              return from(fileProperties)
+                .pipe(
+                  map((properties: AWS.S3.HeadObjectOutput): ProjectFileInput => {
+                  if (properties.ContentLength === undefined) {
+                    throw new InternalServerErrorException(`The size of '${file.location.path}' for simulation run '${id}' could not be retrieved.`)
+                  }
+
+                  return {
                     id: id + '/' + file.location.path.replace('./', ''),
                     name: file.location.value.filename,
                     location: file.location.path.replace('./', ''),
-                    size: fileSize,
+                    size: properties.ContentLength,
                     format: file.format,
                     master: file.master,
                     url: fileUrl,
                   };
-                  return fileObject;
                 }),
               );
-              return apiFile;
             });
           // Array of observables to observable of array
           return combineLatest(apiFiles);
@@ -223,7 +232,7 @@ export class FileService {
         error?.response?.data?.detail || error?.response?.statusText
       }`;
     } else {
-      message = `${error?.status || error?.statusCode}: ${error?.message}`;
+      message = `${error?.status || error?.statusCode}: ${error?.message || error?.code}`;
     }
 
     return message.replace(/\n/g, '\n  ');

--- a/apps/dispatch-service/src/metadata/metadata.service.ts
+++ b/apps/dispatch-service/src/metadata/metadata.service.ts
@@ -33,7 +33,6 @@ export class MetadataService {
   }
 
   public async createMetadata(id: string): Promise<void> {
-    // get external endpoint since combine service my not be running locally
     const url = this.endpoints.getRunDownloadEndpoint(false, id);
     this.logger.debug(
       `Fetching metadata for archive for simulation run '${id}' at URL: ${url}`,

--- a/apps/dispatch-service/src/sedml/sedml.service.ts
+++ b/apps/dispatch-service/src/sedml/sedml.service.ts
@@ -33,7 +33,6 @@ export class SedmlService {
 
   public async processSedml(id: string): Promise<void> {
     this.logger.log(`Processing SED-ML documents for simulation run '${id}'.`);
-    // get external url since combine service may not be local
     const url = this.endpoints.getRunDownloadEndpoint(false, id);
     const req = this.combine.getSedMlSpecs(undefined, url);
     const sedml = req.pipe(

--- a/apps/dispatch-service/src/simulation-results/simulation-results.service.spec.ts
+++ b/apps/dispatch-service/src/simulation-results/simulation-results.service.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SimulationResultsService } from './simulation-results.service';
+import { ConfigService } from '@nestjs/config';
+
+import { SshService } from '../app/services/ssh/ssh.service';
+
+class MockSSHService {
+  updateSimulationRunResultsSize(id: string, size: number) {}
+}
+
+describe('SimulationResultsService', () => {
+  let service: SimulationResultsService;
+
+  beforeEach(async () => {
+    const mockHttp = {};
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SimulationResultsService,
+
+        {
+          provide: SshService,
+          useClass: MockSSHService,
+        },
+
+        ConfigService,
+      ],
+    }).compile();
+    service = module.get<SimulationResultsService>(SimulationResultsService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/apps/dispatch-service/src/simulation-results/simulation-results.service.ts
+++ b/apps/dispatch-service/src/simulation-results/simulation-results.service.ts
@@ -1,0 +1,58 @@
+import {
+  Endpoints,
+  FilePaths,
+} from '@biosimulations/config/common';
+import { DataPaths } from '@biosimulations/hsds/client';
+import {
+  Injectable,
+  Logger,
+} from '@nestjs/common';
+import { SshService } from '../app/services/ssh/ssh.service';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class SimulationResultsService {
+  private logger = new Logger(SimulationResultsService.name);
+  private endpoints: Endpoints;
+  private filePaths: FilePaths;
+  private dataPaths: DataPaths;
+
+  public constructor(
+    private configService: ConfigService,
+    private sshService: SshService,
+  ) {
+    const env = configService.get('server.env');
+    this.endpoints = new Endpoints(env);
+    this.filePaths = new FilePaths(env);
+    this.dataPaths = new DataPaths();
+  }
+
+  public async processResults(id: string): Promise<void> {
+    this.logger.log(`Processing results for simulation run '${id}'.`);
+
+    const simDirname = `${this.configService.get('hpc.hpcBaseDir')}/${id}`;
+    const outputsS3Subpath = this.filePaths.getSimulationRunOutputsPath(
+      id,
+      false,
+    );
+    const hsdsBasePath = this.configService.get('data.externalBasePath');
+    const hsdsUsername = this.configService.get('data.username');
+    const hsdsPassword = this.configService.get('data.password');
+    const simulationRunResultsHsdsPath =
+      this.dataPaths.getSimulationRunResultsPath(id);
+
+    const command = (
+      `hsload`
+      + ` --endpoint ${hsdsBasePath}`
+      + ` --username ${hsdsUsername}`
+      + ` --password ${hsdsPassword}`
+      + ` --verbose`
+      + ` ${simDirname}/${outputsS3Subpath}/reports.h5`
+      + ` '${simulationRunResultsHsdsPath}'`
+    );
+    console.log(command)
+    await this.sshService.execStringCommand(command);
+
+    return;
+  }
+}

--- a/libs/config/common/src/lib/file-paths.ts
+++ b/libs/config/common/src/lib/file-paths.ts
@@ -93,6 +93,11 @@ export class FilePaths {
     const dirPath = thumbnailType
       ? FilePaths.simulationRunThumbnailSubpath + '/' + thumbnailType
       : FilePaths.simulationRunContentsSubpath;
+
+    if (fileLocation?.startsWith('./')) {
+      fileLocation = fileLocation.substring(2);
+    }
+
     const filePath = fileLocation !== undefined ? `/${fileLocation}` : '';
     return this.getSimulationRunPath(runId, `${dirPath}${filePath}`);
   }

--- a/libs/shared/storage/src/lib/shared-storage.service.ts
+++ b/libs/shared/storage/src/lib/shared-storage.service.ts
@@ -51,10 +51,14 @@ export class SharedStorageService {
     }
   }
 
-  public async isObject(id: string): Promise<boolean> {
-    const call = this.retryS3<any>(async (): Promise<any> => {
+  public async headObject(id: string): Promise<AWS.S3.HeadObjectOutput> {
+    return await this.retryS3<any>(async (): Promise<any> => {
       return this.s3.headObject({ Bucket: this.BUCKET, Key: id }).promise();
     });
+  }
+
+  public async isObject(id: string): Promise<boolean> {
+    const call = this.headObject(id);
 
     try {
       await call;

--- a/libs/shared/storage/src/lib/simulation-storage.service.ts
+++ b/libs/shared/storage/src/lib/simulation-storage.service.ts
@@ -208,4 +208,10 @@ export class SimulationStorageService {
         });
     }
   }
+
+  public async getFileProperties(
+    s3path: string,
+  ): Promise<AWS.S3.HeadObjectOutput> {
+    return await this.storage.headObject(s3path);
+  }
 }


### PR DESCRIPTION
Enables more control over our load on the HSDS. In principle, the previous design seems better. However, we seem to be having trouble getting the HSDS to accept all results. It seems we have two options: (a) use more resources so HSDS doesn't in the infrequent cases that we try to send multiple results sets in quick succession, (b) refactor the results uploading in a way that permits more control over the load on the HSDS.

Also 
- Refactored ArchiverService and FileService to get file sizes from S3 API rather than SSH and HTTP HEAD operations.
- Corrected S3 path calculation for when locations start with `./`