### PR TITLE
fix(api): fix missing acroynm for cellml model language

### DIFF
--- a/libs/ontology/extra-sources/src/lib/edam-biosimulations-formats.json
+++ b/libs/ontology/extra-sources/src/lib/edam-biosimulations-formats.json
@@ -31,6 +31,7 @@
     "fileExtensions": ["cellml", "xml"],
     "moreInfoUrl": "https://www.ebi.ac.uk/ols/ontologies/edam/terms?iri=http%3A%2F%2Fedamontology.org%2Fformat_3240",
     "biosimulationsMetadata": {
+      "acronym": "CellML",
       "omexManifestUris": ["http://identifiers.org/combine.specifications/cellml"],
       "icon": "model",
       "modelFormatMetadata": {


### PR DESCRIPTION
in the summary endpoint, the information about model language metadata is loaded from a json file.
This json file was missing the "acronym" field for the cellml format.

fix #4522