### PR TITLE
feat(combine-api): upgraded to flask 2, connexion 2.11, openapi-schema-validator 0.2

### DIFF
--- a/apps/combine-api/Dockerfile-assets/Pipfile
+++ b/apps/combine-api/Dockerfile-assets/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-flask = {version = "<2"}
-connexion = {extras = ["swagger-ui"],version = ">=2.7.0"}
+flask = ">=2"
+connexion = {extras = ["swagger-ui"],version = ">=2.11.1"}
 openapi-schema-validator = "<0.3" # due to conflicting required version of jsonschema with connexion >= 2.9
 requests = "*"
 biosimulators-utils = {version = ">=0.1.159", extras = ["bngl", "cellml", "lems", "logging", "neuroml", "sbml", "smoldyn"]}

--- a/apps/combine-api/Dockerfile-assets/Pipfile
+++ b/apps/combine-api/Dockerfile-assets/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 flask = ">=2"
 connexion = {extras = ["swagger-ui"],version = ">=2.11.1"}
-openapi-schema-validator = "<0.3" # due to conflicting required version of jsonschema with connexion >= 2.9
+openapi-schema-validator = "<0.3" # avoid prereleases
 requests = "*"
 biosimulators-utils = {version = ">=0.1.159", extras = ["bngl", "cellml", "lems", "logging", "neuroml", "sbml", "smoldyn"]}
 python-dateutil = "*"

--- a/apps/combine-api/Dockerfile-assets/Pipfile.lock
+++ b/apps/combine-api/Dockerfile-assets/Pipfile.lock
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "hash": {
-      "sha256": "8b9bbb5456ebfbbe602367bf124d34021fec23abe1c31f2e0f18defde1751923"
+      "sha256": "41ed7099dbafb76eb5d19b3daab6cee8ae75d225026760c2cb3a9094de881ee8"
     },
     "pipfile-spec": 6,
     "requires": {
@@ -286,11 +286,11 @@
         "smoldyn"
       ],
       "hashes": [
-        "sha256:49afd34ed7729138bbd4287056f888eed691ce14a313b7d9a04386eb5b7a6d9b",
-        "sha256:51b9bc09577ffd448e5abeec970798c6dfc8e95f692f4c803d0f11741e5f7cb0"
+        "sha256:2bf5e6bb961d0e23b5634d28018113ba84c3c6414e6d92ca1efa7222ec592fd2",
+        "sha256:c7f5af25031f50686bbc2b82d701cfa0556db46649e516401ae8ed965516c30a"
       ],
       "index": "pypi",
