### PR TITLE
fix: updated structured log to include more extensive message

### DIFF
--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -71,10 +71,10 @@ export class HpcService {
     const res = this.sshService.execStringCommand(command);
 
     return res.catch((err) => {
-      this.logger.error(`The job for simulation run '${runId}' could not be submitted.`);
+      this.logger.error(`The job for simulation run '${runId}' could not be submitted: ${err}, command: ${command}`);
       return {
         stdout: '',
-        stderr: `The job for simulation run '${runId}' could not be submitted: ${err}`,
+        stderr: `The job for simulation run '${runId}' could not be submitted: ${err}, command: ${command}`,
       };
     });
   }

--- a/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
+++ b/apps/dispatch-service/src/app/services/ssh/ssh.service.ts
@@ -44,6 +44,7 @@ export class SshService {
       let stdout = '';
       let stderr = '';
 
+      const start = new Date().getTime();
       this.connection.exec(cmd, async (err, stream) => {
         if (err) {
           this.logger.error(err);
@@ -63,7 +64,8 @@ export class SshService {
               stderr += data.toString('utf8');
             });
         } else {
-          this.logger.error('Stream is null');
+          const elapsed = (new Date().getTime() - start) / 1000.0;
+          this.logger.error(`Stream is null in SSH service execStringCommand: ${cmd}. Elapsed time: ${elapsed}`);
 
           if (retryCount < retries) {
             this.logger.debug(`Retrying SSH connection ${retryCount + 1} of ${retries} ...`);

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -172,7 +172,7 @@ export class CompleteProcessor extends WorkerHost {
   }
 
   private getFailedStepErrorMessage(step: stepsInfo, failedSteps: stepsInfo[]): string {
-    let message = step.description + ' ... failed';
+    let message = step.description + ' ... failed due to ' + step.reason;
     let failedDueToChild = false;
     const children = step.children;
     children.forEach((child) => {

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -257,7 +257,7 @@ export class CompleteProcessor extends WorkerHost {
         returnValue: flow.job.returnvalue.data,
         required: flow.job.data.required,
         description: flow.job.data.description,
-        errorMessage: flow.job.data.errorMessage,
+        errorMessage,
         data: flow.job.data,
         children: children,
       });

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -172,7 +172,11 @@ export class CompleteProcessor extends WorkerHost {
   }
 
   private getFailedStepErrorMessage(step: stepsInfo, failedSteps: stepsInfo[]): string {
-    let message = step.description + ' ... failed due to ' + step.reason;
+    let suffix = ' ... failed';
+    if (step.reason) {
+      suffix += ' due to: ' + step.reason;
+    }
+    let message = step.description + suffix;
     let failedDueToChild = false;
     const children = step.children;
     children.forEach((child) => {

--- a/apps/dispatch-service/src/app/submission/complete.processor.ts
+++ b/apps/dispatch-service/src/app/submission/complete.processor.ts
@@ -257,7 +257,7 @@ export class CompleteProcessor extends WorkerHost {
         returnValue: flow.job.returnvalue.data,
         required: flow.job.data.required,
         description: flow.job.data.description,
-        errorMessage,
+        errorMessage: flow.job.data.errorMessage,
         data: flow.job.data,
         children: children,
       });

--- a/apps/dispatch-service/src/app/submission/process.processor.ts
+++ b/apps/dispatch-service/src/app/submission/process.processor.ts
@@ -27,7 +27,6 @@ export class ProcessProcessor extends WorkerHost {
   public async process(job: Job): Promise<void> {
     // Called as soon as simulation is complete.
     this.logger.log(`Processing job ${job.id}`);
-
     const runId = job.data.runId;
     // Each job defined below should be as close to atomic as possible to enable retries.
 
@@ -145,7 +144,8 @@ export class ProcessProcessor extends WorkerHost {
       data: {
         runId: job.data.runId,
         description: 'Post the SED-ML file to the API',
-        moreInfo: undefined,
+        moreInfo: job.data.moreInfo,
+        reason: job.failedReason,
         validator: undefined,
         errorMessage: `There was an error uploading the SED-ML specifications to the API.`,
         required: true,

--- a/apps/dispatch-service/src/app/submission/process.processor.ts
+++ b/apps/dispatch-service/src/app/submission/process.processor.ts
@@ -144,7 +144,7 @@ export class ProcessProcessor extends WorkerHost {
       data: {
         runId: job.data.runId,
         description: 'Post the SED-ML file to the API',
-        moreInfo: job.data.moreInfo,
+        moreInfo: undefined,
         reason: job.failedReason,
         validator: undefined,
         errorMessage: `There was an error uploading the SED-ML specifications to the API.`,

--- a/apps/dispatch/src/app/components/simulations/view/view.component.scss
+++ b/apps/dispatch/src/app/components/simulations/view/view.component.scss
@@ -57,3 +57,7 @@ biosimulations-tab-page ::ng-deep .icon-list {
   margin-right: 3rem;
   max-width: 700px;
 }
+
+.info-message {
+  margin-top: 3rem;
+}

--- a/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
+++ b/libs/simulation-runs/ui/src/lib/metadata/metadata.component.scss
@@ -8,7 +8,7 @@ $ACCENT: var(--accent-darker-color) !important;
   overflow: auto;
   max-width: 1000px;
 
-  .description-column {
+  /*.description-column {
     display: none;
     opacity: 0;
     transition: opacity 0.5s ease, max-height 0.5s ease;
@@ -18,7 +18,7 @@ $ACCENT: var(--accent-darker-color) !important;
     display: block;
     opacity: 1;
     max-height: 1000px;
-  }
+  }*/
 
   .thumbnails-column {
     height: auto;


### PR DESCRIPTION
_What does this PR do?_:

- Adds `stepsInfo.reason` to `dispatch-service.submission.complete.processor.CompleteProcessor.getFailedStepErrorMessage` error message for more verbose output.
