### PR TITLE
fix(api): prevent process crash for missing results and improve error…

### DIFF
--- a/apps/api/src/results/datamodel.ts
+++ b/apps/api/src/results/datamodel.ts
@@ -19,6 +19,17 @@ export class Output {
   public updated!: string;
 }
 
+export class OutputParsingError {
+  public simId!: string;
+  public outputId!: string;
+  public type?: string;
+  public name?: string;
+  public errorSummary!: string;
+}
+export const isOutputParsingError = (obj: any): obj is OutputParsingError => {
+  return obj.errorSummary !== undefined;
+};
+
 export class Results {
   public simId!: string;
   public outputs!: Output[];

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -49,7 +49,6 @@ import {
   DispatchProcessedPayload,
 } from '@biosimulations/messages/messages';
 import { ClientProxy } from '@nestjs/microservices';
-import { BiosimulationsException } from '@biosimulations/shared/exceptions';
 import { firstValueFrom, Observable, of, map } from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Endpoints, AppRoutes } from '@biosimulations/config/common';


### PR DESCRIPTION
… handling

when a not found simulation run resutls were queried multiple promises were created.
However, only was was awaited. Additional error handling then threw and error, leaving the first promise to eventually error out after the end of the call.
In later versions of node, this crashes the process.

Also added improved error handling by adding typing to internal throws. Return error objects rather than throw and catch errors

closes #4007