-      "version": "==0.1.159"
+      "version": "==0.1.160"
     },
     "biosimulators-xpp": {
       "hashes": [
@@ -302,11 +302,32 @@
     },
     "black": {
       "hashes": [
-        "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3",
-        "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"
+        "sha256:07e5c049442d7ca1a2fc273c79d1aecbbf1bc858f62e8184abe1ad175c4f7cc2",
+        "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71",
+        "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6",
+        "sha256:228b5ae2c8e3d6227e4bde5920d2fc66cc3400fde7bcc74f480cb07ef0b570d5",
+        "sha256:2d6f331c02f0f40aa51a22e479c8209d37fcd520c77721c034517d44eecf5912",
+        "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866",
+        "sha256:3524739d76b6b3ed1132422bf9d82123cd1705086723bc3e235ca39fd21c667d",
+        "sha256:35944b7100af4a985abfcaa860b06af15590deb1f392f06c8683b4381e8eeaf0",
+        "sha256:373922fc66676133ddc3e754e4509196a8c392fec3f5ca4486673e685a421321",
+        "sha256:5fa1db02410b1924b6749c245ab38d30621564e658297484952f3d8a39fce7e8",
+        "sha256:6f2f01381f91c1efb1451998bd65a129b3ed6f64f79663a55fe0e9b74a5f81fd",
+        "sha256:742ce9af3086e5bd07e58c8feb09dbb2b047b7f566eb5f5bc63fd455814979f3",
+        "sha256:7835fee5238fc0a0baf6c9268fb816b5f5cd9b8793423a75e8cd663c48d073ba",
+        "sha256:8871fcb4b447206904932b54b567923e5be802b9b19b744fdff092bd2f3118d0",
+        "sha256:a7c0192d35635f6fc1174be575cb7915e92e5dd629ee79fdaf0dcfa41a80afb5",
+        "sha256:b1a5ed73ab4c482208d20434f700d514f66ffe2840f63a6252ecc43a9bc77e8a",
+        "sha256:c8226f50b8c34a14608b848dc23a46e5d08397d009446353dad45e04af0c8e28",
+        "sha256:ccad888050f5393f0d6029deea2a33e5ae371fd182a697313bdbd835d3edaf9c",
+        "sha256:dae63f2dbf82882fa3b2a3c49c32bffe144970a573cd68d247af6560fc493ae1",
+        "sha256:e2f69158a7d120fd641d1fa9a921d898e20d52e44a74a6fbbcc570a62a6bc8ab",
+        "sha256:efbadd9b52c060a8fc3b9658744091cb33c31f830b3f074422ed27bad2b18e8f",
+        "sha256:f5660feab44c2e3cb24b2419b998846cbb01c23c7fe645fee45087efa3da2d61",
+        "sha256:fdb8754b453fb15fad3f72cd9cad3e16776f0964d67cf30ebcbf10327a3777a3"
       ],
       "markers": "python_full_version >= '3.6.2'",
-      "version": "==21.12b0"
+      "version": "==22.1.0"
     },
     "bleach": {
       "hashes": [
@@ -333,19 +354,19 @@
     },
     "boto3": {
       "hashes": [
-        "sha256:87994c3753ef386189a222556eaf7cb1ef63432d516b4344c7b2899ce544ad2a",
-        "sha256:c62362e3105c918272a95c9f4881587c3a3c68aa5fedcd322313def3688c9f7b"
+        "sha256:1a272a1dd36414b1626a47bb580425203be0b5a34caa117f38a5e18adf21f918",
+        "sha256:8129ad42cc0120d1c63daa18512d6f0b1439e385b2b6e0fe987f116bdf795546"
       ],
       "index": "pypi",
-      "version": "==1.20.50"
+      "version": "==1.20.54"
     },
     "botocore": {
       "hashes": [
-        "sha256:109d9a200f70268d5429423fd8052f6fed5e041853d6621081692ea5ad7f70c7",
-        "sha256:aa953d9767ff99a7aa35dde770a1405c8877cef9caf280859b94104483b8368d"
+        "sha256:06ae8076c4dcf3d72bec4d37e5f2dce4a92a18a8cdaa3bfaa6e3b7b5e30a8d7e",
+        "sha256:4bb9ba16cccee5f5a2602049bc3e2db6865346b2550667f3013bdf33b0a01ceb"
       ],
       "markers": "python_version >= '3.6'",
-      "version": "==1.23.50"
+      "version": "==1.23.54"
     },
     "brian2": {
       "hashes": [
@@ -471,19 +492,19 @@
     },
     "charset-normalizer": {
       "hashes": [
-        "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-        "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+        "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+        "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
       ],
       "markers": "python_version >= '3'",
-      "version": "==2.0.11"
+      "version": "==2.0.12"
     },
     "click": {
       "hashes": [
-        "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
-        "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+        "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3",
+        "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-      "version": "==7.1.2"
+      "markers": "python_version >= '3.6'",
+      "version": "==8.0.3"
     },
     "clickclick": {
       "hashes": [
@@ -532,11 +553,11 @@
     "connexion": {
       "extras": ["swagger-ui"],
       "hashes": [
-        "sha256:b10df8b67dde1b9d61ff0676f354d02ab838bed9818eb89d582504b3a3acbd71",
-        "sha256:de0cab04ff548e392ba206228ded9d46620765a4b27f0d0c8ab3999ad20b53dc"
+        "sha256:66620b10b2c03eab6af981f8489d0ff7ada19f66710274effc71258fb8221419",
+        "sha256:b5e5ba236894a02b8da4d10face412f471abb6ff77de10dad32fa88cb894acf7"
       ],
       "index": "pypi",
-      "version": "==2.10.0"
+      "version": "==2.11.1"
     },
     "cycler": {
       "hashes": [
@@ -705,11 +726,11 @@
     },
     "flask": {
       "hashes": [
-        "sha256:0fbeb6180d383a9186d0d6ed954e0042ad9f18e0e8de088b2b419d526927d196",
-        "sha256:c34f04500f2cbbea882b1acb02002ad6fe6b7ffa64a6164577995657f50aed22"
+        "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2",
+        "sha256:cb90f62f1d8e4dc4621f52106613488b5ba826b2e1e10a33eac92f723093ab6a"
       ],
       "index": "pypi",
-      "version": "==1.1.4"
+      "version": "==2.0.2"
     },
     "flask-cors": {
       "hashes": [
@@ -994,11 +1015,11 @@
     },
     "itsdangerous": {
       "hashes": [
-        "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
-        "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+        "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+        "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-      "version": "==1.1.0"
+      "markers": "python_version >= '3.6'",
+      "version": "==2.0.1"
     },
     "jedi": {
       "hashes": [
@@ -1010,11 +1031,11 @@
     },
     "jinja2": {
       "hashes": [
-        "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
-        "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+        "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8",
+        "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-      "version": "==2.11.3"
+      "markers": "python_version >= '3.6'",
+      "version": "==3.0.3"
     },
     "jmespath": {
       "hashes": [
@@ -1400,11 +1421,11 @@
     },
     "nbconvert": {
       "hashes": [
-        "sha256:7dce3f977c2f9651841a3c49b5b7314c742f24dd118b99e51b8eec13c504f555",
-        "sha256:fe93bc42485c54c5a49a2324c834aca1ff315f320a535bed3e3c4e085d3eebe3"
+        "sha256:7b006ae9979af56200e7fa3db39d9d12c99e811e8843b05dbe518e5b754bcb2e",
+        "sha256:eb2803db18f6facce6bf3b01b684fe47907994bd156d15eaccdf011e3d7f8164"
       ],
       "markers": "python_version >= '3.7'",
-      "version": "==6.4.1"
+      "version": "==6.4.2"
     },
     "nbformat": {
       "hashes": [
@@ -1566,30 +1587,30 @@
     },
     "pandas": {
       "hashes": [
-        "sha256:0f19504f2783526fb5b4de675ea69d68974e21c1624f4b92295d057a31d5ec5f",
-        "sha256:156aac90dd7b303bf0b91bae96c0503212777f86c731e41929c571125d26c8e9",
-        "sha256:1d59c958d6b8f96fdf850c7821571782168d5acfe75ccf78cd8d1ac15fb921df",
-        "sha256:1f3b74335390dda49f5d5089fab71958812bf56f42aa27663ee4c16d19f4f1c5",
-        "sha256:23c04dab11f3c6359cfa7afa83d3d054a8f8c283d773451184d98119ef54da97",
-        "sha256:2dad075089e17a72391de33021ad93720aff258c3c4b68c78e1cafce7e447045",
-        "sha256:46a18572f3e1cb75db59d9461940e9ba7ee38967fa48dd58f4139197f6e32280",
-        "sha256:4a8d5a200f8685e7ea562b2f022c77ab7cb82c1ca5b240e6965faa6f84e5c1e9",
-        "sha256:51e5da3802aaee1aa4254108ffaf1129a15fb3810b7ce8da1ec217c655b418f5",
-        "sha256:5229c95db3a907451dacebc551492db6f7d01743e49bbc862f4a6010c227d187",
-        "sha256:5280d057ddae06fe4a3cd6aa79040b8c205cd6dd21743004cf8635f39ed01712",
-        "sha256:55ec0e192eefa26d823fc25a1f213d6c304a3592915f368e360652994cdb8d9a",
-        "sha256:73f7da2ccc38cc988b74e5400b430b7905db5f2c413ff215506bea034eaf832d",
-        "sha256:784cca3f69cfd7f6bd7c7fdb44f2bbab17e6de55725e9ff36d6f382510dfefb5",
-        "sha256:b5af258c7b090cca7b742cf2bd67ad1919aa9e4e681007366c9edad2d6a3d42b",
-        "sha256:cdd76254c7f0a1583bd4e4781fb450d0ebf392e10d3f12e92c95575942e37df5",
-        "sha256:de62cf699122dcef175988f0714678e59c453dc234c5b47b7136bfd7641e3c8c",
-        "sha256:de8f8999864399529e8514a2e6bfe00fd161f0a667903655552ed12e583ae3cb",
-        "sha256:f045bb5c6bfaba536089573bf97d6b8ccc7159d951fe63904c395a5e486fbe14",
-        "sha256:f103a5cdcd66cb18882ccdc18a130c31c3cfe3529732e7f10a8ab3559164819c",
-        "sha256:fe454180ad31bbbe1e5d111b44443258730467f035e26b4e354655ab59405871"
+        "sha256:0259cd11e7e6125aaea3af823b80444f3adad6149ff4c97fef760093598b3e34",
+        "sha256:04dd15d9db538470900c851498e532ef28d4e56bfe72c9523acb32042de43dfb",
+        "sha256:0b1a13f647e4209ed7dbb5da3497891d0045da9785327530ab696417ef478f84",
+        "sha256:19f7c632436b1b4f84615c3b127bbd7bc603db95e3d4332ed259dc815c9aaa26",
+        "sha256:1b384516dbb4e6aae30e3464c2e77c563da5980440fbdfbd0968e3942f8f9d70",
+        "sha256:1d85d5f6be66dfd6d1d8d13b9535e342a2214260f1852654b19fa4d7b8d1218b",
+        "sha256:2e5a7a1e0ecaac652326af627a3eca84886da9e667d68286866d4e33f6547caf",
+        "sha256:3129a35d9dad1d80c234dd78f8f03141b914395d23f97cf92a366dcd19f8f8bf",
+        "sha256:358b0bc98a5ff067132d23bf7a2242ee95db9ea5b7bbc401cf79205f11502fd3",
+        "sha256:3dfb32ed50122fe8c5e7f2b8d97387edd742cc78f9ec36f007ee126cd3720907",
+        "sha256:4e1176f45981c8ccc8161bc036916c004ca51037a7ed73f2d2a9857e6dbe654f",
+        "sha256:508c99debccd15790d526ce6b1624b97a5e1e4ca5b871319fb0ebfd46b8f4dad",
+        "sha256:6105af6533f8b63a43ea9f08a2ede04e8f43e49daef0209ab0d30352bcf08bee",
+        "sha256:6d6ad1da00c7cc7d8dd1559a6ba59ba3973be6b15722d49738b2be0977eb8a0c",
+        "sha256:7ea47ba1d6f359680130bd29af497333be6110de8f4c35b9211eec5a5a9630fa",
+        "sha256:8db93ec98ac7cb5f8ac1420c10f5e3c43533153f253fe7fb6d891cf5aa2b80d2",
+        "sha256:96e9ece5759f9b47ae43794b6359bbc54805d76e573b161ae770c1ea59393106",
+        "sha256:bbb15ad79050e8b8d39ec40dd96a30cd09b886a2ae8848d0df1abba4d5502a67",
+        "sha256:c614001129b2a5add5e3677c3a213a9e6fd376204cb8d17c04e84ff7dfc02a73",
+        "sha256:e6a7bbbb7950063bfc942f8794bc3e31697c020a14f1cd8905fc1d28ec674a01",
+        "sha256:f02e85e6d832be37d7f16cf6ac8bb26b519ace3e5f3235564a91c7f658ab2a43"
       ],
       "markers": "python_version >= '3.8'",
-      "version": "==1.4.0"
+      "version": "==1.4.1"
     },
     "pandocfilters": {
       "hashes": [
@@ -1704,19 +1725,19 @@
     },
     "platformdirs": {
       "hashes": [
-        "sha256:1d7385c7db91728b83efd0ca99a5afb296cab9d0ed8313a45ed8ba17967ecfca",
-        "sha256:440633ddfebcc36264232365d7840a970e75e1018d15b4327d11f91909045fda"
+        "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb",
+        "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"
       ],
       "markers": "python_version >= '3.7'",
-      "version": "==2.4.1"
+      "version": "==2.5.0"
     },
     "plotly": {
       "hashes": [
-        "sha256:20b8a1a0f0434f9b8d10eb7caa66e947a9a1d698e5a53d40d447bbc0d2ae41f0",
-        "sha256:bc7d19272560f73fe4c2c989c31b00774a35d3a76891fab0b72c17616862d0e0"
+        "sha256:20277d211ea0e00e2a86d31e9f865a1ab45a7b17576f3bb865992ecbf15db093",
+        "sha256:d86e44ebde38f4753dff982ab9b5e03cf872aab8fdf53a403e999ed378154331"
       ],
       "markers": "python_version >= '3.6'",
-      "version": "==5.5.0"
+      "version": "==5.6.0"
     },
     "pluggy": {
       "hashes": [
@@ -1736,11 +1757,11 @@
     },
     "prompt-toolkit": {
       "hashes": [
-        "sha256:cb7dae7d2c59188c85a1d6c944fad19aded6a26bd9c8ae115a4e1c20eb90b713",
-        "sha256:f2b6a8067a4fb959d3677d1ed764cc4e63e0f6f565b9a4fc7edc2b18bf80217b"
+        "sha256:30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c",
+        "sha256:9f1cd16b1e86c2968f2519d7fb31dd9d669916f515612c269d14e9ed52b51650"
       ],
       "markers": "python_full_version >= '3.6.2'",
-      "version": "==3.0.27"
+      "version": "==3.0.28"
     },
     "pronto": {
       "hashes": [
@@ -1946,11 +1967,11 @@
     },
     "pytest": {
       "hashes": [
-        "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-        "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+        "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+        "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
       ],
       "markers": "python_version >= '3.6'",
-      "version": "==7.0.0"
+      "version": "==7.0.1"
     },
     "python-copasi": {
       "hashes": [
@@ -2362,17 +2383,20 @@
     },
     "rich": {
       "hashes": [
-        "sha256:365ebcdbfb3aa8d4b0ed2490e0fbf7b886a39d14eb7ea5fb7aece950835e1eed",
-        "sha256:43e03d8eec12e21beaecc22c828a41c4247356414a12d5879834863d4ad53816"
+        "sha256:1a6266a5738115017bb64a66c59c717e7aa047b3ae49a011ede4abdeffc6536e",
+        "sha256:d5f49ad91fb343efcae45a2b2df04a9755e863e50413623ab8c9e74f05aee52b"
       ],
       "markers": "python_version < '4' and python_full_version >= '3.6.2'",
-      "version": "==11.1.0"
+      "version": "==11.2.0"
     },
     "rpy2": {
       "hashes": [
-        "sha256:ed4284df32d00b1fba5b1409e5df64b04b02d47aff543d6ef1dc211ab94e247f"
+        "sha256:0dfc1838954e6b3c4778499f83f6f14e444c97669a21a84728af006b5c4077cc",
+        "sha256:44235c2a48d0fd03f7820cee93f595e45b20e3b54cc3cf4569c87ec409b86d6c",
+        "sha256:5d31a5ea43f5a59f6dec30faca87edb01fc9b8affa0beae96a99be923bd7dab3",
+        "sha256:a86bb6a47df7454cbf72a4d98ef1a2a8eb65efbe1082265ba60978d8d421239a"
       ],
-      "version": "==3.1.0"
+      "version": "==3.4.5"
     },
     "rrplugins": {
       "hashes": [
@@ -2384,11 +2408,11 @@
     },
     "ruamel.yaml": {
       "hashes": [
-        "sha256:4b8a33c1efb2b443a93fcaafcfa4d2e445f8e8c29c528d9f5cdafb7cc9e4004c",
-        "sha256:810eef9c46523a3f77479c66267a4708255ebe806a2d540078408c2227f011af"
+        "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7",
+        "sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af"
       ],
       "markers": "python_version >= '3'",
-      "version": "==0.17.20"
+      "version": "==0.17.21"
     },
     "ruamel.yaml.clib": {
       "hashes": [
@@ -2485,20 +2509,6 @@
       ],
       "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
       "version": "==1.8.1b0"
-    },
-    "setuptools": {
-      "hashes": [
-        "sha256:07e97e2f1e5607d240454e98c75c7004560ac8417ca5ae1dbaa50811cb6cc95c",
-        "sha256:23aad87cc27f4ae704079618c1d117a71bd43d41e355f0698c35f6b1c796d26c"
-      ],
-      "markers": "python_version >= '3.7'",
-      "version": "==60.8.1"
-    },
-    "simplegeneric": {
-      "hashes": [
-        "sha256:dc972e06094b9af5b855b3df4a646395e43d1c9d0d39ed345b7393560d0b9173"
-      ],
-      "version": "==0.8.1"
     },
     "simplejson": {
       "hashes": [
@@ -2709,11 +2719,11 @@
     },
     "tomli": {
       "hashes": [
-        "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
-        "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
+        "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
       ],
-      "markers": "python_version >= '3.6'",
-      "version": "==1.2.3"
+      "markers": "python_version >= '3.7'",
+      "version": "==2.0.1"
     },
     "toposort": {
       "hashes": [
@@ -2787,11 +2797,11 @@
     },
     "typing-extensions": {
       "hashes": [
-        "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e",
-        "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"
+        "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095",
+        "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"
       ],
-      "markers": "python_version >= '3.6'",
-      "version": "==4.0.1"
+      "markers": "python_version < '3.10'",
+      "version": "==4.1.0"
     },
     "tzdata": {
       "hashes": [
@@ -2841,11 +2851,11 @@
     },
     "werkzeug": {
       "hashes": [
-        "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
-        "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+        "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
+        "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-      "version": "==1.0.1"
+      "markers": "python_version >= '3.6'",
+      "version": "==2.0.3"
     },
     "wurlitzer": {
       "hashes": [
@@ -2864,11 +2874,11 @@
     },
     "xyzservices": {
       "hashes": [
-        "sha256:042ddd3c27a7c8707cc555737d0c8a86137e70bb00f8530117bee484993bd6e4",
-        "sha256:c982874cd00cb9fc0c422a674d50b2813ce0517b42f6ed3b727384e3ac1b8beb"
+        "sha256:5451c76b34791a1f8100cb3e1288d3f725bea77ed30c3324b4770a848e932bf1",
+        "sha256:a63c139d284f2547d1071348cf4d76e27660b6bb5f7bf7f8ea02059c1a96f56e"
       ],
       "markers": "python_version >= '3.7'",
-      "version": "==2022.1.1"
+      "version": "==2022.2.0"
     },
     "yamldown": {
       "hashes": [
@@ -2969,11 +2979,11 @@
     },
     "charset-normalizer": {
       "hashes": [
-        "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45",
-        "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"
+        "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
+        "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
       ],
       "markers": "python_version >= '3'",
-      "version": "==2.0.11"
+      "version": "==2.0.12"
     },
     "coverage": {
       "extras": ["toml"],
@@ -3201,11 +3211,11 @@
     },
     "pytest": {
       "hashes": [
-        "sha256:42901e6bd4bd4a0e533358a86e848427a49005a3256f657c5c8f8dd35ef137a9",
-        "sha256:dad48ffda394e5ad9aa3b7d7ddf339ed502e5e365b1350e0af65f4a602344b11"
+        "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db",
+        "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"
       ],
       "markers": "python_version >= '3.6'",
-      "version": "==7.0.0"
+      "version": "==7.0.1"
     },
     "pytest-cov": {
       "hashes": [
@@ -3266,14 +3276,6 @@
       "index": "pypi",
       "version": "==2.27.1"
     },
-    "setuptools": {
-      "hashes": [
-        "sha256:07e97e2f1e5607d240454e98c75c7004560ac8417ca5ae1dbaa50811cb6cc95c",
-        "sha256:23aad87cc27f4ae704079618c1d117a71bd43d41e355f0698c35f6b1c796d26c"
-      ],
-      "markers": "python_version >= '3.7'",
-      "version": "==60.8.1"
-    },
     "six": {
       "hashes": [
         "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
@@ -3284,11 +3286,11 @@
     },
     "tomli": {
       "hashes": [
-        "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f",
-        "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"
+        "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+        "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
       ],
-      "markers": "python_version >= '3.6'",
-      "version": "==1.2.3"
+      "markers": "python_version >= '3.7'",
+      "version": "==2.0.1"
     },
     "urllib3": {
       "hashes": [
@@ -3300,11 +3302,11 @@
     },
     "werkzeug": {
       "hashes": [
-        "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
-        "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+        "sha256:1421ebfc7648a39a5c58c601b154165d05cf47a3cd0ccb70857cbdacf6c8f2b8",
+        "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"
       ],
-      "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-      "version": "==1.0.1"
+      "markers": "python_version >= '3.6'",
+      "version": "==2.0.3"
     }
   }
 }


### PR DESCRIPTION
Removes need to navigate requirements for conflicting versions of jsonschema between connexion and openapi-schema-validator.

Upgrades:
- flask: 2.0.2
- connexion 2.11.1
- openapi-schema-validator: 0.2.3
- biosimulators-utils: 0.1.160
- various additional minor upgrades