### PR TITLE
fix: project list pagination with filtering showed no projects

### DIFF
--- a/apps/api/src/projects/projects.service.ts
+++ b/apps/api/src/projects/projects.service.ts
@@ -220,7 +220,7 @@ export class ProjectsService implements OnModuleInit {
     pageIndex: number,
     filters: ProjectFilterQueryItem[],
   ): Promise<ProjectSummaryQueryResults> {
-    return this.getProjectSummariesWithoutSearch_withoutSort(0, maxNumRecordsToTextSearch, filters).then(
+    return this.getProjectSummariesWithoutSearch_withoutSort(maxNumRecordsToTextSearch, 0, filters).then(
       (results: ProjectSummaryQueryResults) => {
         return {
           ...results,


### PR DESCRIPTION
**What new features does this PR implement?**
### Problem
The Biosimulations projects page displayed a blank project list when a filter is used without a search term.
### Solution
fixed project api for filtering, page size and page index were transposed.

**How have you tested this PR?**
Tested manually, locally.  Proper unit tests are needed.