### PR TITLE
fix(dispatch): ensure params can be fetched for models provided by url

### DIFF
--- a/libs/simulation-project-utils/ui/src/lib/create-project/create-project/create-project.component.ts
+++ b/libs/simulation-project-utils/ui/src/lib/create-project/create-project/create-project.component.ts
@@ -634,20 +634,17 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
       this.modelParametersAndVariablesSubscription = undefined;
     }
 
-    const modelLocationTypeControl = this.formGroup.controls
-      .modelLocationType as FormControl;
-    const modelLocationDetailsControl = this.formGroup.controls
-      .modelLocationDetails as FormControl;
+    const modelLocationTypeControl = this.formGroup.controls.modelLocationType;
+    const modelLocationDetailsControl = this.formGroup.controls.modelLocationDetails;
 
     const modelLocationType: LocationType = modelLocationTypeControl.value;
-    const modelLocationDetails: File | string | undefined =
-      modelLocationDetailsControl.value?.files?.[0];
+    const modelFile: File = modelLocationDetailsControl.value?.files?.[0];
+    const modelUrl: string = modelLocationDetailsControl.value;
 
-    if (
-      !modelLocationDetails ||
-      (modelLocationType == LocationType.url &&
-        !isUrl(modelLocationDetails as string))
-    ) {
+    const missingFileForFileType = modelLocationType == LocationType.file && !modelFile;
+    const badUrlForUrlType = modelLocationType == LocationType.url && (!modelUrl || !isUrl(modelUrl));
+
+    if (missingFileForFileType || badUrlForUrlType) {
       return;
     }
 
@@ -682,9 +679,9 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
 
     const formData = new FormData();
     if (modelLocationType === LocationType.file) {
-      formData.append('modelFile', modelLocationDetails);
+      formData.append('modelFile', modelFile);
     } else {
-      formData.append('modelUrl', modelLocationDetails);
+      formData.append('modelUrl', modelUrl);
     }
     const modelLanguage =
       this.edamIdFormatMap[modelFormat]?.biosimulationsMetadata
@@ -709,7 +706,7 @@ export class CreateProjectComponent implements OnInit, OnDestroy {
           'This feature is only currently available for models encoded in BNGL, CellML, SBML, SBML-fbc, ' +
           'SBML-qual, and Smoldyn. Please refresh to try again.';
         if (modelLocationType === LocationType.url) {
-          msg += ` Please check that ${modelLocationDetails} is an accessible URL.`;
+          msg += ` Please check that ${modelUrl} is an accessible URL.`;
         }
 
         this.snackBar.open(msg, 'Ok', {


### PR DESCRIPTION
Currently a bug prevents the get-parameters-variables-for-simulation from being hit when uploading a
model via url through the create project form. This commit fixes this issue.

**What new features does this PR implement?**
N/A

**What bugs does this PR fix?**
When location type is set to url, then the file will always be missing, and this conditional will always resolve to false. The result is that when using the create project flow, and uploading a model via a url, the algorithm parameters, model changes, and model namespaces will not be preloaded. This could result in users uploading models with incorrect settings or failing to complete the form at all.

**Does this PR introduce any additional changes?**
N/A

**How have you tested this PR?**
- I used the production create project form and confirmed that no network call to get-parameters-and-variables-for-simulation occurs when using a model url. 
- After making this change, I tried the same process again, and confirmed that the network call is sent and that a SedDoc is returned.
- I followed the process again with the same file but uploaded locally and confirmed that the network call is still sent and returns successfully in this case as well. 

**Additional information**
I have a commit to redesign this form and do some code clean up coming, and discovered this bug while testing it. It seemed impactful enough that I should break it into a pr of its own. 
