### PR TITLE
fix(dispatch-service): fix temporary directories for containers

### DIFF
--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -66,7 +66,7 @@ export class HpcService {
 
     const sbatchFilename = `${simDirname}/job.sbatch`;
     // eslint-disable-next-line max-len
-    const command = `mkdir ${simDirname} && echo "${sbatchString}" > ${sbatchFilename} && chmod +x ${sbatchFilename} && sbatch ${sbatchFilename}`;
+    const command = `mkdir -p ${simDirname} && { cat > ${sbatchFilename} << 'EOF'\n${sbatchString}\nEOF\n} && chmod +x ${sbatchFilename} && sbatch ${sbatchFilename}`;
 
     const res = this.sshService.execStringCommand(command);
 

--- a/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
+++ b/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
@@ -41,6 +41,7 @@ export class SshService {
   public getSSHJobOutputsDirectory(id: string): string {
     return path.join(this.hpcBase, id, 'outputs');
   }
+
   public async execStringCommand(
     cmd: string,
     retryCount = 0,

--- a/libs/shared/storage/src/lib/file-paths.ts
+++ b/libs/shared/storage/src/lib/file-paths.ts
@@ -152,7 +152,7 @@ export class FilePaths {
     runId: string,
     absolute = true,
   ): string {
-    const relativePath = `${runId}.zip`;
+    const relativePath = OutputFileName.OUTPUT_ARCHIVE;
     if (absolute) {
       return this.getSimulationRunPath(runId, relativePath);
     } else {


### PR DESCRIPTION
Closes #4281
Closes #4262
Closes #4302  

With this change, I was able to run simulations with Smoldyn in UConn HPC.

I now see this in the log, but it doesn't seem to prevent execution
```
_XSERVTransmkdir: Owner of /tmp/.X11-unix should be set to root
```

Replaces #4282 