### PR TITLE
fix: force build test deploy workflow for merged PR 4755

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -220,6 +220,7 @@ jobs:
       runs-on: ubuntu-latest
       needs:
         - reviewDevDeploymentTests
+      # if: jobs.reviewDevDeploymentTests.result == 'success'
       environment: prod_environment
       strategy:
         matrix:
@@ -255,6 +256,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - reviewDevDeploymentTests
+    # if: jobs.reviewDevDeploymentTests.result == 'success'
     environment: prod_environment
     steps:
       - name: Checkout repository

--- a/apps/platform/src/app/app.component.html
+++ b/apps/platform/src/app/app.component.html
@@ -22,7 +22,7 @@
         <biosimulations-dropdown-menu-item heading="Browse Simulation Runs" [routerLink]="['/runs']">
         </biosimulations-dropdown-menu-item>
 
-        <biosimulations-dropdown-menu-item heading="Run A Simulation" [routerLink]="['/runs', 'new']">
+        <biosimulations-dropdown-menu-item heading="Run a Simulation" [routerLink]="['/runs', 'new']">
         </biosimulations-dropdown-menu-item>
       </ng-container>
     </biosimulations-hover-open-menu>


### PR DESCRIPTION
forces build/deploy workflow for previous PR #4755 which changed only a text file which was only used in continuous deployment actions.

Here, we introduce a small text change in a web page to force build/test/deploy workflow