### PR TITLE
feat(api): standardized titles of error messages

### DIFF
--- a/apps/api/src/simulation-run/simulation-run-validation.service.ts
+++ b/apps/api/src/simulation-run/simulation-run-validation.service.ts
@@ -122,7 +122,7 @@ export class SimulationRunValidationService {
     } catch {
       throw new BiosimulationsException(
         HttpStatus.BAD_REQUEST,
-        'Simulation run is not valid for publication.',
+        'Simulation run is not valid for publication',
         `'${id}' is not a valid id for a simulation run. Only successful simulation runs can be published.`,
       );
     }
@@ -130,7 +130,7 @@ export class SimulationRunValidationService {
     if (!run) {
       throw new BiosimulationsException(
         HttpStatus.BAD_REQUEST,
-        'Simulation run is not valid for publication.',
+        'Simulation run is not valid for publication',
         `A simulation run with id '${id}' could not be found. Only successful simulation runs can be published.`,
       );
     }
@@ -182,7 +182,7 @@ export class SimulationRunValidationService {
     if (errorDetails.length) {
       throw new BiosimulationsException(
         HttpStatus.BAD_REQUEST,
-        'Simulation run is not valid for publication.',
+        'Simulation run is not valid for publication',
         errorSummaries.join('\n\n'),
       );
     }
@@ -452,7 +452,7 @@ export class SimulationRunValidationService {
       );
       throw new BiosimulationsException(
         HttpStatus.BAD_REQUEST,
-        'Simulation run is not valid for publication.',
+        'Simulation run is not valid for publication',
         errorSummaries.join('\n\n'),
       );
     }

--- a/apps/api/src/simulation-run/simulation-run.service.ts
+++ b/apps/api/src/simulation-run/simulation-run.service.ts
@@ -176,8 +176,8 @@ export class SimulationRunService {
       }.`;
       throw new BiosimulationsException(
         HttpStatus.INTERNAL_SERVER_ERROR,
+        'Simulation run could not be created',
         message,
-        undefined,
         undefined,
         undefined,
         undefined,

--- a/libs/shared/exceptions/exceptions/src/lib/exception.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/exception.ts
@@ -4,6 +4,7 @@ import {
   ErrorSourceObject,
 } from '@biosimulations/datamodel/api';
 import { HttpException } from '@nestjs/common';
+import { StatusCodes, ReasonPhrases } from 'http-status-codes';
 
 // TODO refactor to be able to hold multiple errors
 export class BiosimulationsException extends Error {
@@ -25,12 +26,19 @@ export class BiosimulationsException extends Error {
   }
 
   createError(): ErrorObject {
+    const statusCode = StatusCodes?.[this.status] as ((keyof typeof ReasonPhrases) | undefined);
+    const title = statusCode === undefined
+      ? this.title
+      : ReasonPhrases?.[statusCode] || this.title;
+
     const error: ErrorObject = {
       status: this.status.toString(),
-      title: this.title,
+      title: title,
     };
     if (this.detail) {
-      error.detail = this.detail;
+      error.detail = `${this.title}: ${this.detail}`;
+    } else {
+      error.detail = this.title
     }
     if (this.code) {
       error.code = this.code;

--- a/libs/shared/exceptions/exceptions/src/lib/exception.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/exception.ts
@@ -35,20 +35,24 @@ export class BiosimulationsException extends Error {
       status: this.status.toString(),
       title: title,
     };
+
     if (this.detail) {
       error.detail = `${this.title}: ${this.detail}`;
     } else {
       error.detail = this.title
     }
+
     if (this.code) {
       error.code = this.code;
     }
+
     if (this.link) {
       const linkObject: AboutLinksObject = {
         about: this.link,
       };
       error.links = linkObject;
     }
+
     if (this.sourceParameter || this.sourcePointer) {
       const source: ErrorSourceObject = {};
       if (this.sourcePointer) {
@@ -59,14 +63,17 @@ export class BiosimulationsException extends Error {
       }
       error.source = source;
     }
+
     if (this.meta) {
       error.meta = this.meta;
     }
     return error;
   }
+
   getStatus(): number {
     return this.status;
   }
+
   getError(): ErrorObject {
     return this.errorObject;
   }
@@ -88,6 +95,7 @@ export class BiosimulationsException extends Error {
     }
   }
 }
+
 export function isBiosimulationsException(
   exception: BiosimulationsException | HttpException,
 ): exception is BiosimulationsException {

--- a/libs/shared/exceptions/exceptions/src/lib/exception.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/exception.ts
@@ -77,23 +77,6 @@ export class BiosimulationsException extends Error {
   getError(): ErrorObject {
     return this.errorObject;
   }
-
-  // TODO write test
-  static fromHTTP(exception: HttpException): BiosimulationsException {
-    const response = exception.getResponse() as any;
-    if (response && typeof response == 'object') {
-      return new BiosimulationsException(
-        exception.getStatus(),
-        response.error,
-        response.message,
-      );
-    } else {
-      return new BiosimulationsException(
-        exception.getStatus(),
-        exception.message,
-      );
-    }
-  }
 }
 
 export function isBiosimulationsException(

--- a/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
+++ b/libs/shared/exceptions/exceptions/src/lib/validationExceptionFactory.ts
@@ -9,7 +9,7 @@ export const BiosimulationsValidationExceptionFactory = (
 
   const bioSimErr = new BiosimulationsException(
     HttpStatus.BAD_REQUEST,
-    'Validation Error',
+    'Object is invalid',
     message,
     undefined,
     undefined,

--- a/libs/shared/exceptions/filters/src/lib/utils.ts
+++ b/libs/shared/exceptions/filters/src/lib/utils.ts
@@ -1,5 +1,6 @@
 import { ErrorObject } from '@biosimulations/datamodel/api';
 import { HttpException, HttpStatus } from '@nestjs/common';
+import { StatusCodes, ReasonPhrases } from 'http-status-codes';
 
 export const makeErrorObject = (
   status: HttpStatus,
@@ -42,5 +43,12 @@ export const makeErrorObjectFromHttp = (exception: HttpException) => {
       resp = (resp as any)?.error as string;
     }
   }
-  return makeErrorObject(exception.getStatus(), exception.message, resp);
+
+  const status: number = exception.getStatus();
+  const code = StatusCodes?.[status] as ((keyof typeof ReasonPhrases) | undefined);
+  const title = code === undefined
+    ? exception.message
+    : ReasonPhrases?.[code] || exception.message;
+
+  return makeErrorObject(status, title, resp);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@sendgrid/mail": "7.6.0",
         "@stoplight/json-ref-resolver": "3.1.3",
         "@types/err-code": "3.0.0",
+        "@types/http-status-codes": "^1.2.0",
         "@types/retry": "0.12.1",
         "@types/sharp": "0.29.5",
         "archiver": "5.3.0",
@@ -46,6 +47,7 @@
         "err-code": "3.0.1",
         "form-data": "4.0.0",
         "hammerjs": "2.0.8",
+        "http-status-codes": "^2.2.0",
         "husky": "7.0.4",
         "is-url": "1.2.4",
         "json5": "2.2.0",
@@ -15701,6 +15703,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-status-codes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-status-codes/-/http-status-codes-1.2.0.tgz",
+      "integrity": "sha512-vjpjevMaxtrtdrrV/TQNIFT7mKL8nvIKG7G/LjMDZdVvqRxRg5SNfGkeuSaowVc0rbK8xDA2d/Etunyb5GyzzA==",
+      "deprecated": "This is a stub types definition for http-status-codes (https://github.com/prettymuchbryce/node-http-status). http-status-codes provides its own type definitions, so you don\\'t need @types/http-status-codes installed!",
+      "dependencies": {
+        "http-status-codes": "*"
+      }
+    },
     "node_modules/@types/ioredis": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.2.tgz",
@@ -24896,6 +24907,11 @@
       "engines": {
         "node": ">=0.10"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.0",
@@ -39754,6 +39770,12 @@
         "vega-lite": "*"
       }
     },
+    "node_modules/vega-embed/node_modules/yallist": {
+      "version": "4.0.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/vega-encode": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.8.3.tgz",
@@ -50636,6 +50658,14 @@
         "@types/node": "*"
       }
     },
+    "@types/http-status-codes": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-status-codes/-/http-status-codes-1.2.0.tgz",
+      "integrity": "sha512-vjpjevMaxtrtdrrV/TQNIFT7mKL8nvIKG7G/LjMDZdVvqRxRg5SNfGkeuSaowVc0rbK8xDA2d/Etunyb5GyzzA==",
+      "requires": {
+        "http-status-codes": "*"
+      }
+    },
     "@types/ioredis": {
       "version": "4.28.2",
       "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.2.tgz",
@@ -57971,6 +58001,11 @@
         "jsprim": "^2.0.2",
         "sshpk": "^1.14.1"
       }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "https-proxy-agent": {
       "version": "5.0.0",
@@ -69185,6 +69220,13 @@
         "vega-schema-url-parser": "^2.2.0",
         "vega-themes": "^2.10.0",
         "vega-tooltip": "^0.27.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "bundled": true,
+          "extraneous": true
+        }
       }
     },
     "vega-encode": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@sendgrid/mail": "7.6.0",
     "@stoplight/json-ref-resolver": "3.1.3",
     "@types/err-code": "3.0.0",
+    "@types/http-status-codes": "^1.2.0",
     "@types/retry": "0.12.1",
     "@types/sharp": "0.29.5",
     "archiver": "5.3.0",
@@ -77,6 +78,7 @@
     "err-code": "3.0.1",
     "form-data": "4.0.0",
     "hammerjs": "2.0.8",
+    "http-status-codes": "^2.2.0",
     "husky": "7.0.4",
     "is-url": "1.2.4",
     "json5": "2.2.0",
@@ -232,4 +234,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Closes #4017 

Standardized titles using the `http-status-codes` package.

@bilalshaikh42 the function below seems to be unused. Please confirm this can be deleted.
