### PR TITLE
build: fix typo in container registry domain

### DIFF
--- a/libs/hpc/singularity-builder/src/lib/hpc-singularity-builder.spec.ts
+++ b/libs/hpc/singularity-builder/src/lib/hpc-singularity-builder.spec.ts
@@ -17,7 +17,7 @@ const data = {
   singularityModule: 'singularity',
   singularityCacheDir: '/tmp/singularitycachedir',
   forceOverwrite: false,
-  dockerImageUrl: 'gchr.io/biosimulations/tellurium:1.0.0',
+  dockerImageUrl: 'ghcr.io/biosimulations/tellurium:1.0.0',
 };
 describe('hpcSingularityBuilder', () => {
   const expected = `#!/bin/bash
@@ -49,7 +49,7 @@ export SINGULARITY_PULLFOLDER=/tmp/singularity-pull
 echo "Building image with Singularity '$(singularity --version)' on '$(hostname)' ... "
 
 # build image
-singularity -v pull --tmpdir /local  gchr.io/biosimulations/tellurium:1.0.0`;
+singularity -v pull --tmpdir /local  ghcr.io/biosimulations/tellurium:1.0.0`;
 
   const expectedOverwrite = `#!/bin/bash
 #SBATCH --job-name=Build-simulator-tellurium-1.0.0
@@ -80,7 +80,7 @@ export SINGULARITY_PULLFOLDER=/tmp/singularity-pull
 echo "Building image with Singularity '$(singularity --version)' on '$(hostname)' ... "
 
 # build image
-singularity -v pull --tmpdir /local --force gchr.io/biosimulations/tellurium:1.0.0`;
+singularity -v pull --tmpdir /local --force ghcr.io/biosimulations/tellurium:1.0.0`;
   it('should generate sbatch', () => {
     expect(generateImageUpdateSbatch(data)).toEqual(expected);
   });


### PR DESCRIPTION
Hi `biosimulations/biosimulations`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used - In some cases it's only a matter of wrongly tagged container images)
Please verify the changes made with this PR and check your documentation for similar typos.