### PR TITLE
fix: update hsload args for h5pyd 0.14.1 to upload to HSDS from Slurm

### DIFF
--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -303,7 +303,7 @@ echo -e '${cyan}=================================================== Saving resul
 srun --job-name="Save-results-to-HSDS" \
   hsload \
     --endpoint ${hsdsBasePath} \
-    --username ${hsdsUsername} \
+    --user ${hsdsUsername} \
     --password ${hsdsPassword} \
     --retries ${hsdsRetries} \
     --verbose \


### PR DESCRIPTION
update hsload arguments for new version of h5pyd package which was upgraded on the HPC server from 0.8.4 to 0.14.1 (to correspond to currently deployed version of HSDS.

username option changed to user

