### PR TITLE
refactor(dispatch): use combine-api datamodel in dispatch component

### DIFF
--- a/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
+++ b/apps/dispatch/src/app/components/run/dispatch/dispatch.component.ts
@@ -15,19 +15,23 @@ import {
 } from '@biosimulations/simulation-project-utils/service';
 import { Simulation } from '../../../datamodel';
 import {
-  CombineArchiveSedDocSpecs,
-  CombineArchiveSedDocSpecsContent,
-  SedDocument,
-  SedModel,
-  SedSimulation,
-  Purpose,
   AlgorithmSubstitutionPolicyLevels,
   ALGORITHM_SUBSTITUTION_POLICIES,
   AlgorithmSubstitution,
   AlgorithmSubstitutionPolicy,
   AlgorithmSummary,
+  EnvironmentVariable,
+  Purpose,
+  SimulationRun,
+  SimulationRunStatus,
 } from '@biosimulations/datamodel/common';
-import { SimulationRunStatus, EnvironmentVariable, SimulationRun } from '@biosimulations/datamodel/common';
+import {
+  CombineArchiveSedDocSpecs,
+  CombineArchiveSedDocSpecsContent,
+  SedDocument,
+  SedModel,
+  SedSimulation,
+} from '@biosimulations/combine-api-angular-client';
 import { BIOSIMULATIONS_FORMATS } from '@biosimulations/ontology/extra-sources';
 import { Observable, Subscription } from 'rxjs';
 import { ConfigService } from '@biosimulations/config/angular';

--- a/apps/dispatch/src/app/services/combine-api/combine-api.service.ts
+++ b/apps/dispatch/src/app/services/combine-api/combine-api.service.ts
@@ -3,7 +3,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { catchError, shareReplay } from 'rxjs/operators';
 import { environment } from '@biosimulations/shared/environments';
-import { CombineArchiveSedDocSpecs } from '@biosimulations/datamodel/common';
+import { CombineArchiveSedDocSpecs } from '@biosimulations/combine-api-angular-client';
 import { Endpoints } from '@biosimulations/config/common';
 
 @Injectable({

--- a/libs/datamodel/common/src/lib/sedml/sedml.ts
+++ b/libs/datamodel/common/src/lib/sedml/sedml.ts
@@ -459,12 +459,6 @@ export interface CombineArchiveLocation {
   value: SedDocument | CombineArchiveContentFile;
 }
 
-export interface CombineArchiveSedDocSpecsLocation {
-  _type: 'CombineArchiveSedDocSpecsLocation';
-  path: string;
-  value: SedDocument;
-}
-
 export interface CombineArchiveContent {
   _type: 'CombineArchiveContent';
   location: CombineArchiveLocation;
@@ -472,21 +466,9 @@ export interface CombineArchiveContent {
   master: boolean;
 }
 
-export interface CombineArchiveSedDocSpecsContent {
-  _type: 'CombineArchiveSedDocSpecsContent';
-  location: CombineArchiveSedDocSpecsLocation;
-  format: string;
-  master: boolean;
-}
-
 export interface CombineArchive {
   _type: 'CombineArchive';
   contents: CombineArchiveContent[];
-}
-
-export interface CombineArchiveSedDocSpecs {
-  _type: 'CombineArchiveSedDocSpecs';
-  contents: CombineArchiveSedDocSpecsContent[];
 }
 
 export interface SedDocumentReports {


### PR DESCRIPTION
I noticed there are currently separate implementations of some data model objects in libs/combine-api/angular-client and libs/datamodel/common. Is there a functional reason these must be duplicated, or are the libs/datamodel instances perhaps legacy remnants from before the autogenned files in combine-api were created? If the latter is the case, then removing them and using only the data models exported from the combine-api library would make things easier.

I've created a commit that migrates a couple usages of duplicate datamodel/common types to combine-api types within the dispatch component, and then deletes the duplicated types. If we like this approach, and these duplicate types are not needed for another reason, I can take this further and migrate off of and then delete more duplicated types.