### PR TITLE
fix(dispatch): fix data generator id set during archive creation

### DIFF
--- a/libs/simulation-project-utils/service/src/lib/create-project/archive-creation.ts
+++ b/libs/simulation-project-utils/service/src/lib/create-project/archive-creation.ts
@@ -217,7 +217,7 @@ function CreateSedDataSetAndGenerators(
 
     const dataGen: SedDataGenerator = {
       _type: SedDataGeneratorTypeEnum.SedDataGenerator,
-      id: 'data_generator_' + variable.id,
+      id: 'data_generator_' + rawId,
       parameters: [],
       variables: [variable],
       math: variable.id,


### PR DESCRIPTION
Ensure the id set on the data generator created during frontend archive creation matches
'data_generator' + the id of the data set

**What bugs does this PR fix?**
I noticed this small error when diff'ing an archive downloaded from the old project creation flow with one from the reworked flow. DataGenerators originally would be named like: 'data_generator_flux_reaction_R_ACALD' and after my changes they were named like: 'data_generator_variable_flux_reaction_R_ACALD'. After this fix they will once again be named without the extraneous '_variable'.

Im not aware if the _variable token in the id actually causes any issues, but I figured best to revert to the original behavior just in case.
