### PR TITLE
feat: improved project sort order

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,14 +43,10 @@ jobs:
         with:
           useRollingCache: true
 
-      - name: Install nrwl cli
-        run: npm install -g @nrwl/cli && npm install -g nx@latest
-
-
       - name: Build dev app
         run: |
           mv libs/shared/environments/src/lib/environment.stage.ts libs/shared/environments/src/lib/environment.prod.ts \
-          && nx build ${{matrix.app}} --prod
+          && npx nx build ${{matrix.app}} --prod
 
       - name: Upload build
         uses: actions/upload-artifact@v2
@@ -96,11 +92,8 @@ jobs:
         with:
           useRollingCache: true
 
-      - name: Install nrwl cli
-        run: npm install -g @nrwl/cli && npm install -g nx@latest
-
       - name: Build prod app
-        run:  nx build ${{matrix.app}} --prod
+        run:  npx nx build ${{matrix.app}} --prod
 
       - name: Upload build
         uses: actions/upload-artifact@v2

--- a/apps/combine-api/poetry.lock
+++ b/apps/combine-api/poetry.lock
@@ -311,13 +311,13 @@ tests = ["biosimulators-utils[containers]", "python-dateutil"]
 
 [[package]]
 name = "biosimulators-utils"
-version = "0.1.180"
+version = "0.1.181"
 description = "Command-line program and library for reading, writing, validating and executing modeling projects (COMBINE/OMEX archives with SED-ML files)."
 optional = false
 python-versions = "*"
 files = [
-    {file = "biosimulators_utils-0.1.180-py2.py3-none-any.whl", hash = "sha256:0950e6fca1174e8448a2007630e1caba11971a7bda0ba63ad73f9d611a74c92b"},
-    {file = "biosimulators_utils-0.1.180.tar.gz", hash = "sha256:231ac45877262cefde29ad46e71242635b35fc0c44084ef002086149e5687cf0"},
+    {file = "biosimulators_utils-0.1.181-py2.py3-none-any.whl", hash = "sha256:9f7be8d4c21c9ea8fae2aa1272fea830b9e2610fe717c252bd51eb85fd6f7d7f"},
+    {file = "biosimulators_utils-0.1.181.tar.gz", hash = "sha256:3bfd72fad63d768a9f682e2aa668deca8d141a75e178c426579757be91d7f756"},
 ]
 
 [package.dependencies]
@@ -326,7 +326,7 @@ bionetgen = {version = ">=0.7.2", optional = true, markers = "extra == \"bngl\""
 biopython = "*"
 capturer = {version = "*", optional = true, markers = "extra == \"logging\""}
 cement = "*"
-evalidate = "*"
+evalidate = ">=2.0.0"
 h5py = "*"
 kisao = ">=2.32"
 libcellml = {version = "*", optional = true, markers = "extra == \"cellml\""}
@@ -1427,13 +1427,13 @@ files = [
 
 [[package]]
 name = "evalidate"
-version = "1.0.2"
+version = "2.0.0"
 description = "Validation and secure evaluation of untrusted python expressions"
 optional = false
 python-versions = "*"
 files = [
-    {file = "evalidate-1.0.2-py3-none-any.whl", hash = "sha256:85adf36872e431c96433930b69ab6b510014737fa6a32316b9e37cebb926e850"},
-    {file = "evalidate-1.0.2.tar.gz", hash = "sha256:7830c91fc828a27bb4e9f01db2da6fabbddafda3d067af642758b2ce33521484"},
+    {file = "evalidate-2.0.0-py3-none-any.whl", hash = "sha256:0caf82a9abb2c38ded7683789b6fc052b626998a5118466e999ca24ede2c715c"},
+    {file = "evalidate-2.0.0.tar.gz", hash = "sha256:c74ff15ccaa3fe8e6a384d4978d41ba53f31b84f4a49bffdf5c99a086b5a815f"},
 ]
 
 [[package]]
@@ -5446,4 +5446,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "780d07c90bbdadc81097b5db80fcbf87014e5f15bfb950daacc7122aff4df01c"
+content-hash = "be5f963eab334eec5f4419ca22178bfd66256aa260a45565fe15ec8cff8f1a0a"

--- a/apps/combine-api/pyproject.toml
+++ b/apps/combine-api/pyproject.toml
@@ -18,7 +18,7 @@ orjson = "^3.8.7"
 flask-cors = "^3.0.10"
 pyyaml = "^6.0"
 boto3 = "^1.26.89"
-biosimulators_utils = {extras = ["bngl", "cellml", "lems", "logging", "neuroml", "sbml", "smoldyn"], version = "^0.1.180"}
+biosimulators_utils = {extras = ["bngl", "cellml", "lems", "logging", "neuroml", "sbml", "smoldyn"], version = "^0.1.181"}
 parameterized = "^0.8.1"
 pytest = "^7.2.2"
 swagger-ui-bundle = "^0.0.9"

--- a/docs/src/developers/setup/services.md
+++ b/docs/src/developers/setup/services.md
@@ -12,7 +12,7 @@ The BioSimulations apps requires connecting to several infrastructure services f
     We recommend running a local redis container with the following command:
 
     ```bash
-    docker run -d -p 6379:6379 --network host --name redis redis
+    docker run -d -p 6379:6379 --name redis redis
     ```
 
 - NATS messaging queue
@@ -22,7 +22,7 @@ The BioSimulations apps requires connecting to several infrastructure services f
     We recommend running a local NATS container with the following command:
 
     ```bash
-    docker run -d -p 4222:4222 --network host --name nats nats
+    docker run -d -p 4222:4222 --name nats nats
     ```
 
 - MongoDB
@@ -31,7 +31,7 @@ The BioSimulations apps requires connecting to several infrastructure services f
 
     We recommend running a local MongoDB container with the following command:
     ```bash
-    docker run -d -p 27017:27017 --network host --name mongodb mongo
+    docker run -d -p 27017:27017 --name mongodb mongo
     ```
 
     Alternatively, you can use a free MongoDB cluster from [MongoDB Atlas](https://www.mongodb.com/cloud/atlas/).


### PR DESCRIPTION
**What new features does this PR implement?**
apply a sort order to the project list which features projects which are more completely curated.

ideally, a new field 'curation score' would be added to the Project collection in Mongodb, but since the dev and production sites are temporarily sharing the same database, this was implemented entirely in memory.

A small amount of tech debt to be paid back shortly after we update the production site.

