### PR TITLE
refactor(api): remove results caching using redis

### DIFF
--- a/apps/api/src/results/results.controller.spec.ts
+++ b/apps/api/src/results/results.controller.spec.ts
@@ -35,11 +35,7 @@ describe('ResultsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ResultsController],
-      imports: [
-        BiosimulationsAuthModule,
-        BiosimulationsConfigModule,
-        CacheModule.register(),
-      ],
+      imports: [BiosimulationsAuthModule, BiosimulationsConfigModule],
       providers: [
         ResultsService,
         {

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -114,7 +114,7 @@ export class CompleteProcessor {
     }
 
     const oneDay = 24 * 60 * 60 * 1000;
-    const oneWeek = 7 * oneDay;
+    
     //clean queues
     if (finalStatus === SimulationRunStatus.SUCCEEDED) {
       this.cleanUpQueue.add(
@@ -124,7 +124,6 @@ export class CompleteProcessor {
           queueName: JobQueue.complete,
         },
         {
-          delay: oneDay,
           removeOnComplete: 10,
           removeOnFail: 100,
         },
@@ -137,7 +136,7 @@ export class CompleteProcessor {
           queueName: JobQueue.complete,
         },
         {
-          delay: oneWeek,
+          delay: oneDay,
           removeOnComplete: 10,
           removeOnFail: 100,
         },


### PR DESCRIPTION
removes the caching of results using redis. HSDS contains its own cacheing, so this could help
reduce load on redis for other features like the queue.

closes #4222