### PR TITLE
feat(dispatch,platform): disabled 2d plots for 1d data

### DIFF
--- a/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
+++ b/libs/datamodel/simulation-runs/src/lib/simulation-run.ts
@@ -66,6 +66,7 @@ export interface VegaVisualization {
   userDesigned: false;
   renderer: 'Vega';
   vegaSpec: Observable<VegaSpec | false>;
+  enabled: true;
 }
 
 export interface SedPlot2DVisualization {
@@ -75,6 +76,7 @@ export interface SedPlot2DVisualization {
   userDesigned: false;
   renderer: 'Plotly';
   plotlyDataLayout: Observable<Observable<PlotlyDataLayout>>;
+  enabled: true;
 }
 
 export interface Histogram1DVisualization {
@@ -88,6 +90,7 @@ export interface Histogram1DVisualization {
   uriSedDataSetMap: UriSedDataSetMap;
   plotlyDataLayoutSubject: BehaviorSubject<Observable<PlotlyDataLayout | null>>;
   plotlyDataLayout: Observable<Observable<PlotlyDataLayout | null>>;
+  enabled: boolean;
 }
 
 export interface Heatmap2DVisualization {
@@ -101,6 +104,7 @@ export interface Heatmap2DVisualization {
   uriSedDataSetMap: UriSedDataSetMap;
   plotlyDataLayoutSubject: BehaviorSubject<Observable<PlotlyDataLayout | null>>;
   plotlyDataLayout: Observable<Observable<PlotlyDataLayout | null>>;
+  enabled: boolean;
 }
 
 export interface Line2DVisualization {
@@ -114,6 +118,7 @@ export interface Line2DVisualization {
   uriSedDataSetMap: UriSedDataSetMap;
   plotlyDataLayoutSubject: BehaviorSubject<Observable<PlotlyDataLayout | null>>;
   plotlyDataLayout: Observable<Observable<PlotlyDataLayout | null>>;
+  enabled: boolean;
 }
 
 export type DesignVisualization =

--- a/libs/simulation-runs/service/src/lib/view/view.service.ts
+++ b/libs/simulation-runs/service/src/lib/view/view.service.ts
@@ -930,6 +930,7 @@ export class ViewService {
           );
 
           const uriSedDataSetMap: UriSedDataSetMap = {};
+          let hasData2D = false;
           sedmlArchiveContents.forEach(
             (sedDocLocation: SimulationRunSedDocument): void => {
               const sedDoc = deserializeSedDocument({
@@ -943,6 +944,13 @@ export class ViewService {
                 dataGenerators: sedDocLocation.dataGenerators,
                 outputs: sedDocLocation.outputs,
               });
+
+              for (const simulation of sedDoc.simulations) {
+                if (simulation._type === 'SedUniformTimeCourseSimulation' && simulation.numberOfSteps >= 1) {
+                  hasData2D = true;
+                  break;
+                }
+              }
 
               sedDoc.outputs.forEach((output: SedOutput): void => {
                 if (output._type === 'SedReport') {
@@ -979,6 +987,7 @@ export class ViewService {
             renderer: 'Plotly',
             plotlyDataLayoutSubject: behaviorSubject,
             plotlyDataLayout: behaviorSubject.asObservable(),
+            enabled: true,
           });
 
           behaviorSubject = new BehaviorSubject<
@@ -995,6 +1004,7 @@ export class ViewService {
             renderer: 'Plotly',
             plotlyDataLayoutSubject: behaviorSubject,
             plotlyDataLayout: behaviorSubject.asObservable(),
+            enabled: hasData2D,
           });
 
           behaviorSubject = new BehaviorSubject<
@@ -1011,6 +1021,7 @@ export class ViewService {
             renderer: 'Plotly',
             plotlyDataLayoutSubject: behaviorSubject,
             plotlyDataLayout: behaviorSubject.asObservable(),
+            enabled: hasData2D,
           });
 
           const designVisualizationsList: VisualizationList[] = [
@@ -1064,6 +1075,7 @@ export class ViewService {
           }),
           shareReplay(1),
         ),
+      enabled: true,
     };
   }
 
@@ -1107,6 +1119,7 @@ export class ViewService {
           shareReplay(1),
         ),
       ),
+      enabled: true,
     };
   }
 

--- a/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.spec.ts
+++ b/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.spec.ts
@@ -32,6 +32,7 @@ describe('RenderVisualizationComponent', () => {
       userDesigned: false,
       renderer: 'Vega',
       vegaSpec: of(false),
+      enabled: true,
     };
     fixture.detectChanges();
   });

--- a/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.html
+++ b/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.html
@@ -15,6 +15,7 @@
               <mat-option
                 *ngFor="let visualization of visualizationList.visualizations"
                 [value]="visualization"
+                [disabled]="!visualization.enabled"
               >
                 {{ visualization.name }}
               </mat-option>


### PR DESCRIPTION
Closes #4238 

Basically, this disables 2D line and heatmap plots for 
- One step simulations (not currently used)
- Steady-state simulations (e.g., FBA, RBA)

This should avoid users being confused about why FBA results don't display with 2D line plots (because the data is 1D).