### PR TITLE
fix: create project fails in combine-api

### DIFF
--- a/apps/combine-api/combine_api/handlers/combine/create.py
+++ b/apps/combine-api/combine_api/handlers/combine/create.py
@@ -20,6 +20,9 @@ import requests.exceptions
 import werkzeug.datastructures  # noqa: F401
 import werkzeug.wrappers.response  # noqa: F401
 
+import logging
+
+logger = logging.getLogger(__name__)
 
 def handler(body, files=None):
     ''' Create a COMBINE/OMEX archive.
@@ -133,8 +136,13 @@ def handler(body, files=None):
                                download_name='archive.omex')
 
     else:
-        # save COMBINE/OMEX archive to S3 bucket
-        archive_url = combine_api.s3.save_temporary_combine_archive_to_s3_bucket(archive_filename, public=True)
+        try:
+          # save COMBINE/OMEX archive to S3 bucket
+          archive_url = combine_api.s3.save_temporary_combine_archive_to_s3_bucket(archive_filename, public=True)
 
-        # return URL for archive in S3 bucket
-        return archive_url
+          # return URL for archive in S3 bucket
+          return archive_url
+        except Exception as exception:
+          logging.exception('Failed to save COMBINE/OMEX archive to S3 bucket', exception)
+          raise exception
+

--- a/apps/combine-api/combine_api/handlers/combine/create.py
+++ b/apps/combine-api/combine_api/handlers/combine/create.py
@@ -24,19 +24,20 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def handler(body, files=None):
-    ''' Create a COMBINE/OMEX archive.
+
+def handler(body, _files=None):
+    """ Create a COMBINE/OMEX archive.
 
     Args:
         body (:obj:`dict`): dictionary with schema ``CreateCombineArchiveSpecsAndFiles`` with the
             specifications of the COMBINE/OMEX archive to create
-        files (:obj:`list` of :obj:`werkzeug.datastructures.FileStorage`, optional): files (e.g., SBML
+        _files (:obj:`list` of :obj:`werkzeug.datastructures.FileStorage`, optional): files (e.g., SBML
             file)
 
     Returns:
         :obj:`werkzeug.wrappers.response.Response` or :obj:`str`: response with COMBINE/OMEX
             archive or a URL to a COMBINE/OMEX archive
-    '''
+    """
     download = body.get('download', False)
     archive_specs = body['specs']
     files = connexion.request.files.getlist('files')
@@ -137,12 +138,11 @@ def handler(body, files=None):
 
     else:
         try:
-          # save COMBINE/OMEX archive to S3 bucket
-          archive_url = combine_api.s3.save_temporary_combine_archive_to_s3_bucket(archive_filename, public=True)
+            # save COMBINE/OMEX archive to S3 bucket
+            archive_url = combine_api.s3.save_temporary_combine_archive_to_s3_bucket(archive_filename, public=True)
 
-          # return URL for archive in S3 bucket
-          return archive_url
+            # return URL for archive in S3 bucket
+            return archive_url
         except Exception as exception:
-          logging.exception('Failed to save COMBINE/OMEX archive to S3 bucket', exception)
-          raise exception
-
+            logging.exception('Failed to save COMBINE/OMEX archive to S3 bucket', exception)
+            raise exception

--- a/apps/combine-api/combine_api/s3.py
+++ b/apps/combine-api/combine_api/s3.py
@@ -40,12 +40,12 @@ class S3Bucket(object):
         s3: ServiceResource = boto3.resource('s3',
                                              endpoint_url=environ.get(ENVVAR_STORAGE_ENDPOINT),
                                              aws_access_key_id=environ.get(ENVVAR_STORAGE_ACCESS_KEY),
-                                             aws_secret_access_key=environ.get(ENVVAR_STORAGE_ACCESS_KEY),
+                                             aws_secret_access_key=environ.get(ENVVAR_STORAGE_SECRET),
                                              verify=False)
         self.client: Client = boto3.client('s3',
                                            endpoint_url=environ.get(ENVVAR_STORAGE_ENDPOINT),
                                            aws_access_key_id=environ.get(ENVVAR_STORAGE_ACCESS_KEY),
-                                           aws_secret_access_key=environ.get(ENVVAR_STORAGE_ACCESS_KEY),
+                                           aws_secret_access_key=environ.get(ENVVAR_STORAGE_SECRET),
                                            verify=False,
                                            )
         self.bucket = s3.Bucket(environ.get(ENVVAR_TEMP_STORAGE_BUCKET))

--- a/apps/combine-api/combine_api/spec/spec.yml
+++ b/apps/combine-api/combine_api/spec/spec.yml
@@ -160,7 +160,7 @@ paths:
   /combine/create:
     post:
       requestBody:
-        description: Specifiations for the COMBINE/OMEX archive and its contents (specifications
+        description: Specifications for the COMBINE/OMEX archive and its contents (specifications
           of the SED-ML documents and file(s)).
         content:
           multipart/form-data:


### PR DESCRIPTION
**What bugs does this PR fix?**
Fixes silent failure when creating new omex file.  The transaction failed when uploading to a temporary S3 bucket.  The cause was improper environment variable used for S3 credentials.

* Fixes create project fails when writing to S3 (closes #4736)

**How have you tested this PR?**
Unit test `CreateCombineArchiveTestCase.test_create_combine_archive_with_uploaded_model_file_and_save_to_s3_biomd0000000010()` exercises this code path in combine-api.

