### PR TITLE
fix: disable updatesitemaps again

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,8 @@ jobs:
 #       GH_ACCESS_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
 
   Release:
-    needs: [DependencyLicense, Format, UpdateSitemaps]
+    # needs: [DependencyLicense, Format, UpdateSitemaps]
+    needs: [DependencyLicense, Format]
     uses: ./.github/workflows/release.yml
     secrets:
       GH_RELEASE_TOKEN: ${{ secrets.GH_RELEASE_TOKEN }}


### PR DESCRIPTION
**What new features does this PR implement?**
see #4795 - redoing previous PR to disable Update Site Maps prior to release (chicken or egg problem) - broken production site breaks UpdateSiteMaps action, so can't fix production site.
