### PR TITLE
fix: adjustments to view component family and more

### DIFF
--- a/apps/platform/src/app/components/home/featured/featured.service.ts
+++ b/apps/platform/src/app/components/home/featured/featured.service.ts
@@ -83,7 +83,7 @@ export class FeaturedService {
     descriptionVerbose: `Swagger page provides developers with a detailed and interactive documentation of \
       our API endpoints, simplifying the integration process and offering an intuitive interface for \
       executing services, which facilitates efficient interaction with our platform's functionalities and resources.`,
-    routingLink: 'https://api.biosimulations.org',
+    routingLink: 'https://api.biosimulations.dev',
     logo: 'idea',
     headerColor: '#951ed9',
     color: 'rgba(0, 150, 136, 0.85)',

--- a/apps/platform/src/app/components/projects/view/view.component.html
+++ b/apps/platform/src/app/components/projects/view/view.component.html
@@ -28,7 +28,7 @@
 
           <mat-tab-group #tabGroup preserveContent="true" [dynamicHeight]="true" [selectedIndex]="selectedTabIndex">
             <!-- Start Visualizations Tab -->
-
+            <!-- FOR FUTURE IMPLEMENTATIONS: cdkdrag of plot position
             <mat-tab class="right-col-tab figures">
               <ng-template mat-tab-label>
                 <biosimulations-icon icon="write"></biosimulations-icon>
@@ -52,6 +52,35 @@
                     </mat-grid-tile-header>
                     <div class="plotparent">
                       <div class="figure-card-placeholder" *cdkDragPlaceholder></div>
+                      <biosimulations-project-visualization
+                        [visualization]="plotVisualization"
+                        [plotTitle]="plotVisualization.name"
+                        [projectTitle]="projectMetadata.title">
+                      </biosimulations-project-visualization>
+                    </div>
+                  </mat-grid-tile>
+                </mat-grid-list>
+              </mat-card>
+            </mat-tab> -->
+            <mat-tab class="right-col-tab figures">
+              <ng-template mat-tab-label>
+                <biosimulations-icon icon="write"></biosimulations-icon>
+                <div style="width: 5px"></div>
+                Figures
+              </ng-template>
+              <mat-card class="plots-card">
+                <mat-grid-list
+                  *ngFor="let plotVisualization of plotVisualizations$ | async"
+                  cols="1"
+                  rowHeight="525px"
+                  gutterSize="20">
+                  <mat-grid-tile class="figure-card">
+                    <mat-grid-tile-header
+                      class="figure-card-header"
+                      style="background-color: #2196f3; height: 6%">
+                      {{ plotVisualization.name }}
+                    </mat-grid-tile-header>
+                    <div class="plotparent">
                       <biosimulations-project-visualization
                         [visualization]="plotVisualization"
                         [plotTitle]="plotVisualization.name"

--- a/apps/platform/src/app/components/projects/view/view.component.html
+++ b/apps/platform/src/app/components/projects/view/view.component.html
@@ -189,27 +189,38 @@
                         *ngTemplateOutlet="
                           sectionsTemplate;
                           context: {
-                            sections: projectMetadata?.modelSimulation || [],
-                            expanded: panelExpandedStatus['modelSimulation']
+                            sections: projectMetadata?.identifiers || [],
+                            expanded: true
                           }
-                        ">
-                      </ng-container>
-                      <ng-container
-                        *ngTemplateOutlet="sectionsTemplate; context: { sections: simulationRun || [] }"></ng-container>
+                        "></ng-container>
                       <ng-container
                         *ngTemplateOutlet="
                           sectionsTemplate;
                           context: {
-                            sections: projectMetadata?.provenance || [],
-                            expanded: panelExpandedStatus['provenance']
+                            sections: simulationRun || [],
+                            expanded: true
                           }
                         ">
                       </ng-container>
+
                       <ng-container
                         *ngTemplateOutlet="
                           sectionsTemplate;
-                          context: { sections: projectMetadata?.identifiers || [] }
-                        "></ng-container>
+                          context: {
+                            sections: projectMetadata?.modelSimulation || []
+                          }
+                        ">
+                      </ng-container>
+
+                      <ng-container
+                        *ngTemplateOutlet="
+                          sectionsTemplate;
+                          context: {
+                            sections: projectMetadata?.provenance || []
+                          }
+                        ">
+                      </ng-container>
+
                       <!-- End NG Containers -->
                       <!-- Start template for containers -->
                       <ng-template #sectionsTemplate let-sections="sections" let-expanded="expanded">

--- a/apps/platform/src/app/components/projects/view/view.component.scss
+++ b/apps/platform/src/app/components/projects/view/view.component.scss
@@ -65,6 +65,7 @@
 .display-data {
   flex-direction: row;
   font-family: 'Roboto', sans-serif;
+  margin-top: 3rem;
 
   @media (max-width: 768px) {
     flex-direction: column;
@@ -278,4 +279,10 @@ biosimulations-tab-page ::ng-deep .icon-list {
 
 .rerun {
   margin-top: 0 !important;
+}
+
+.figure-card,
+.files-card,
+.details-card {
+  margin-top: 2rem;
 }

--- a/apps/simulators/src/styles.scss
+++ b/apps/simulators/src/styles.scss
@@ -92,3 +92,10 @@
   display: flex;
   align-items: center;
 }
+
+biosimulations-hover-open-menu button:hover {
+  background-color: var(--primary-darker-color) !important;
+  transition: background-color 0.35s ease !important;
+  color: white !important;
+  font-weight: 700;
+}

--- a/libs/shared/styles/src/lib/_global.scss
+++ b/libs/shared/styles/src/lib/_global.scss
@@ -1789,3 +1789,10 @@ mat-option {
   font-weight: 700 !important;
   background-color: var(--primary-darker-color) !important;
 }
+
+biosimulations-hover-open-menu button:hover {
+  background-color: var(--accent-darker-color) !important;
+  transition: background-color 0.3s ease !important;
+  color: white !important;
+  font-weight: 700;
+}

--- a/libs/shared/styles/src/lib/_global.scss
+++ b/libs/shared/styles/src/lib/_global.scss
@@ -1588,7 +1588,9 @@ biosimulations-home biosimulations-home-subsection {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 6rem;
+  padding-top: 3rem;
+  padding-right: 3rem;
+  padding-left: 3rem;
 }
 
 .data-table-container {

--- a/libs/shared/ui/src/lib/home/home-subsection.component.scss
+++ b/libs/shared/ui/src/lib/home/home-subsection.component.scss
@@ -10,7 +10,7 @@ biosimulations-icon {
 }
 
 .heading {
-  color: var(--primary-color);
+  color: var(--primary-darker-color);
   font-size: 24px;
   font-weight: 700;
   margin-top: 0.5rem;

--- a/libs/shared/ui/src/lib/tab-page/tab-page.component.html
+++ b/libs/shared/ui/src/lib/tab-page/tab-page.component.html
@@ -1,7 +1,12 @@
 <biosimulations-full-page-spinner *ngIf="loading"> </biosimulations-full-page-spinner>
 
 <div [ngClass]="{ hidden: loading }" class="tab-page-container">
-  <mat-tab-group #tabGroup preserveContent="true" [dynamicHeight]="true" [selectedIndex]="selectedTabIndex">
+  <mat-tab-group
+    #tabGroup
+    preserveContent="true"
+    [dynamicHeight]="true"
+    [(selectedIndex)]="selectedTabIndex"
+    (selectedTabChange)="tabChanged($event)">
     <ng-content></ng-content>
   </mat-tab-group>
 </div>

--- a/libs/shared/ui/src/lib/table/table-tabular-data.component.html
+++ b/libs/shared/ui/src/lib/table/table-tabular-data.component.html
@@ -38,7 +38,7 @@
         <span [ngSwitch]="column.leftAction" *ngIf="element._cache[column.id].left.icon">
           <ng-template [ngSwitchCase]="'routerLink'">
             <a
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary routerlink"
               *ngIf="element._cache[column.id].left.routerLink as routerLink; else noRouterLink"
               [routerLink]="routerLink"
@@ -54,7 +54,7 @@
 
           <ng-template [ngSwitchCase]="'href'">
             <a
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary"
               *ngIf="element._cache[column.id].left.href as href; noHref"
               [href]="href"
@@ -71,7 +71,7 @@
 
           <ng-template [ngSwitchCase]="'click'">
             <button
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary"
               *ngIf="element._cache[column.id].left.click as click; else noClick"
               (click)="click(element)">
@@ -154,7 +154,7 @@
         <span [ngSwitch]="column.rightAction" *ngIf="element._cache[column.id].right.icon">
           <ng-template [ngSwitchCase]="'routerLink'">
             <a
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary"
               *ngIf="element._cache[column.id].right.routerLink as routerLink; else noRouterLink"
               [routerLink]="routerLink"
@@ -176,7 +176,7 @@
 
           <ng-template [ngSwitchCase]="'href'">
             <a
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary"
               *ngIf="element._cache[column.id].right.href as href; else noHref"
               [href]="href"
@@ -199,7 +199,7 @@
 
           <ng-template [ngSwitchCase]="'click'">
             <button
-              mat-icon-button
+              mat-flat-button
               class="biosimulations-button primary"
               *ngIf="element._cache[column.id].right.click as click; else noClick"
               (click)="click(element)">

--- a/libs/shared/ui/src/lib/table/table-tabular-data.component.scss
+++ b/libs/shared/ui/src/lib/table/table-tabular-data.component.scss
@@ -37,6 +37,7 @@ mat-cell {
 
 .biosimulations-table {
   width: 100%;
+  margin-left: -0.5rem;
   white-space: nowrap;
   background-color: #f5f5f5;
 }
@@ -56,6 +57,10 @@ mat-cell {
 
 .cell-content-container {
   width: fit-content;
+}
+
+.primary {
+  margin-left: -0.7rem;
 }
 
 .cell-content-container:hover,

--- a/libs/shared/ui/src/lib/text-page/text-page-side-bar-section.component.scss
+++ b/libs/shared/ui/src/lib/text-page/text-page-side-bar-section.component.scss
@@ -22,3 +22,8 @@ biosimulations-text-page-section ::ng-deep a {
     color: var(--accent-color);
   }
 }
+
+.sidebar-card {
+  max-width: 100%;
+  margin-left: -2rem;
+}

--- a/libs/simulation-project-utils/simulation-project-utils/src/lib/ui/create-project/form-steps/form-steps.scss
+++ b/libs/simulation-project-utils/simulation-project-utils/src/lib/ui/create-project/form-steps/form-steps.scss
@@ -118,7 +118,7 @@ mat-option:hover {
 }
 
 .card-form-title {
-  background-color: var(--primary-color);
+  background-color: var(--primary-darker-color);
   color: white;
   font-size: 16px;
   height: 100%;

--- a/libs/simulation-project-utils/simulation-project-utils/src/lib/ui/validate-metadata/validate-metadata.component.html
+++ b/libs/simulation-project-utils/simulation-project-utils/src/lib/ui/validate-metadata/validate-metadata.component.html
@@ -1,7 +1,6 @@
 <div class="form-parent-container validate-metadata">
   <biosimulations-page heading="Validate metadata (OMEX Metadata files)">
-    <mat-card class="mat-elevation-z2">
-      <mat-card-content>
+
         <form [formGroup]="formGroup" (ngSubmit)="onFormSubmit()">
           <div class="form-section">
             <div class="form-section-head">
@@ -194,7 +193,5 @@
             </div>
           </div>
         </form>
-      </mat-card-content>
-    </mat-card>
   </biosimulations-page>
 </div>

--- a/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.scss
+++ b/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.scss
@@ -1,0 +1,3 @@
+.plotly-visualization {
+  transform: scale(0.875);
+}

--- a/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.ts
+++ b/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.ts
@@ -152,7 +152,7 @@ export class PlotlyVisualizationComponent implements AfterViewInit, OnDestroy, O
   }
 
   private setLegendLayout(
-    x = 0.5,
+    x = 4.5,
     y = 1.5,
     orientation = 'v',
     traceorder = 'normal',

--- a/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.ts
+++ b/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.ts
@@ -152,7 +152,7 @@ export class PlotlyVisualizationComponent implements AfterViewInit, OnDestroy, O
   }
 
   private setLegendLayout(
-    x = 4.5,
+    x = 0.5,
     y = 1.5,
     orientation = 'v',
     traceorder = 'normal',


### PR DESCRIPTION
**What new features does this PR implement?**
Please summarize the features that this PR implements. As relevant, please indicate the issues that the PR closes.

* `platform`/`dispatch`: implements updated two-way event and property binding for `.runs.view` within `mat-tab-group`. (Fixes #4768)
* `platform`/`dispatch`: implements new logic for controlling which `mat-expansion-panels` render pre-opened in `.runs.view` for simulation project details. (Fixes #4771).

**What bugs does this PR fix?**
Please summarize the bugs that this PR fixes. As relevant, please indicate the issues that the PR closes.

* `platform`/`dispatch`: adjusts `mat-card` widths properly in `sideBar` selector for `.runs/view`.
* `platform`: adjusts `.plotly-visualization` layout declaration in `./projects/view` to properly scale with entire content width. (Fixes #4774)

**Does this PR introduce any additional changes?**
Please summarize any additional changes that this PR introduces.

* Adds deeper `...-darker-color` uniquely for both `platform`/`dispatch` and `simulators` apps on `:hover` in `biosimulations-navigation` hero banner nav buttons.

**How have you tested this PR?**
Please summarize the tests that you implemented to test this PR.

* CI/CD pipeline testing.
* SonarCloud CI.
* CodeFactor CI.

**Additional information**
This serves as the second UI adjustment following a deployment after nearly a year of ui-dev stagnation.
