### PR TITLE
fix: disable broken UpdateSitemaps step of Continuous integration

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,11 +24,11 @@ jobs:
     with:
       branch: dev
 
-  UpdateSitemaps:
-    uses: ./.github/workflows/buildSitemaps.yml
-    secrets:
-       GPG_PRIVATE_KEY: ${{secrets.GPG_PRIVATE_KEY}}
-       GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
+#  UpdateSitemaps:
+#    uses: ./.github/workflows/buildSitemaps.yml
+#    secrets:
+#       GPG_PRIVATE_KEY: ${{secrets.GPG_PRIVATE_KEY}}
+#       GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
 
   Release:
     needs: [DependencyLicense, Format, UpdateSitemaps]


### PR DESCRIPTION
**What new features does this PR implement?**
disable UpdateSitemaps step of Continuous integration action in cd.yml.  It is failing in a non-recoverable way - it bootstraps off of a healthy biosimulations.org site, but since biosimulations.org is not healthy at the moment, this step blocks any progress.

This step will be restored in the future - hopefully in a way that doesn't reach out to the server - or make it optional