### PR TITLE
fix: fix height for consent screen on mobile

### DIFF
--- a/libs/analytics/angular-analytics/src/lib/consent.service.ts
+++ b/libs/analytics/angular-analytics/src/lib/consent.service.ts
@@ -49,6 +49,7 @@ export class ConsentService {
       this.dialog.open(CookieConsentComponent, {
         hasBackdrop: true,
         maxWidth: 'min(900px, calc(100vw - 1.5rem))',
+        maxHeight: 'min(900px, calc(100vh - 2rem))',
         disableClose: true,
         closeOnNavigation: false,
       });


### PR DESCRIPTION
the consent popup now has a max-height that depends on the screen height

closes #4143