### PR TITLE
fix: combine-api CORS to allow biosimulations.org/dev

### DIFF
--- a/apps/combine-api/combine_api/app.py
+++ b/apps/combine-api/combine_api/app.py
@@ -102,5 +102,7 @@ CORS(app.app,
          'https://www.biosimulators.dev',
          'https://run.biosimulations.dev',
          'https://run.biosimulations.org',
+         'https://biosimulations.dev',
+         'https://biosimulations.org',
          'https://bio.libretexts.org',
      ])


### PR DESCRIPTION
**What new features does this PR implement?**
adds biosimulations.dev and biosimulations.org to CORS for combine-api service.
