### PR TITLE
fix: s3 import in combine-api and updated create-project unit tests

### DIFF
--- a/apps/combine-api/combine_api/handlers/combine/create.py
+++ b/apps/combine-api/combine_api/handlers/combine/create.py
@@ -14,7 +14,7 @@ from biosimulators_utils.sedml.io import (
 import connexion
 import flask
 import os
-import combine_api
+import combine_api.s3
 import requests
 import requests.exceptions
 import werkzeug.datastructures  # noqa: F401

--- a/apps/combine-api/tests/combine/test_create_combine_archive.py
+++ b/apps/combine-api/tests/combine/test_create_combine_archive.py
@@ -1,10 +1,12 @@
 from biosimulators_utils.combine.io import CombineArchiveReader
 from biosimulators_utils.sedml.io import SedmlSimulationReader
 from combine_api import app
+from combine_api.app_config import ENVVAR_STORAGE_SECRET
 from unittest import mock
 from werkzeug.datastructures import MultiDict
 import json
 import os
+import pytest
 import shutil
 import tempfile
 import unittest
@@ -165,6 +167,89 @@ class CreateCombineArchiveTestCase(unittest.TestCase):
         archive = CombineArchiveReader().run(downloaded_archive_filename, contents_dirname)
 
         self.assertEqual(len(archive.contents), 3)
+
+
+    def test_create_combine_archive_with_uploaded_model_file_and_download_biomd0000000010(self):
+        # Repressilator-Elowitz-Nature-2000
+        endpoint = '/combine/create'
+
+        archive_specs_filename = os.path.join(
+            self.FIXTURES_DIR, 'BIOMD0000000010-archive-specs.json')
+        with open(archive_specs_filename, 'rb') as file:
+            archive_specs = json.load(file)
+
+        file_0_path = os.path.abspath(os.path.join(self.FIXTURES_DIR, 'BIOMD0000000010.xml'))
+        # file_1_path = os.path.abspath(os.path.join(self.FIXTURES_DIR, 'file.txt'))
+        archive_specs['contents'][0]['location']['value']['filename'] = file_0_path
+        # archive_specs['contents'][1]['location']['value']['filename'] = file_1_path
+
+        fid_0 = open(file_0_path, 'rb')
+        # fid_1 = open(file_1_path, 'rb')
+
+        data = MultiDict([
+            ('specs', json.dumps(archive_specs)),
+            ('files', fid_0),
+            # ('files', fid_1),
+            ('download', True),
+        ])
+        with app.app.app.test_client() as client:
+            archive_filename = os.path.join(self.temp_dirname, 'archive.omex')
+
+            response = client.post(endpoint, data=data, content_type="multipart/form-data")
+
+        fid_0.close()
+        # fid_1.close()
+
+        self.assertEqual(response.status_code, 200, response.json)
+        self.assertEqual(response.content_type, 'application/zip')
+        downloaded_archive_filename = os.path.join(self.temp_dirname, 'archive-downloaded.omex')
+        with open(downloaded_archive_filename, 'wb') as file:
+            file.write(response.data)
+
+        contents_dirname = os.path.join(self.temp_dirname, 'archive')
+        archive = CombineArchiveReader().run(downloaded_archive_filename, contents_dirname)
+
+        self.assertEqual(len(archive.contents), 2)
+
+    @pytest.mark.skipif(ENVVAR_STORAGE_SECRET not in os.environ,
+                        reason=f"S3 test skipped, S3 config {ENVVAR_STORAGE_SECRET} not supplied")
+    def test_create_combine_archive_with_uploaded_model_file_and_save_to_s3_biomd0000000010(self):
+        # Repressilator-Elowitz-Nature-2000
+        endpoint = '/combine/create'
+
+        archive_specs_filename = os.path.join(
+            self.FIXTURES_DIR, 'BIOMD0000000010-archive-specs.json')
+        with open(archive_specs_filename, 'rb') as file:
+            archive_specs = json.load(file)
+
+        file_0_path = os.path.abspath(os.path.join(self.FIXTURES_DIR, 'BIOMD0000000010.xml'))
+        archive_specs['contents'][0]['location']['value']['filename'] = file_0_path
+
+        fid_0 = open(file_0_path, 'rb')
+
+        data = MultiDict([
+            ('specs', json.dumps(archive_specs)),
+            ('files', fid_0),
+            ('download', False),
+        ])
+        with app.app.app.test_client() as client:
+            archive_filename = os.path.join(self.temp_dirname, 'archive.omex')
+
+            response = client.post(endpoint, data=data, content_type="multipart/form-data")
+
+        fid_0.close()
+
+        self.assertEqual(response.status_code, 200, response.json)
+        self.assertEqual(response.content_type, 'application/zip')
+        downloaded_archive_filename = os.path.join(self.temp_dirname, 'archive-downloaded.omex')
+        with open(downloaded_archive_filename, 'wb') as file:
+            file.write(response.data)
+
+        contents_dirname = os.path.join(self.temp_dirname, 'archive')
+        archive = CombineArchiveReader().run(downloaded_archive_filename, contents_dirname)
+
+        self.assertEqual(len(archive.contents), 2)
+
 
     def test_create_combine_archive_with_model_at_url(self):
         endpoint = '/combine/create'

--- a/apps/combine-api/tests/fixtures/BIOMD0000000010-archive-specs.json
+++ b/apps/combine-api/tests/fixtures/BIOMD0000000010-archive-specs.json
@@ -1,0 +1,362 @@
+{
+  "_type": "CombineArchive",
+  "contents": [
+    {
+      "_type": "CombineArchiveContent",
+      "format": "http://identifiers.org/combine.specifications/sbml",
+      "master": false,
+      "location": {
+        "_type": "CombineArchiveLocation",
+        "path": "model.xml",
+        "value": {
+          "_type": "CombineArchiveContentFile",
+          "filename": "BIOMD0000000010_url.xml"
+        }
+      }
+    },
+    {
+      "_type": "CombineArchiveContent",
+      "format": "http://identifiers.org/combine.specifications/sed-ml",
+      "master": true,
+      "location": {
+        "_type": "CombineArchiveLocation",
+        "path": "simulation.sedml",
+        "value": {
+          "_type": "SedDocument",
+          "level": 1,
+          "version": 3,
+          "styles": [],
+          "models": [
+            {
+              "_type": "SedModel",
+              "id": "model",
+              "language": "urn:sedml:language:sbml",
+              "source": "model.xml",
+              "changes": []
+            }
+          ],
+          "simulations": [
+            {
+              "_type": "SedUniformTimeCourseSimulation",
+              "id": "simulation",
+              "initialTime": 0,
+              "outputStartTime": 0,
+              "outputEndTime": 1,
+              "numberOfSteps": 10,
+              "algorithm": {
+                "_type": "SedAlgorithm",
+                "kisaoId": "KISAO_0000019",
+                "changes": []
+              }
+            }
+          ],
+          "tasks": [
+            {
+              "_type": "SedTask",
+              "id": "task",
+              "model": "model",
+              "simulation": "simulation"
+            }
+          ],
+          "dataGenerators": [
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_time",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_time",
+                  "task": "task",
+                  "name": "Time",
+                  "symbol": "urn:sedml:symbol:time"
+                }
+              ],
+              "math": "variable_time",
+              "name": "Time"
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MAPK",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MAPK",
+                  "task": "task",
+                  "name": "Dynamics of species \"Erk2\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MAPK']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MAPK",
+              "name": "Dynamics of species \"Erk2\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MAPK_P",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MAPK_P",
+                  "task": "task",
+                  "name": "Dynamics of species \"Erk2-P\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MAPK_P']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MAPK_P",
+              "name": "Dynamics of species \"Erk2-P\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MAPK_PP",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MAPK_PP",
+                  "task": "task",
+                  "name": "Dynamics of species \"Erk2-PP\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MAPK_PP']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MAPK_PP",
+              "name": "Dynamics of species \"Erk2-PP\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MKK",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MKK",
+                  "task": "task",
+                  "name": "Dynamics of species \"Mek1\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MKK']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MKK",
+              "name": "Dynamics of species \"Mek1\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MKK_P",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MKK_P",
+                  "task": "task",
+                  "name": "Dynamics of species \"Mek1-P\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MKK_P']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MKK_P",
+              "name": "Dynamics of species \"Mek1-P\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MKK_PP",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MKK_PP",
+                  "task": "task",
+                  "name": "Dynamics of species \"Mek1-PP\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MKK_PP']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MKK_PP",
+              "name": "Dynamics of species \"Mek1-PP\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MKKK",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MKKK",
+                  "task": "task",
+                  "name": "Dynamics of species \"Mos\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MKKK']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MKKK",
+              "name": "Dynamics of species \"Mos\""
+            },
+            {
+              "_type": "SedDataGenerator",
+              "id": "data_generator_dynamics_species_MKKK_P",
+              "parameters": [],
+              "variables": [
+                {
+                  "_type": "SedVariable",
+                  "id": "variable_dynamics_species_MKKK_P",
+                  "task": "task",
+                  "name": "Dynamics of species \"Mos-P\"",
+                  "target": {
+                    "_type": "SedTarget",
+                    "value": "/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id='MKKK_P']",
+                    "namespaces": [
+                      {
+                        "_type": "Namespace",
+                        "uri": "http://www.sbml.org/sbml/level2/version4",
+                        "prefix": "sbml"
+                      }
+                    ]
+                  }
+                }
+              ],
+              "math": "variable_dynamics_species_MKKK_P",
+              "name": "Dynamics of species \"Mos-P\""
+            }
+          ],
+          "outputs": [
+            {
+              "_type": "SedReport",
+              "id": "report",
+              "dataSets": [
+                {
+                  "_type": "SedDataSet",
+                  "id": "time",
+                  "label": "Time",
+                  "dataGenerator": "data_generator_time",
+                  "name": "Time"
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MAPK",
+                  "label": "Dynamics of species \"Erk2\"",
+                  "dataGenerator": "data_generator_dynamics_species_MAPK",
+                  "name": "Dynamics of species \"Erk2\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MAPK_P",
+                  "label": "Dynamics of species \"Erk2-P\"",
+                  "dataGenerator": "data_generator_dynamics_species_MAPK_P",
+                  "name": "Dynamics of species \"Erk2-P\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MAPK_PP",
+                  "label": "Dynamics of species \"Erk2-PP\"",
+                  "dataGenerator": "data_generator_dynamics_species_MAPK_PP",
+                  "name": "Dynamics of species \"Erk2-PP\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MKK",
+                  "label": "Dynamics of species \"Mek1\"",
+                  "dataGenerator": "data_generator_dynamics_species_MKK",
+                  "name": "Dynamics of species \"Mek1\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MKK_P",
+                  "label": "Dynamics of species \"Mek1-P\"",
+                  "dataGenerator": "data_generator_dynamics_species_MKK_P",
+                  "name": "Dynamics of species \"Mek1-P\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MKK_PP",
+                  "label": "Dynamics of species \"Mek1-PP\"",
+                  "dataGenerator": "data_generator_dynamics_species_MKK_PP",
+                  "name": "Dynamics of species \"Mek1-PP\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MKKK",
+                  "label": "Dynamics of species \"Mos\"",
+                  "dataGenerator": "data_generator_dynamics_species_MKKK",
+                  "name": "Dynamics of species \"Mos\""
+                },
+                {
+                  "_type": "SedDataSet",
+                  "id": "dynamics_species_MKKK_P",
+                  "label": "Dynamics of species \"Mos-P\"",
+                  "dataGenerator": "data_generator_dynamics_species_MKKK_P",
+                  "name": "Dynamics of species \"Mos-P\""
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/apps/combine-api/tests/fixtures/BIOMD0000000010.xml
+++ b/apps/combine-api/tests/fixtures/BIOMD0000000010.xml
@@ -1,0 +1,704 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" metaid="_492719" level="2" version="4">
+  <model metaid="_000001" id="BIOMD0000000010" name="Kholodenko2000 - Ultrasensitivity and negative feedback bring oscillations in MAPK cascade">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <div class="dc:title">Kholodenko2000 - Ultrasensitivity and negative feedback bring oscillations in MAPK cascade</div>
+        <div class="dc:description">
+          <p>The combination of ultrasensitivity and negative feedback bring sustained oscillations in the mitogen-activated protein kinase cascades.</p>
+        </div>
+        <div class="dc:bibliographicCitation">
+          <p>This model is described in the article:</p>
+          <div class="bibo:title">
+            <a href="http://identifiers.org/pubmed/10712587" title="Access to this publication">Negative feedback and ultrasensitivity can bring about oscillations in the mitogen-activated protein kinase cascades.</a>
+          </div>
+          <div class="bibo:authorList">Kholodenko BN</div>
+          <div class="bibo:Journal">Eur. J. Biochem. 2000; 267(6):1583-8</div>
+          <p>Abstract:</p>
+          <div class="bibo:abstract">
+            <p>Functional organization of signal transduction into protein phosphorylation cascades, such as the mitogen-activated protein kinase (MAPK) cascades, greatly enhances the sensitivity of cellular targets to external stimuli. The sensitivity increases multiplicatively with the number of cascade levels, so that a tiny change in a stimulus results in a large change in the response, the phenomenon referred to as ultrasensitivity. In a variety of cell types, the MAPK cascades are imbedded in long feedback loops, positive or negative, depending on whether the terminal kinase stimulates or inhibits the activation of the initial level. Here we demonstrate that a negative feedback loop combined with intrinsic ultrasensitivity of the MAPK cascade can bring about sustained oscillations in MAPK phosphorylation. Based on recent kinetic data on the MAPK cascades, we predict that the period of oscillations can range from minutes to hours. The phosphorylation level can vary between the base level and almost 100% of the total protein. The oscillations of the phosphorylation cascades and slow protein diffusion in the cytoplasm can lead to intracellular waves of phospho-proteins.</p>
+          </div>
+        </div>
+        <div class="dc:publisher">
+          <p>This model is hosted on        <a href="http://www.ebi.ac.uk/biomodels/">BioModels Database</a>
+            and identified by:        <a href="http://identifiers.org/biomodels.db/BIOMD0000000010">BIOMD0000000010</a>
+            .        </p>
+          <p>To cite BioModels Database, please use:        <a href="http://identifiers.org/pubmed/20587024" title="Latest BioModels Database publication">BioModels Database: An enhanced, curated and annotated resource for published quantitative kinetic models</a>
+            .        </p>
+        </div>
+        <div class="dc:license">
+          <p>To the extent possible under law, all copyright and related or neighbouring rights to this encoded model have been dedicated to the public domain worldwide. Please refer to        <a href="http://creativecommons.org/publicdomain/zero/1.0/" title="Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication">CC0 Public Domain Dedication</a>
+            for more information.        </p>
+        </div>
+      </body>
+    </notes>
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+        <rdf:Description rdf:about="#_000001">
+          <dc:creator>
+            <rdf:Bag>
+              <rdf:li rdf:parseType="Resource">
+                <vCard:N rdf:parseType="Resource">
+                  <vCard:Family>Sauro</vCard:Family>
+                  <vCard:Given>Herbert</vCard:Given>
+                </vCard:N>
+                <vCard:EMAIL>Herbert_Sauro@kgi.edu</vCard:EMAIL>
+                <vCard:ORG rdf:parseType="Resource">
+                  <vCard:Orgname>Keck Graduate Institute</vCard:Orgname>
+                </vCard:ORG>
+              </rdf:li>
+            </rdf:Bag>
+          </dc:creator>
+          <dcterms:created rdf:parseType="Resource">
+            <dcterms:W3CDTF>2005-02-12T00:18:12Z</dcterms:W3CDTF>
+          </dcterms:created>
+          <dcterms:modified rdf:parseType="Resource">
+            <dcterms:W3CDTF>2015-06-02T12:04:33Z</dcterms:W3CDTF>
+          </dcterms:modified>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL6615119181"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:is>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000010"/>
+            </rdf:Bag>
+          </bqmodel:is>
+          <bqmodel:isDescribedBy>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/pubmed/10712587"/>
+            </rdf:Bag>
+          </bqmodel:isDescribedBy>
+          <bqbiol:isVersionOf>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/go/GO:0000165"/>
+            </rdf:Bag>
+          </bqbiol:isVersionOf>
+          <bqbiol:isHomologTo>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_634"/>
+            </rdf:Bag>
+          </bqbiol:isHomologTo>
+          <bqbiol:hasTaxon>
+            <rdf:Bag>
+              <rdf:li rdf:resource="http://identifiers.org/taxonomy/8355"/>
+            </rdf:Bag>
+          </bqbiol:hasTaxon>
+        </rdf:Description>
+      </rdf:RDF>
+    </annotation>
+    <listOfUnitDefinitions>
+      <unitDefinition metaid="metaid_0000022" id="substance" name="nanomole">
+        <listOfUnits>
+          <unit metaid="_653149" kind="mole" scale="-9"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment metaid="_584463" id="uVol" size="1"/>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species metaid="_584475" id="MKKK" name="Mos" compartment="uVol" initialConcentration="90">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584475">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P09560"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584495" id="MKKK_P" name="Mos-P" compartment="uVol" initialConcentration="10">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584495">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P09560"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584515" id="MKK" name="Mek1" compartment="uVol" initialConcentration="280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584515">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584535" id="MKK_P" name="Mek1-P" compartment="uVol" initialConcentration="10">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584535">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584555" id="MKK_PP" name="Mek1-PP" compartment="uVol" initialConcentration="10">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584555">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584575" id="MAPK" name="Erk2" compartment="uVol" initialConcentration="280">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584575">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584595" id="MAPK_P" name="Erk2-P" compartment="uVol" initialConcentration="10">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584595">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+      <species metaid="_584615" id="MAPK_PP" name="Erk2-PP" compartment="uVol" initialConcentration="10">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584615">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
+    </listOfSpecies>
+    <listOfReactions>
+      <reaction metaid="_584635" id="J0" name="MAPKKK activation" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584635">
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_525"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.1"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000185"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0008349"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653161" species="MKKK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653173" species="MKKK_P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_653185" species="MAPK_PP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_653197">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V1 </ci>
+                <ci> MKKK </ci>
+              </apply>
+              <apply>
+                <times/>
+                <apply>
+                  <plus/>
+                  <cn type="integer"> 1 </cn>
+                  <apply>
+                    <power/>
+                    <apply>
+                      <divide/>
+                      <ci> MAPK_PP </ci>
+                      <ci> Ki </ci>
+                    </apply>
+                    <ci> n </ci>
+                  </apply>
+                </apply>
+                <apply>
+                  <plus/>
+                  <ci> K1 </ci>
+                  <ci> MKKK </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001327" id="V1" value="2.5"/>
+            <parameter metaid="_001328" id="Ki" value="9"/>
+            <parameter metaid="_001329" id="n" value="1"/>
+            <parameter metaid="_001331" id="K1" value="10"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584655" id="J1" name="MAPKKK inactivation" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584655">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0051390"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653209" species="MKKK_P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653221" species="MKKK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_653233">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V2 </ci>
+                <ci> MKKK_P </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK2 </ci>
+                <ci> MKKK_P </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001333" id="V2" value="0.25"/>
+            <parameter metaid="_001335" id="KK2" value="8"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584675" id="J2" name="phosphorylation of MAPKK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584675">
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_614"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.25"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004709"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653245" species="MKK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653257" species="MKK_P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_653269" species="MKKK_P"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_653281">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> k3 </ci>
+                <ci> MKKK_P </ci>
+                <ci> MKK </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK3 </ci>
+                <ci> MKK </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001337" id="k3" value="0.025"/>
+            <parameter metaid="_001339" id="KK3" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584695" id="J3" name="phosphorylation of MAPKK-P" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584695">
+              <bqbiol:isHomologTo>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_614"/>
+                </rdf:Bag>
+              </bqbiol:isHomologTo>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.11.25"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000186"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004709"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653293" species="MKK_P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653305" species="MKK_PP"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_653317" species="MKKK_P"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_653329">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> k4 </ci>
+                <ci> MKKK_P </ci>
+                <ci> MKK_P </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK4 </ci>
+                <ci> MKK_P </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001341" id="k4" value="0.025"/>
+            <parameter metaid="_001343" id="KK4" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584715" id="J4" name="dephosphorylation of MAPKK-PP" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584715">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0051389"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653341" species="MKK_PP"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653353" species="MKK_P"/>
+        </listOfProducts>
+        <kineticLaw metaid="_653365">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V5 </ci>
+                <ci> MKK_PP </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK5 </ci>
+                <ci> MKK_PP </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001345" id="V5" value="0.75"/>
+            <parameter metaid="_001347" id="KK5" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584735" id="J5" name="dephosphorylation of MAPKK-P" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584735">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653377" species="MKK_P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653389" species="MKK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_653402">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V6 </ci>
+                <ci> MKK_P </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK6 </ci>
+                <ci> MKK_P </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001349" id="V6" value="0.75"/>
+            <parameter metaid="_001351" id="KK6" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584755" id="J6" name="phosphorylation of MAPK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584755">
+              <bqbiol:hasVersion>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+                </rdf:Bag>
+              </bqbiol:hasVersion>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004708"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653414" species="MAPK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653426" species="MAPK_P"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_653438" species="MKK_PP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_653450">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> k7 </ci>
+                <ci> MKK_PP </ci>
+                <ci> MAPK </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK7 </ci>
+                <ci> MAPK </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001353" id="k7" value="0.025"/>
+            <parameter metaid="_001355" id="KK7" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584775" id="J7" name="phosphorylation of MAPK-P" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584775">
+              <bqbiol:hasVersion>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+                  <rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+                </rdf:Bag>
+              </bqbiol:hasVersion>
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006468"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0004708"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000187"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653463" species="MAPK_P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653475" species="MAPK_PP"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_653487" species="MKK_PP"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_653499">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> k8 </ci>
+                <ci> MKK_PP </ci>
+                <ci> MAPK_P </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK8 </ci>
+                <ci> MAPK_P </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001357" id="k8" value="0.025"/>
+            <parameter metaid="_001359" id="KK8" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584795" id="J8" name="dephosphorylation of MAPK-PP" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584795">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0000188"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653511" species="MAPK_PP"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653523" species="MAPK_P"/>
+        </listOfProducts>
+        <kineticLaw metaid="_653535">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V9 </ci>
+                <ci> MAPK_PP </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK9 </ci>
+                <ci> MAPK_PP </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001361" id="V9" value="0.5"/>
+            <parameter metaid="_001363" id="KK9" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+      <reaction metaid="_584815" id="J9" name="dephosphorylation of MAPK-P" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#_584815">
+              <bqbiol:isVersionOf>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+                  <rdf:li rdf:resource="http://identifiers.org/go/GO:0006470"/>
+                </rdf:Bag>
+              </bqbiol:isVersionOf>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+        <listOfReactants>
+          <speciesReference metaid="_653547" species="MAPK_P"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_653559" species="MAPK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_653571">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <divide/>
+              <apply>
+                <times/>
+                <ci> uVol </ci>
+                <ci> V10 </ci>
+                <ci> MAPK_P </ci>
+              </apply>
+              <apply>
+                <plus/>
+                <ci> KK10 </ci>
+                <ci> MAPK_P </ci>
+              </apply>
+            </apply>
+          </math>
+          <listOfParameters>
+            <parameter metaid="_001365" id="V10" value="0.5"/>
+            <parameter metaid="_001367" id="KK10" value="15"/>
+          </listOfParameters>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>


### PR DESCRIPTION
**What new features does this PR implement?**
Failure when creating a new omex project from a model (e.g. uploaded SBML file).

This functionality in combine-api service defaults to temporarily saving the generated archive in an S3 bucket.  

A bad import statement caused a runtime error when invoking the S3 operation.  This problem was not flagged by MyPy and only manifested itself runtime.  The test coverage for S3 functionality relies on mocks so it wasn't caught there either.

**How have you tested this PR?**
added two explicit test cases, one with the unused 'download' and one that returns a URL to an S3 bucket location.

