### PR TITLE
perf(dispatch-service): maintain persistent ssh connections

### DIFF
--- a/apps/dispatch-service/src/app/results/archiver.service.ts
+++ b/apps/dispatch-service/src/app/results/archiver.service.ts
@@ -19,7 +19,8 @@ export class ArchiverService {
     const path = this.sshService.getSSHJobDirectory(id);
     const archive = `${path}/${id}.zip`;
     const command = `du -b ${archive} | cut -f1`;
-    this.sshService.execStringCommand(command).then((output) => {
+    // Need to await otherwise unhandled promise rejection
+    await this.sshService.execStringCommand(command).then((output) => {
       this.service
         .updateSimulationRunResultsSize(id, parseInt(output.stdout))
         .pipe(

--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.spec.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.spec.ts
@@ -14,7 +14,7 @@ describe('HpcService', () => {
       imports: [SharedNatsClientModule],
       providers: [
         HpcService,
-        SshService,
+        { provide: SshService, useValue: {} },
         ConfigService,
         SbatchService,
         { provide: FilePaths, useValue: {} },

--- a/apps/dispatch-service/src/app/services/ssh/ssh.service.spec.ts
+++ b/apps/dispatch-service/src/app/services/ssh/ssh.service.spec.ts
@@ -2,12 +2,22 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { SshService } from './ssh.service';
 import { ConfigService } from '@nestjs/config';
 
+class mockConfigService {
+  get(key: string, defaultValue = undefined) {
+    if (key == 'hpc.sshInit') {
+      return 'false';
+    }
+  }
+}
 describe('SshService', () => {
   let service: SshService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SshService, ConfigService],
+      providers: [
+        SshService,
+        { provide: ConfigService, useClass: mockConfigService },
+      ],
     }).compile();
 
     service = module.get<SshService>(SshService);

--- a/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
+++ b/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
@@ -12,21 +12,24 @@ export class SshConnectionConfig {
   ) {}
 }
 
-@Injectable()
+@Injectable({})
 export class SshService {
+  private connection!: SSHClient;
   private sshConfig: SshConnectionConfig =
     this.configService.get<SshConnectionConfig>(
       'hpc.ssh',
       new SshConnectionConfig('', 0, '', ''),
     );
 
+  private retry = 1;
   private logger = new Logger('SshService');
-
   private hpcBase: string = this.configService.get<string>(
     'hpc.hpcBaseDir',
     '',
   );
-  constructor(private configService: ConfigService) {}
+  public constructor(private configService: ConfigService) {
+    this.connection = this.initConnection();
+  }
 
   public getSSHJobDirectory(id: string): string {
     return path.join(this.hpcBase, id);
@@ -35,46 +38,98 @@ export class SshService {
   public getSSHJobOutputsDirectory(id: string): string {
     return path.join(this.hpcBase, id, 'outputs');
   }
-
   public execStringCommand(
     cmd: string,
   ): Promise<{ stdout: string; stderr: string }> {
+    this.logger.debug(`Executing command`);
+
     return new Promise<{ stdout: string; stderr: string }>(
       (resolve, reject) => {
-        const conn = new SSHClient();
-        conn
-          .on('ready', () => {
-            this.logger.debug('Connection ready');
-            let stdout = '';
-            let stderr = '';
-            conn.exec(cmd, (err, stream) => {
-              if (err) {
-                this.logger.error(err);
-                reject(err);
-              }
-              stream
-                .on('close', (code: any, signal: any) => {
-                  this.logger.debug(
-                    'Stream :: close :: code: ' + code + ', signal: ' + signal,
-                  );
-                  resolve({ stdout, stderr });
-                  conn.end();
-                  this.logger.debug('Connection closed');
-                })
-                .on('data', (data: any) => {
-                  stdout += data.toString('utf8');
-                })
-                .stderr.on('data', (data) => {
-                  stderr += data.toString('utf8');
-                });
-            });
-          })
-          .on('error', (err) => {
+        let stdout = '';
+        let stderr = '';
+
+        this.connection.exec(cmd, (err, stream) => {
+          if (err) {
             this.logger.error(err);
             reject(err);
-          })
-          .connect(this.sshConfig);
+            this.connection.end();
+          }
+          if (stream) {
+            stream
+
+              .on('close', (code: any, signal: any) => {
+                this.logger.debug(
+                  'Stream :: close :: code: ' + code + ', signal: ' + signal,
+                );
+                resolve({ stdout, stderr });
+              })
+              .on('data', (data: any) => {
+                stdout += data.toString('utf8');
+              })
+              .stderr.on('data', (data) => {
+                stderr += data.toString('utf8');
+              });
+          } else {
+            this.logger.error('Stream is null');
+            reject('Stream is null');
+          }
+        });
       },
     );
+  }
+
+  private initConnection(): SSHClient {
+    const config = this.sshConfig;
+    this.logger.debug('Initializing connection');
+
+    const connection = new SSHClient();
+    this.addConnectionListeners(connection);
+    return connection.connect(config);
+  }
+
+  private retryInit(): void {
+    this.logger.log('Retrying SSH connection');
+    setTimeout(
+      () => (this.connection = this.initConnection()),
+      this.getRetryBackoff(),
+    );
+  }
+  private addConnectionListeners(connection: SSHClient): SSHClient {
+    return connection
+      .on('ready', () => {
+        this.retry = 1;
+        this.logger.debug('Connection ready');
+      })
+
+      .on('timeout', (message: string) => {
+        this.logger.error(`Connection timeout: ${message}`);
+      })
+
+      .on('error', (err) => {
+        this.logger.error('Connection Error: ' + err);
+
+        connection.removeAllListeners();
+        this.retryInit();
+      })
+
+      .on('end', () => {
+        this.logger.error('Connection end');
+        connection.removeAllListeners();
+        this.retryInit();
+      })
+
+      .on('close', () => {
+        this.logger.log('Connection closed');
+        connection.removeAllListeners();
+        connection = this.initConnection();
+      });
+  }
+
+  private getRetryBackoff(): number {
+    const MAX_RETRY_BACKOFF = 60 * 1000;
+    if (this.retry < MAX_RETRY_BACKOFF) {
+      this.retry = this.retry * 2;
+    }
+    return this.retry;
   }
 }

--- a/apps/dispatch-service/src/sedml/sedml.service.ts
+++ b/apps/dispatch-service/src/sedml/sedml.service.ts
@@ -33,7 +33,7 @@ export class SedmlService {
 
   public async processSedml(id: string): Promise<void> {
     this.logger.log(`Processing SED-ML documents for simulation run '${id}'.`);
-    const url = this.endpoints.getRunDownloadEndpoint(false, id);
+    const url = this.endpoints.getRunDownloadEndpoint(true, id);
     const req = this.combine.getSedMlSpecs(undefined, url);
     const sedml = req.pipe(
       pluck('data'),

--- a/libs/config/nest/src/lib/biosimulations-hpc-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-hpc-config.ts
@@ -10,6 +10,7 @@ export default registerAs('hpc', () => {
       username: process.env.HPC_SSH_USERNAME,
       privateKey: process.env.HPC_SSH_PRIVATE_KEY,
     },
+    sshInit: process.env.HPC_SSH_INIT, // set to false to disable ssh init when testing
     hpcBaseDir: process.env.HPC_BASE_DIR,
     homeDir: process.env.HPC_HOME_DIR,
     executablesPath: process.env.HPC_EXECUTABLES_PATH,


### PR DESCRIPTION
refactored the ssh service to maintain a persistent ssh connection rather than create and close the connection for each command
also added event listners to maintain the connection and reconnect if there is an error
this should speed up the commands as well as reduce errors due to too many connections.