### PR TITLE
fix: missing space in bash script

### DIFF
--- a/apps/dispatch-service/src/app/services/sbatch/expected_sbatch.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/expected_sbatch.ts
@@ -62,7 +62,7 @@ else
 fi
 
 
-if [[$err -eq 0 ]]; then
+if [[ $err -eq 0 ]]; then
   echo -e ''
   echo -e '\\033[0;36m=========================================== Executing COMBINE/OMEX archive ==========================================\\033[0m'
   TEMP_DIRNAME=$(mktemp --directory --tmpdir=/local)

--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -219,7 +219,7 @@ else
 fi
 
 
-if [[$err -eq 0 ]]; then
+if [[ $err -eq 0 ]]; then
   echo -e ''
   echo -e '${cyan}=========================================== Executing COMBINE/OMEX archive ==========================================${nc}'
   TEMP_DIRNAME=$(mktemp --directory --tmpdir=/local)


### PR DESCRIPTION
**What new features does this PR implement?**
fix syntax error in #4787 

**What bugs does this PR fix?**
when deployed to dev site, all simulations fail because bash syntax is slightly wrong (missing a space!!)

**Does this PR introduce any additional changes?**
No.

**How have you tested this PR?**
manually fixed the script on the HPC server and submitted using sbatch, works now.

