### PR TITLE
style(dispatch): fix simple lint warnings in dispatch

### DIFF
--- a/apps/dispatch/src/app/app.component.ts
+++ b/apps/dispatch/src/app/app.component.ts
@@ -11,22 +11,22 @@ import { Observable } from 'rxjs';
   styleUrls: ['./app.component.scss'],
 })
 export class AppComponent implements OnInit, AfterViewInit {
-  title = 'dispatch';
+  public title = 'dispatch';
 
-  healthy$!: Observable<boolean>;
+  public healthy$!: Observable<boolean>;
 
-  constructor(
+  public constructor(
     public config: ConfigService,
     private scrollService: ScrollService,
     private updateService: UpdateService,
     private healthService: HealthService,
   ) {}
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.healthy$ = this.healthService.isHealthy();
   }
 
-  ngAfterViewInit(): void {
+  public ngAfterViewInit(): void {
     this.scrollService.init();
   }
 }

--- a/apps/dispatch/src/app/components/home/home.component.ts
+++ b/apps/dispatch/src/app/components/home/home.component.ts
@@ -7,5 +7,5 @@ import { ConfigService } from '@biosimulations/config/angular';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent {
-  constructor(public config: ConfigService) {}
+  public constructor(public config: ConfigService) {}
 }

--- a/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
+++ b/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
@@ -83,13 +83,13 @@ type AlgorithmsMap = { [id: string]: Algorithm };
 })
 export class DispatchComponent implements OnInit, OnDestroy {
   private submitMethod: SubmitMethod = SubmitMethod.file;
-  formGroup: FormGroup;
+  public formGroup: FormGroup;
   private submitMethodControl: FormControl;
-  projectFileControl: FormControl;
-  projectUrlControl: FormControl;
-  modelFormatsControl: FormControl;
-  simulationAlgorithmsControl: FormControl;
-  simulationAlgorithmSubstitutionPolicyControl: FormControl;
+  public projectFileControl: FormControl;
+  public projectUrlControl: FormControl;
+  public modelFormatsControl: FormControl;
+  public simulationAlgorithmsControl: FormControl;
+  public simulationAlgorithmSubstitutionPolicyControl: FormControl;
   private simulatorControl: FormControl;
   private simulatorVersionControl: FormControl;
   private cpusControl: FormControl;
@@ -99,15 +99,15 @@ export class DispatchComponent implements OnInit, OnDestroy {
   private emailControl: FormControl;
   private emailConsentControl: FormControl;
 
-  exampleCombineArchiveUrl: string;
-  exampleCombineArchivesUrl: string;
+  public exampleCombineArchiveUrl: string;
+  public exampleCombineArchivesUrl: string;
 
   private modelFormatsMap?: OntologyTermsMap;
   private simulationAlgorithmsMap?: AlgorithmsMap;
 
-  modelFormats?: OntologyTerm[];
-  simulationAlgorithms?: Algorithm[];
-  ALGORITHM_SUBSTITUTION_POLICIES = ALGORITHM_SUBSTITUTION_POLICIES.filter(
+  public modelFormats?: OntologyTerm[];
+  public simulationAlgorithms?: Algorithm[];
+  public ALGORITHM_SUBSTITUTION_POLICIES = ALGORITHM_SUBSTITUTION_POLICIES.filter(
     (policy: AlgorithmSubstitutionPolicy): boolean => {
       return (
         policy.level >= AlgorithmSubstitutionPolicyLevels.SAME_METHOD &&
@@ -117,17 +117,17 @@ export class DispatchComponent implements OnInit, OnDestroy {
   );
 
   private simulatorIds = new Set<string>();
-  simulators: SimulatorIdNameDisabled[] = [];
-  simulatorVersions: string[] = [];
+  public simulators: SimulatorIdNameDisabled[] = [];
+  public simulatorVersions: string[] = [];
   private simulatorSpecsMap: SimulatorSpecsMap | undefined = undefined;
 
-  emailUrl!: string;
+  public emailUrl!: string;
 
-  submitPushed = false;
+  public submitPushed = false;
 
   private subscriptions: Subscription[] = [];
 
-  constructor(
+  public constructor(
     private config: ConfigService,
     private route: ActivatedRoute,
     private router: Router,
@@ -235,7 +235,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     this.emailUrl = 'mailto:' + config.email;
   }
 
-  maxFileSizeValidator(control: FormControl): ValidationErrors | null {
+  public maxFileSizeValidator(control: FormControl): ValidationErrors | null {
     if (
       control.value &&
       control.value.size > this.config.appConfig.maxUploadFileSize
@@ -248,7 +248,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  integerValidator(formControl: FormControl): ValidationErrors | null {
+  public integerValidator(formControl: FormControl): ValidationErrors | null {
     const value = formControl.value as number;
 
     if (value == Math.floor(value)) {
@@ -258,7 +258,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  formValidator(formGroup: FormGroup): ValidationErrors | null {
+  public formValidator(formGroup: FormGroup): ValidationErrors | null {
     const errors: ValidationErrors = {};
 
     if (formGroup.value.submitMethod == SubmitMethod.file) {
@@ -285,7 +285,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     const simulatorsDataObs = this.commonDispatchService.getSimulatorsFromDb();
 
     const algSubObs = simulatorsDataObs.pipe(
@@ -541,7 +541,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
   }
 
-  makeArray(value: string | string[] | null): string[] {
+  public makeArray(value: string | string[] | null): string[] {
     if (!value) {
       return [];
     } else if (typeof value === 'string') {
@@ -551,7 +551,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  changeSubmitMethod(): void {
+  public changeSubmitMethod(): void {
     const submitMethodControl = this.formGroup.controls
       .submitMethod as FormControl;
     if (submitMethodControl.value === SubmitMethod.file) {
@@ -563,7 +563,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  changeProject(): void {
+  public changeProject(): void {
     const submitMethodControl = this.formGroup.controls
       .submitMethod as FormControl;
 
@@ -663,7 +663,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     }
   }
 
-  filterSimulators(): void {
+  public filterSimulators(): void {
     const modelFormatIds = this.formGroup.value.modelFormats;
     const simulationAlgorithmIds = this.formGroup.value.simulationAlgorithms;
     const algSubPolicy: number =
@@ -739,7 +739,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     return _intersection;
   }
 
-  onFormSubmit(): void {
+  public onFormSubmit(): void {
     this.submitPushed = true;
 
     if (!this.formGroup.valid) {
@@ -859,7 +859,7 @@ export class DispatchComponent implements OnInit, OnDestroy {
     );
   }
 
-  changeSimulator() {
+  public changeSimulator(): void {
     if (this.simulatorSpecsMap !== undefined) {
       this.simulatorVersions =
         this.simulatorSpecsMap[this.simulatorControl.value]?.versions || [];

--- a/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
+++ b/apps/dispatch/src/app/components/simulations/browse/browse.component.ts
@@ -30,9 +30,9 @@ import { ClipboardService } from '@biosimulations/shared/angular';
 export class BrowseComponent implements OnInit {
   private endpoints = new Endpoints();
 
-  @ViewChild(TableComponent) table!: TableComponent;
+  @ViewChild(TableComponent) public table!: TableComponent;
 
-  columns: Column[] = [
+  public columns: Column[] = [
     {
       id: 'id',
       heading: 'Id',
@@ -188,7 +188,7 @@ export class BrowseComponent implements OnInit {
       comparator: (
         a: SimulationRunStatus,
         b: SimulationRunStatus,
-        sign: number,
+        _sign: number,
       ): number => {
         const aVal = SimulationStatusService.getSimulationStatusOrder(a);
         const bVal = SimulationStatusService.getSimulationStatusOrder(b);
@@ -336,7 +336,7 @@ export class BrowseComponent implements OnInit {
           return null;
         }
       },
-      formatter: (hasReports: boolean): null => {
+      formatter: (_hasReports: boolean): null => {
         return null;
       },
       stackedFormatter: (hasReports: boolean): string | null => {
@@ -350,7 +350,7 @@ export class BrowseComponent implements OnInit {
       maxWidth: 38,
       filterable: false,
       sortable: false,
-      comparator: (a: boolean, b: boolean, sign: number): number => {
+      comparator: (a: boolean, b: boolean, _sign: number): number => {
         if (a > b) return -1;
         if (a < b) return 1;
         return 0;
@@ -415,7 +415,7 @@ export class BrowseComponent implements OnInit {
           return null;
         }
       },
-      formatter: (hasReports: boolean): null => {
+      formatter: (_hasReports: boolean): null => {
         return null;
       },
       stackedFormatter: (hasReports: boolean): string | null => {
@@ -429,7 +429,7 @@ export class BrowseComponent implements OnInit {
       maxWidth: 38,
       filterable: false,
       sortable: false,
-      comparator: (a: boolean, b: boolean, sign: number): number => {
+      comparator: (a: boolean, b: boolean, _sign: number): number => {
         if (a > b) return -1;
         if (a < b) return 1;
         return 0;
@@ -468,7 +468,7 @@ export class BrowseComponent implements OnInit {
           return null;
         }
       },
-      formatter: (status: SimulationRunStatus): null => {
+      formatter: (_status: SimulationRunStatus): null => {
         return null;
       },
       stackedFormatter: (status: SimulationRunStatus): string | null => {
@@ -485,7 +485,7 @@ export class BrowseComponent implements OnInit {
       comparator: (
         a: SimulationRunStatus,
         b: SimulationRunStatus,
-        sign: number,
+        _sign: number,
       ): number => {
         const aVal = SimulationStatusService.isSimulationStatusCompleted(a)
           ? 0
@@ -553,7 +553,7 @@ export class BrowseComponent implements OnInit {
           };
         }
       },
-      formatter: (status: SimulationRunStatus): null => {
+      formatter: (_status: SimulationRunStatus): null => {
         return null;
       },
       stackedFormatter: (status: SimulationRunStatus): string => {
@@ -628,7 +628,7 @@ export class BrowseComponent implements OnInit {
           };
         }
       },
-      formatter: (simulation: ISimulation): null => {
+      formatter: (_simulation: ISimulation): null => {
         return null;
       },
       stackedFormatter: (simulation: ISimulation): string => {
@@ -680,7 +680,7 @@ export class BrowseComponent implements OnInit {
           return ['/simulations', simulation.id, 'publish'];
         }
       },
-      formatter: (status: SimulationRunStatus): null => {
+      formatter: (_status: SimulationRunStatus): null => {
         return null;
       },
       stackedFormatter: (status: SimulationRunStatus): string => {
@@ -705,7 +705,7 @@ export class BrowseComponent implements OnInit {
       leftIcon: 'trash',
       leftAction: ColumnActionType.click,
       leftClick: (
-        simulation: ISimulation,
+        _simulation: ISimulation,
       ): ((simulation: ISimulation) => void) => {
         return (simulation: ISimulation): void => {
           this.removeSimulations(simulation);
@@ -713,16 +713,16 @@ export class BrowseComponent implements OnInit {
       },
       centerAction: ColumnActionType.click,
       centerClick: (
-        simulation: ISimulation,
+        _simulation: ISimulation,
       ): ((simulation: ISimulation) => void) => {
         return (simulation: ISimulation): void => {
           this.removeSimulations(simulation);
         };
       },
-      formatter: (id: string): null => {
+      formatter: (_id: string): null => {
         return null;
       },
-      stackedFormatter: (id: string): string => {
+      stackedFormatter: (_id: string): string => {
         return 'Remove simulation';
       },
       minWidth: 38,
@@ -733,9 +733,9 @@ export class BrowseComponent implements OnInit {
       showStacked: false,
     },
   ];
-  simulations!: Observable<ISimulation[]>;
+  public simulations!: Observable<ISimulation[]>;
 
-  constructor(
+  public constructor(
     private config: ConfigService,
     private simulationService: SimulationService,
     private snackBar: MatSnackBar,
@@ -759,7 +759,7 @@ export class BrowseComponent implements OnInit {
     });
   }
 
-  ngOnInit(): void {
+  public ngOnInit(): void {
     this.simulations = this.simulationService
       .getSimulations()
       /*
@@ -770,11 +770,11 @@ export class BrowseComponent implements OnInit {
       .pipe(debounceTime(16));
   }
 
-  getStackedHeading(simulation: ISimulation): string {
+  public getStackedHeading(simulation: ISimulation): string {
     return (simulation.name || 'N/A') + ' (' + simulation.id + ')';
   }
 
-  getStackedHeadingMoreInfoRouterLink(
+  public getStackedHeadingMoreInfoRouterLink(
     simulation: ISimulation,
   ): string[] | null {
     if (isUnknownSimulation(simulation)) {
@@ -784,7 +784,7 @@ export class BrowseComponent implements OnInit {
     }
   }
 
-  exportSimulations(): void {
+  public exportSimulations(): void {
     const simulations = this.simulationService.getSimulations();
     // Use the take operator to make sure that we don't download every time the observable emits
     simulations.pipe(take(1)).subscribe((sims: ISimulation[]) => {
@@ -798,7 +798,7 @@ export class BrowseComponent implements OnInit {
     });
   }
 
-  importSimulations(): void {
+  public importSimulations(): void {
     const input = document.createElement('input');
     input.setAttribute('type', 'file');
     input.onchange = (): void => {
@@ -821,7 +821,7 @@ export class BrowseComponent implements OnInit {
     input.click();
   }
 
-  removeSimulations(simulation?: ISimulation): void {
+  public removeSimulations(simulation?: ISimulation): void {
     const dialogRef = this.dialog.open(DeleteSimulationsDialogComponent, {
       width: '350px',
       data: simulation,
@@ -838,7 +838,7 @@ export class BrowseComponent implements OnInit {
     });
   }
 
-  loadExampleSimulations(): number {
+  public loadExampleSimulations(): number {
     const exampleSimulationsJson =
       environment.env == 'prod'
         ? exampleSimulationsProdJson

--- a/apps/dispatch/src/app/components/simulations/browse/delete-simulations-dialog.component.ts
+++ b/apps/dispatch/src/app/components/simulations/browse/delete-simulations-dialog.component.ts
@@ -8,7 +8,7 @@ import { Simulation } from '../../../datamodel';
   styleUrls: ['./delete-simulations-dialog.component.scss'],
 })
 export class DeleteSimulationsDialogComponent {
-  constructor(
+  public constructor(
     private dialogRef: MatDialogRef<BrowseComponent>,
     @Inject(MAT_DIALOG_DATA) public simulation: Simulation | undefined,
   ) {}

--- a/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
+++ b/apps/dispatch/src/app/components/simulations/publish/publish.component.ts
@@ -37,10 +37,10 @@ export class PublishComponent implements OnInit, OnDestroy {
   public archiveUrl!: string;
 
   private simulation!: Simulation;
-  valid$!: Observable<true | string>;
+  public valid$!: Observable<true | string>;
 
-  formGroup: FormGroup;
-  submitPushed = false;
+  public formGroup: FormGroup;
+  public submitPushed = false;
 
   private subscriptions: Subscription[] = [];
 
@@ -91,7 +91,7 @@ export class PublishComponent implements OnInit, OnDestroy {
   public isIdAvailable(id: string): Observable<boolean> {
     return this.projectService.getProject(id).pipe(
       map((_): false => false),
-      catchError((error: HttpErrorResponse): Observable<boolean> => {
+      catchError((_error: HttpErrorResponse): Observable<boolean> => {
         return of(true);
       }),
     );

--- a/apps/dispatch/src/app/components/simulations/view/overview/overview.component.ts
+++ b/apps/dispatch/src/app/components/simulations/view/overview/overview.component.ts
@@ -8,7 +8,7 @@ import { FormattedSimulation } from '../view.model';
 })
 export class OverviewComponent {
   @Input()
-  simulation!: FormattedSimulation;
+  public simulation!: FormattedSimulation;
 
-  constructor() {}
+  public constructor() {}
 }

--- a/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
+++ b/apps/dispatch/src/app/components/simulations/view/simulation-log/simulation-log.component.ts
@@ -36,38 +36,42 @@ type StatusCountsMap = Map<SimulationRunLogStatus, StatusCount>;
   styleUrls: ['./simulation-log.component.scss'],
 })
 export class SimulationLogComponent {
-  constructor(private scrollService: ScrollService) {}
+  public constructor(private scrollService: ScrollService) {}
 
   @Input()
-  status!: SimulationRunStatus;
+  public status!: SimulationRunStatus;
 
   @Input()
-  rawLog!: RawSimulationLog;
+  public rawLog!: RawSimulationLog;
 
-  StructuredLogLevel = StructuredLogLevel;
+  public StructuredLogLevel = StructuredLogLevel;
   public _structuredLog!: CombineArchiveLog;
-  structuredLogLevel!: StructuredLogLevel;
-  numSedDocuments = 0;
-  numTasks = 0;
-  numReports = 0;
-  numPlots = 0;
-  sedDocumentStatusCounts!: StatusCount[];
-  taskStatusCounts!: StatusCount[];
-  reportStatusCounts!: StatusCount[];
-  plotStatusCounts!: StatusCount[];
-  logHasSedDocuments = false;
-  logHasTasks = false;
-  logHasReports = false;
-  logHasPlots = false;
+  public structuredLogLevel!: StructuredLogLevel;
+  public numSedDocuments = 0;
+  public numTasks = 0;
+  public numReports = 0;
+  public numPlots = 0;
+  public sedDocumentStatusCounts!: StatusCount[];
+  public taskStatusCounts!: StatusCount[];
+  public reportStatusCounts!: StatusCount[];
+  public plotStatusCounts!: StatusCount[];
+  public logHasSedDocuments = false;
+  public logHasTasks = false;
+  public logHasReports = false;
+  public logHasPlots = false;
 
-  taskLogs: { doc: SedDocumentLog; task: SedTaskLog }[] = [];
-  reportLogs: { doc: SedDocumentLog; report: SedReportLog }[] = [];
-  plotLogs: { doc: SedDocumentLog; plot: SedPlot2DLog | SedPlot3DLog }[] = [];
+  public taskLogs: { doc: SedDocumentLog; task: SedTaskLog }[] = [];
+  public reportLogs: { doc: SedDocumentLog; report: SedReportLog }[] = [];
+  public plotLogs: { doc: SedDocumentLog; plot: SedPlot2DLog | SedPlot3DLog }[] = [];
 
-  duration = 'N/A';
+  public duration = 'N/A';
+
+  public tocSections!: Observable<TocSection[]>;
+
+  private scrollOffset = 64 + 32 + 32 + 32;
 
   @Input()
-  set structuredLog(value: CombineArchiveLog | undefined) {
+  public set structuredLog(value: CombineArchiveLog | undefined) {
     value
       ? (this._structuredLog = value)
       : (this._structuredLog = {
@@ -82,11 +86,11 @@ export class SimulationLogComponent {
     this.processStructuredLog(value);
   }
 
-  get structuredLog(): CombineArchiveLog | undefined {
+  public get structuredLog(): CombineArchiveLog | undefined {
     return this._structuredLog;
   }
 
-  private processStructuredLog(log: CombineArchiveLog | undefined) {
+  private processStructuredLog(log: CombineArchiveLog | undefined): void {
     let level: StructuredLogLevel = StructuredLogLevel.None;
     this.numSedDocuments = 0;
     this.numTasks = 0;
@@ -306,22 +310,20 @@ export class SimulationLogComponent {
     return array;
   }
 
-  locationComparator(a: any, b: any): number {
+  public locationComparator(a: any, b: any): number {
     return a.location.localeCompare(b.location, undefined, { numeric: true });
   }
 
-  idComparator(a: any, b: any): number {
+  public idComparator(a: any, b: any): number {
     return a.id.localeCompare(b.id, undefined, { numeric: true });
   }
 
-  getStatus(): SimulationRunLogStatus {
+  public getStatus(): SimulationRunLogStatus {
     return statusConverter(this.status);
   }
 
-  tocSections!: Observable<TocSection[]>;
-
   @ViewChild(TocSectionsContainerDirective)
-  set tocSectionsContainer(container: TocSectionsContainerDirective) {
+  public set tocSectionsContainer(container: TocSectionsContainerDirective) {
     if (container) {
       setTimeout(() => {
         this.tocSections = container.sections$;
@@ -329,18 +331,16 @@ export class SimulationLogComponent {
     }
   }
 
-  private scrollOffset = 64 + 32 + 32 + 32;
-
-  scrollToElement(id: string): void {
+  public scrollToElement(id: string): void {
     const scrollTarget = document.getElementById(id) as HTMLElement;
     this.scrollService.scrollToElement(scrollTarget, this.scrollOffset);
   }
 
-  downloadRawLog(): void {
+  public downloadRawLog(): void {
     this.downloadLog(this.rawLog, 'log.txt', 'text/plain;charset=UTF-8');
   }
 
-  downloadStructuredLog(): void {
+  public downloadStructuredLog(): void {
     this.downloadLog(
       JSON.stringify(this.structuredLog, null, 2),
       'log.json',

--- a/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
+++ b/apps/dispatch/src/app/components/simulations/view/simulation-log/structured-simulation-log-element.component.ts
@@ -38,36 +38,48 @@ interface FormattedSimulatorDetail {
   styleUrls: ['./structured-simulation-log-element.component.scss'],
 })
 export class StructuredSimulationLogElementComponent {
-  constructor(
+  public constructor(
     private sanitizer: DomSanitizer,
     private ontologyService: OntologyService,
     private structuredLogService: StructuredSimulationLogElementService,
   ) {}
 
   @Input()
-  isStructuredLog = true;
+  public isStructuredLog = true;
 
   @Input()
-  elementId!: string;
+  public elementId!: string;
 
   @Input()
-  elementType!: string;
+  public elementType!: string;
 
-  heading!: string;
+  @Input()
+  public compact = false;
+
+  @Input()
+  public iconActionType: IconActionType = 'scrollToTop';
+
+  @Input()
+  public first = false;
+
+  @Input()
+  public last = false;
+
+  public heading!: string;
 
   private _log!: logTypes;
 
-  noOutputMessage = '';
-  formattedOutput!: SafeHtml | undefined;
+  public noOutputMessage = '';
+  public formattedOutput!: SafeHtml | undefined;
 
-  algorithmKisaoTerm: Observable<KisaoTerm> | undefined;
-  algorithmKisaoTermDescription:
+  public algorithmKisaoTerm: Observable<KisaoTerm> | undefined;
+  public algorithmKisaoTermDescription:
     | Observable<AlgorithmKisaoDescriptionFragment[] | undefined>
     | undefined;
-  formattedSimulatorDetails: FormattedSimulatorDetail[] | undefined;
+  public formattedSimulatorDetails: FormattedSimulatorDetail[] | undefined;
 
   @Input()
-  set log(value: logTypes) {
+  public set log(value: logTypes) {
     this._log = value;
     this.heading = this.getHeading();
 
@@ -128,11 +140,11 @@ export class StructuredSimulationLogElementComponent {
     }
   }
 
-  get log(): logTypes {
+  public get log(): logTypes {
     return this._log;
   }
 
-  getHeading(): string {
+  public getHeading(): string {
     const duration = this.log?.duration;
 
     return (
@@ -145,16 +157,4 @@ export class StructuredSimulationLogElementComponent {
       ')'
     );
   }
-
-  @Input()
-  compact = false;
-
-  @Input()
-  iconActionType: IconActionType = 'scrollToTop';
-
-  @Input()
-  first = false;
-
-  @Input()
-  last = false;
 }

--- a/apps/dispatch/src/app/components/simulations/view/view.component.ts
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.ts
@@ -66,6 +66,11 @@ export class ViewComponent implements OnInit {
 
   private endpoints = new Endpoints();
 
+  public selectedTabIndex = 0;
+  public viewVisualizationTabDisabled = true;
+  public selectVisualizationTabIndex = 3;
+  public visualizationTabIndex = 4;
+
   public constructor(
     private simulationService: SimulationService,
     private simulationRunService: SimulationRunService,
@@ -281,11 +286,6 @@ export class ViewComponent implements OnInit {
       shareReplay(1),
     );
   }
-
-  selectedTabIndex = 0;
-  viewVisualizationTabDisabled = true;
-  selectVisualizationTabIndex = 3;
-  visualizationTabIndex = 4;
 
   public renderVisualization(visualization: Visualization): void {
     this.visualization = visualization;

--- a/apps/dispatch/src/app/services/simulation/simulation.service.ts
+++ b/apps/dispatch/src/app/services/simulation/simulation.service.ts
@@ -56,7 +56,7 @@ export class SimulationService {
     this.initStorage();
   }
 
-  async initStorage() {
+  public async initStorage() {
     this._storage = await this.storage.create();
 
     if ((await this._storage.keys()).includes(this.key)) {
@@ -81,11 +81,13 @@ export class SimulationService {
     });
     return simulations;
   }
+  
   /**
-   * Subscribes to the map of the simulators creates and observable list of simulators. This simplifies returning the simulators.
+   * Subscribes to the map of the simulators creates and observable list of simulators.
+   * This simplifies returning the simulators.
    * @see getSimulations
    */
-  private createSimulationsArray() {
+  private createSimulationsArray(): void {
     this.simulationsMapSubject
       .pipe(shareReplay(1))
       .subscribe((simulationMap) => {
@@ -100,6 +102,7 @@ export class SimulationService {
         }
       });
   }
+
   private initSimulations(storedSimulations: ISimulation[]): void {
     const simulations = storedSimulations.concat(
       this.simulationsAddedBeforeStorageInitialized,
@@ -259,11 +262,12 @@ export class SimulationService {
    * @author Bilal
    * @param uuid The id of the simulation
    * Contains the logic for the polling update.
-   * Pull the simulator from cache, but add a debounce. Then, following subscription then must wait some numer of seconds before firing.
-   * If the cached suimulation is still running, call the http service to get the latest simulation. Then, save it to the cache
-   * Since this is happening inside a subscription of the simulator from cache, saving it triggers the subscription again.
-   * This will repeat until the simulator is no longer in a running state, and therefore wont be saved to the cache, and wont cause a repeat
-   * When saving it to the cache also save to local storage
+   * Pull the simulator from cache, but add a debounce. Then, following subscription then must
+   * wait some numer of seconds before firing. If the cached suimulation is still running, call
+   * the http service to get the latest simulation. Then, save it to the cache Since this is 
+   * happening inside a subscription of the simulator from cache, saving it triggers the subscription again.
+   * This will repeat until the simulator is no longer in a running state, and therefore wont be saved to the
+   * cache, and wont cause a repeat. When saving it to the cache also save to local storage
    */
   private updateSimulation(uuid: string): void {
     const current = this.getSimulationFromCache(uuid).pipe(
@@ -320,9 +324,10 @@ export class SimulationService {
    * @author Bilal
    * @param uuid The id of the simulation
    * If we have the simulations in cache(a map of behavior subjects), return it, and trigger an update
-   * If not, then get it via http, store it to cache, trigger an update (to start polling), and return the simulator from cache
-   * In both cases we want to return from cache. This is because the cache contains behavior subjects already configured to poll the api
-   * The recieving method can simply pipe or subscribe to have the latest data
+   * If not, then get it via http, store it to cache, trigger an update (to start polling), and return
+   * the simulator from cache. In both cases we want to return from cache. This is because the cache contains
+   * behavior subjects already configured to poll the api. The recieving method can simply pipe or subscribe
+   * to have the latest data.
    */
   public getSimulation(uuid: string): Observable<ISimulation> {
     if (uuid in this.simulationsMap$) {


### PR DESCRIPTION
Insert an explicit public on implicitly public functions and variables, prepend unused parameters
with _, insert explicit void return types, and reorder variables to the top of classes. This fixes
most of the lint errors within dispatch.

**What new features does this PR implement?**
N/A

**What bugs does this PR fix?**
Lint warnings within dispatch

**Does this PR introduce any additional changes?**
N/A

**How have you tested this PR?**
The app compiles runs fine locally, and the tests pass. 

**Additional information**
N/A
