### PR TITLE
fix: bot pushes to main branch should not trigger deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Continuous deployment
 
 on:
   release:
-    types: [published, edited]
+    types: [published]
 env:
   NX_SKIP_NX_CACHE: ${{ vars.NX_SKIP_NX_CACHE_VALUE }}
 


### PR DESCRIPTION
**What new features does this PR implement?**
deploys are being triggered by successful merges of PRs coming from dependency bots, but sometimes these deployments are incomplete.  The developers should have more control over deployments, as these are not always atomic and need manual oversight.

the trigger for the deploy.yml action should be only on release[published], not release[published,edited].  This means that in order to make a new deployment, you must create a new software release - not just edit the previous one.

**What bugs does this PR fix?**
the renovate bot merged a PR to update a dependency, and this inititated a deployment.  But this unattended deployment failed midstream and broke the deployed dev site.  bots should not deploy their changes to our dev site.

**Does this PR introduce any additional changes?**
just deploy.yml

**How have you tested this PR?**
Cannot test this until a bot merges again.

**Additional information**
It is important that we deploy this soon to refresh the broken deployment and prevent future occurances.
