### PR TITLE
fix: job status is now tolerant of Slurm Job HSDS upload retries

### DIFF
--- a/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
+++ b/apps/dispatch-service/src/app/services/hpc/hpc.service.ts
@@ -139,22 +139,22 @@ export class HpcService {
         }
       });
 
-      if (failedSteps.length === 0) {
-        simStatusReason = {
-          status: SimulationRunStatus.SUCCEEDED,
-          reason:
-            'The simulation project (COMBINE/OMEX archive) was successfully saved, \
+      // if (failedSteps.length === 0) {
+      simStatusReason = {
+        status: SimulationRunStatus.SUCCEEDED,
+        reason:
+          'The simulation project (COMBINE/OMEX archive) was successfully saved, \
             the project executed successfully, and the results of the simulation experiments were successfully saved.',
-        };
-      } else {
-        simStatusReason = {
-          status: SimulationRunStatus.FAILED,
-          reason: `${failedSteps.length} steps of the simulation run job failed:\n  * ${failedSteps.join('\n  * ')}`,
-        };
-        this.logger.error(
-          `Job '${jobId}' completed, but ${failedSteps.length} steps failed:\n  * ${failedSteps.join('\n  * ')}`,
-        );
-      }
+      };
+      // } else {
+      //   simStatusReason = {
+      //     status: SimulationRunStatus.FAILED,
+      //     reason: `${failedSteps.length} steps of the simulation run job failed:\n  * ${failedSteps.join('\n  * ')}`,
+      //   };
+      //   this.logger.error(
+      //     `Job '${jobId}' completed, but ${failedSteps.length} steps failed:\n  * ${failedSteps.join('\n  * ')}`,
+      //   );
+      // }
     } else if (
       finalStatus == 'FAILED' ||
       finalStatus == 'OUT-OF-MEMORY' ||


### PR DESCRIPTION
**What new features does this PR implement?**
A previous change introduced retry logic for HSDS uploads for HPC simulation jobs running on Slurm.  This introduced the possibility that one or more `Save-results-to-HSDS` Slurm steps can fail but eventually complete successfully.  In these cases, the entire job should be considered successful.

For example, the following Slurm job did complete successfully (see `7601352|Simulation-run-6598a8dce0dd9fac8e8c3b43|COMPLETED`), but some intermediate steps failed and were retried (see 7601352.10, 7601352.11, 7601352.12 and 7601352.13).  

The current logic fails the entire job if any Slurm steps fail, this is no longer needed and has been removed.

```
-bash-4.2$ sacct --jobs 7601352 --format jobid,jobname,state --noheader --parsable2 --delimiter "|"
7601352|Simulation-run-6598a8dce0dd9fac8e8c3b43|COMPLETED
7601352.batch|batch|COMPLETED
7601352.extern|extern|COMPLETED
7601352.0|Download-project|COMPLETED
7601352.1|Execute-project|COMPLETED
7601352.2|Save-raw-log-to-S3-1|COMPLETED
7601352.3|Save-structured-log-to-S3|COMPLETED
7601352.4|Zip-outputs|COMPLETED
7601352.5|Save-numerical-outputs-to-S3|COMPLETED
7601352.6|Save-other-outputs-to-S3|COMPLETED
7601352.7|Unzip-COMBINE-archive|COMPLETED
7601352.8|Save-COMBINE-archive-contents-to-S3|COMPLETED
7601352.9|Save-raw-log-to-S3-2|COMPLETED
**7601352.10|Save-results-to-HSDS|FAILED**
**7601352.11|Save-results-to-HSDS|FAILED**
**7601352.12|Save-results-to-HSDS|FAILED**
**7601352.13|Save-results-to-HSDS|COMPLETED**
7601352.14|Save-raw-log-to-S3-3|COMPLETED
```

**How have you tested this PR?**
This is a simple change, but has not been tested.  It will be tested on the staging server.
