### PR TITLE
fix: patch to production app for dev projects page - DO NOT MERGE

### DIFF
--- a/apps/platform/src/app/app.component.html
+++ b/apps/platform/src/app/app.component.html
@@ -13,7 +13,7 @@
         heading="Simulation projects"
         icon="project"
         id="trigger"
-        [routerLink]="['/projects']"
+        [href]="config.platformAppProjectsUrl"
       >
       </biosimulations-topbar-menu-item>
 
@@ -21,7 +21,7 @@
         <biosimulations-dropdown-menu-item
           heading="Browse"
           icon="browse"
-          [routerLink]="['/projects']"
+          [href]="config.platformAppProjectsUrl"
         >
         </biosimulations-dropdown-menu-item>
 
@@ -260,7 +260,7 @@
       <biosimulations-navigation-subitem
         heading="Browse"
         icon="browse"
-        [route]="['/projects', 'browse']"
+        [href]="config.platformAppProjectsUrl"
       >
       </biosimulations-navigation-subitem>
       <biosimulations-navigation-subitem

--- a/apps/platform/src/app/home/home.component.html
+++ b/apps/platform/src/app/home/home.component.html
@@ -16,7 +16,7 @@
     </biosimulations-home-teaser-button>
 
     <biosimulations-home-teaser-button
-      [route]="['/projects']"
+      [href]="config.platformAppProjectsUrl"
       width="180px"
       color="primary"
     >

--- a/apps/platform/src/app/home/home.component.html
+++ b/apps/platform/src/app/home/home.component.html
@@ -67,7 +67,8 @@
     BioSimulations supports a wide range of frameworks (e.g., logical,
     Flux-Balance Analysis (FBA), continuous kinetic, discrete kinetic),
     simulation algorithms (e.g., FBA, SSA), model formats (e.g., SBML), and
-    tools (e.g., COBRApy, COPASI, tellurium).
+    tools (e.g., COBRApy, COPASI, tellurium).<br/><br/>
+    <b>Unlock the power of biosimulations with the Reproducibility Portal — a user-friendly front end to Biosimulations DB. <br/>Explore now: </b><a href="https://explorersb-test.pages.dev"><b>Reproducibility Portal</b></a>
   </ng-container>
 </biosimulations-home-teaser>
 

--- a/apps/platform/src/app/home/home.component.html
+++ b/apps/platform/src/app/home/home.component.html
@@ -68,7 +68,7 @@
     Flux-Balance Analysis (FBA), continuous kinetic, discrete kinetic),
     simulation algorithms (e.g., FBA, SSA), model formats (e.g., SBML), and
     tools (e.g., COBRApy, COPASI, tellurium).<br/><br/>
-    <b>Unlock the power of biosimulations with the Reproducibility Portal — a user-friendly front end to Biosimulations DB. <br/>Explore now: </b><a href="https://explorersb-test.pages.dev"><b>Reproducibility Portal</b></a>
+    <b>Unlock the power of biosimulations with the Reproducibility Portal — a user-friendly front end to Biosimulations DB. <br/>Explore now: </b><a href="https://reproducibilityportal.org"><b>Reproducibility Portal</b></a>
   </ng-container>
 </biosimulations-home-teaser>
 

--- a/apps/platform/src/assets/config.json
+++ b/apps/platform/src/assets/config.json
@@ -15,6 +15,7 @@
   "newIssueUrl": "https://github.com/biosimulations/biosimulations/issues/new/choose",
   "newPullUrl": "https://github.com/biosimulations/biosimulations/compare",
   "platformAppUrl": "https://biosimulations.org/",
+  "platformAppProjectsUrl": "https://biosimulations.dev/projects",
   "platformApiUrl": "https://api.biosimulations.org/",
   "platformNewIssueUrl": "https://github.com/biosimulations/biosimulations/issues/new/choose",
   "platformNewPullUrl": "https://github.com/biosimulations/biosimulations/compare",

--- a/apps/platform/src/assets/config.json
+++ b/apps/platform/src/assets/config.json
@@ -15,7 +15,7 @@
   "newIssueUrl": "https://github.com/biosimulations/biosimulations/issues/new/choose",
   "newPullUrl": "https://github.com/biosimulations/biosimulations/compare",
   "platformAppUrl": "https://biosimulations.org/",
-  "platformAppProjectsUrl": "https://biosimulations.dev/projects",
+  "platformAppProjectsUrl": "https://patch.biosimulations.dev/projects",
   "platformApiUrl": "https://api.biosimulations.org/",
   "platformNewIssueUrl": "https://github.com/biosimulations/biosimulations/issues/new/choose",
   "platformNewPullUrl": "https://github.com/biosimulations/biosimulations/compare",

