### PR TITLE
fix(dispatch-service): bind the /tmp directory to /local on HPC

### DIFF
--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -48,7 +48,6 @@ export class SbatchService {
     purpose: Purpose,
     workDirname: string,
   ): string {
-    // TODO remove the input to function for this
     const combineArchiveFilename = 'input.omex';
     const executablesPath = this.configService.get('hpc.executablesPath');
 
@@ -212,6 +211,7 @@ srun --job-name="Execute-project" \
   singularity run \
     --tmpdir /local \
     --bind ${workDirname}:/root \
+    --bind /local:/tmp \
     "${allEnvVarsString}" \
     ${simulatorImage} \
       -i '/root/${combineArchiveFilename}' \


### PR DESCRIPTION
the /tmp directory on the HPC can sometimes run out of space causing errors for some simulators.
This commit binds the /tmp directory on the singularity container to /local which is configured on
the HPC to work as a fast tmp directory.

closes #4135