### PR TITLE
perf(api): switched to streaming downloaded files to storage bucket

### DIFF
--- a/apps/combine-api/src/s3.py
+++ b/apps/combine-api/src/s3.py
@@ -139,14 +139,9 @@ class S3Bucket(object):
         Args:
             key (:obj:`str`): key for the file to delete
         """
-        self.bucket.delete_objects(
-            Delete={
-                'Objects': [
-                    {
-                        'Key': key,
-                    },
-                ],
-            }
+        self.client.delete_object(
+            Bucket=self.bucket_name,
+            Key=key,
         )
 
     def delete_files_with_prefix(self, prefix: str, max_last_modified: datetime.datetime = None) -> None:
@@ -159,7 +154,8 @@ class S3Bucket(object):
         while True:
             keys = list(self.list_files(prefix, max_last_modified=max_last_modified, max_files=1000))
             if keys:
-                self.bucket.delete_objects(
+                self.client.delete_objects(
+                    Bucket=self.bucket_name,
                     Delete={
                         'Objects': [{'Key': key} for key in keys]
                     }

--- a/apps/combine-api/tests/test_s3.py
+++ b/apps/combine-api/tests/test_s3.py
@@ -169,9 +169,9 @@ class S3TestCase(unittest.TestCase):
     def test_delete_file(self):
         bucket = s3.S3Bucket(config_filename=self.config_filename, secret_filename=self.secret_filename)
 
-        def delete_objects(Delete=None):
+        def delete_object(Bucket=None, Key=None):
             return None
-        bucket.bucket = mock.Mock(delete_objects=delete_objects)
+        bucket.client = mock.Mock(delete_object=delete_object)
         bucket.delete_file('key')
 
     def test_delete_files_with_prefix(self):
@@ -208,11 +208,10 @@ class S3TestCase(unittest.TestCase):
                     'NextMarker': None,
                     'IsTruncated': False,
                 }
-        bucket.client = mock.Mock(list_objects=list_objects)
 
-        def delete_objects(Delete=None):
+        def delete_objects(Bucket=None, Delete=None):
             return None
 
-        bucket.bucket = mock.Mock(delete_objects=delete_objects)
+        bucket.client = mock.Mock(list_objects=list_objects, delete_objects=delete_objects)
 
         bucket.delete_files_with_prefix('key')


### PR DESCRIPTION
Tried to explore #4078, but haven't figured it out.

- Switched to streaming files downloaded from URLs to the storage bucket. Follows https://dev.to/vikasgarghb/streaming-files-to-s3-using-axios-h32.
- Improved error messages and comments
- Updated object deletion in `apps/combine-api/src/s3.py` to work with Google object storage.