--- a/apps/simulators/project.json
+++ b/apps/simulators/project.json
@@ -83,12 +83,12 @@
             {
               "type": "initial",
               "maximumWarning": "2mb",
-              "maximumError": "5mb"
+              "maximumError": "9mb"
             },
             {
               "type": "anyComponentStyle",
               "maximumWarning": "6kb",
-              "maximumError": "10kb"
+              "maximumError": "40kb"
             }
           ]
         }

--- a/apps/simulators/src/app/app.module.ts
+++ b/apps/simulators/src/app/app.module.ts
@@ -34,7 +34,9 @@ import { AngularAnalyticsModule } from '@biosimulations/angular-analytics';
 const routes: Routes = [
   {
     path: '',
-    loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
+    redirectTo: 'simulators',
+    pathMatch: 'full',
+    // loadChildren: () => import('./home/home.module').then((m) => m.HomeModule),
   },
   {
     path: 'simulators',

--- a/libs/analytics/angular-analytics/project.json
+++ b/libs/analytics/angular-analytics/project.json
@@ -6,7 +6,7 @@
   "targets": {
     "build": {
       "executor": "@nrwl/angular:package",
-      "outputs": ["dist/libs/analytics/angular-analytics"],
+      "outputs": ["{workspaceRoot}/dist/libs/analytics/angular-analytics"],
       "options": {
         "project": "libs/analytics/angular-analytics/ng-package.json"
       },
@@ -22,7 +22,7 @@
     },
     "test": {
       "executor": "@nrwl/jest:jest",
-      "outputs": ["coverage/libs/analytics/angular-analytics"],
+      "outputs": ["{workspaceRoot}/coverage/libs/analytics/angular-analytics"],
       "options": {
         "jestConfig": "libs/analytics/angular-analytics/jest.config.js",
         "passWithNoTests": true

--- a/libs/config/angular/src/lib/config/config.service.ts
+++ b/libs/config/angular/src/lib/config/config.service.ts
@@ -15,6 +15,7 @@ export class ConfigService {
   newIssueUrl!: string;
   newPullUrl!: string;
   platformAppUrl!: string;
+  platformAppProjectsUrl!: string;
   platformApiUrl!: string;
   platformNewIssueUrl!: string;
   platformNewPullUrl!: string;

--- a/libs/shared/assets/src/_redirects
+++ b/libs/shared/assets/src/_redirects
@@ -1,2 +1,4 @@
 /api/*  https://api.biosimulations.dev/:splat  200
+/projects    https://patch.biosimulations.dev/projects    200
+/projects/*    https://patch.biosimulations.dev/projects/:splat    200
 /*    /index.html    200

--- a/libs/shared/assets/src/_redirects
+++ b/libs/shared/assets/src/_redirects
@@ -1,4 +1,5 @@
 /api/*  https://api.biosimulations.dev/:splat  200
-/projects    https://patch.biosimulations.dev/projects    200
-/projects/*    https://patch.biosimulations.dev/projects/:splat    200
+/projects    https://patch.biosimulations.dev/projects    302
+/projects/    https://patch.biosimulations.dev/projects/    302
+/projects/*    https://patch.biosimulations.dev/projects/:splat    302
 /*    /index.html    200

--- a/nx.json
+++ b/nx.json
@@ -56,8 +56,7 @@
     ]
   },
   "cli": {
-    "defaultCollection": "@nrwl/angular",
-    "analytics": false
+    "defaultCollection": "@nrwl/angular"
   },
   "defaultProject": "dispatch",
   "generators": {


### PR DESCRIPTION
**What new features does this PR implement?**
patch production site (v9.13.6) to link out to https://biosimulations.dev/projects for all project browsing, and to https://explorersb-test.pages.dev for a preview of the new simplified Reproducibility Portal.  see Issue #4688.

(_**added 6/14/2023**_) - patch production site to bypass biosimulators.org landing page, redirecting to the list of simulators at the /simulators path.  This is to avoid confusing navigation while transitioning to the new navigation scheme in the new development versions.  see Issue #4706

**What bugs does this PR fix?**
Motivation is to highlight recent development on project browsing without touching the production site (because dev site is not yet ready to replace the production site).

* Fixes "Patch Production Site to point to dev projects page" (closes #4688)

**How have you tested this PR?**
build/tested locally (localhost:4200)
will upload build directly to Netlify for only platform app at biosimulations.org - to bypass CI/CD (broken for 9.13.6) 

