### PR TITLE
fix: path for new summary_filtered and old summary api endpoints

### DIFF
--- a/libs/api/angular-client/src/lib/project/project.service.ts
+++ b/libs/api/angular-client/src/lib/project/project.service.ts
@@ -77,7 +77,7 @@ export class ProjectService {
   }
 
   public getProjectSummaries(criteria: SearchCriteria): Observable<ProjectSummaryQueryResults> {
-    const url = this.endpoints.getProjectSummariesEndpoint(false, undefined);
+    const url = this.endpoints.getProjectSummariesFilteredEndpoint(false);
     let httpParams = new HttpParams()
       .set('pageSize', criteria.pageSize)
       .set('pageIndex', criteria.pageIndex)

--- a/libs/config/common/src/lib/endpoints.ts
+++ b/libs/config/common/src/lib/endpoints.ts
@@ -208,6 +208,15 @@ export class Endpoints {
     }
   }
 
+  /** Get the URL for a summary of a project or summaries of each project
+   * @param id The id of the project
+   * @returns URL for a summary of a project or summaries of each project
+   */
+  public getProjectSummariesFilteredEndpoint(external: boolean): string {
+    const projects = this.getProjectsEndpointBaseUrl(external);
+    return `${projects}/summary_filtered`;
+  }
+
   /** Get the URL for validating a project
    */
   public getValidateProjectEndpoint(external: boolean): string {


### PR DESCRIPTION
**What new features does this PR implement?**
new `/projects/summary` api endpoint implementation was not backward compatible, so previous implementation of `/projects/summary` was restored and the new functionality is exposed at `/projects/summary_filtered` endpoint.

This change was partially performed in previous PR #4691, but the frontend api pointed to the `/projects/summary` endpoint rather than the `/projects/summary_filtered`.  This PR points to the appropriate endpoint from the frontend.

**What bugs does this PR fix?**
The frontend was calling the wrong endpoint which has a different signature, so it could not retrieve the projects.

**Does this PR introduce any additional changes?**
No.

**How have you tested this PR?**
Tested locally against a locally served api backend.  Unfortunately, testing of previous PR #4691 was flawed as it connected to a deployed backend rather than local backend. 

**Additional information**
None.
