### PR TITLE
build: enable production to be deployed even if dev tests failed (and failures were manually reviewed)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -199,14 +199,26 @@ jobs:
             --test true \
             --stress 1
 
+  reviewDevDeploymentTests:
+    name: Review the tests of the development deployment
+    runs-on: ubuntu-latest
+    needs:
+      - buildPushDockerImages
+      - buildProdFrontEnds
+      - deployDevFrontend
+      - testDevDeployment
+    if: ${{ always() }}
+    # environment: review_dev_deployment_tests_environment
+    steps:
+      - name: Print status message
+        run: |
+          echo "The tests of the development deployment were reviewed."
+
   deployProdFrontend:
       name: Publish the production frontend
       runs-on: ubuntu-latest
       needs:
-        - buildPushDockerImages
-        - buildProdFrontEnds
-        - deployDevFrontend
-        - testDevDeployment
+        - reviewDevDeploymentTests
       environment: prod_environment
       strategy:
         matrix:
@@ -240,10 +252,7 @@ jobs:
     name: Trigger a new deployment of the production backend
     runs-on: ubuntu-latest
     needs:
-      - buildPushDockerImages
-      - buildProdFrontEnds
-      - deployDevFrontend
-      - testDevDeployment
+      - reviewDevDeploymentTests
     environment: prod_environment
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -207,7 +207,11 @@ jobs:
       - buildProdFrontEnds
       - deployDevFrontend
       - testDevDeployment
-    if: ${{ always() }}
+    if: |
+      needs.buildPushDockerImages.result == 'success'
+      && needs.buildProdFrontEnds.result == 'success'
+      && needs.deployDevFrontend.result == 'success'
+      && (needs.testDevDeployment.outcome == 'success' || needs.testDevDeployment.outcome == 'failure')
     # environment: review_dev_deployment_tests_environment
     steps:
       - name: Print status message


### PR DESCRIPTION
Edited deployment workflow to enable production to be deployed even if the tests of the dev deployment don't succeed. 

Combined with the existing use of the `prod_environment` environment, this allows us to manually review the results and make a decision, which could include ignoring a failure.

- Created a new job `reviewDevDeploymentTests` 
  - Has the original dependencies of the `deployProdFrontend` and `triggerProdDeployment` jobs
  - Runs even if those dependencies don't all succeed
- Made the `deployProdFrontend` and `triggerProdDeployment` jobs dependent on the new job
- Removed the original dependencies of the `deployProdFrontend` and `triggerProdDeployment` jobs