### PR TITLE
fix: add CORS support for simdata-api

### DIFF
--- a/apps/simdata-api/Dockerfile
+++ b/apps/simdata-api/Dockerfile
@@ -31,4 +31,4 @@ VOLUME /app/scratch
 RUN echo "source /app/.venv/bin/activate" >> /etc/bash.bashrc
 
 # run the app
-CMD ["uvicorn", "simdata_api.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "3333" ]
+CMD ["uvicorn", "simdata_api.main:app", "--host", "0.0.0.0", "--port", "3333" ]

--- a/apps/simdata-api/simdata_api/main.py
+++ b/apps/simdata-api/simdata_api/main.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from urllib.parse import unquote
 
 from fastapi import FastAPI, HTTPException
-from starlette.middleware.cors import CORSMiddleware
+from fastapi.middleware.cors import CORSMiddleware
 
 from simdata_api.datamodels import DatasetData, HDF5File, StatusResponse, Status
 from simdata_api.datastore import get_dataset_data, get_results_timestamp, get_hdf5_metadata as get_metadata

--- a/apps/simdata-api/simdata_api/main.py
+++ b/apps/simdata-api/simdata_api/main.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from urllib.parse import unquote
 
 from fastapi import FastAPI, HTTPException
+from starlette.middleware.cors import CORSMiddleware
 
 from simdata_api.datamodels import DatasetData, HDF5File, StatusResponse, Status
 from simdata_api.datastore import get_dataset_data, get_results_timestamp, get_hdf5_metadata as get_metadata
@@ -16,6 +17,31 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="simdata-api", version="1.0.0")
 app.dependency_overrides = {}
+# enable cross-origin resource sharing
+origins=[
+    'http://127.0.0.1:4200',
+    'http://127.0.0.1:4201',
+    'http://127.0.0.1:4202',
+    'http://localhost:4200',
+    'http://localhost:4201',
+    'http://localhost:4202',
+    'https://biosimulators.org',
+    'https://www.biosimulators.org',
+    'https://biosimulators.dev',
+    'https://www.biosimulators.dev',
+    'https://run.biosimulations.dev',
+    'https://run.biosimulations.org',
+    'https://biosimulations.dev',
+    'https://biosimulations.org',
+    'https://bio.libretexts.org',
+ ]
+app.add_middleware(
+    middleware_class=CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 
 @app.get("/")

--- a/apps/simdata-api/simdata_api/main.py
+++ b/apps/simdata-api/simdata_api/main.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(title="simdata-api", version="1.0.0")
 app.dependency_overrides = {}
-# enable cross-origin resource sharing
-origins=[
+# enable cross-origin resource sharing (CORS)
+origins = [
     'http://127.0.0.1:4200',
     'http://127.0.0.1:4201',
     'http://127.0.0.1:4202',
@@ -34,7 +34,7 @@ origins=[
     'https://biosimulations.dev',
     'https://biosimulations.org',
     'https://bio.libretexts.org',
- ]
+]
 app.add_middleware(
     middleware_class=CORSMiddleware,
     allow_origins=origins,


### PR DESCRIPTION
**What new features does this PR implement?**
in a deployed environment, the browser was getting CORS errors.  This PR adds CORS (Cross-origin Resource Sharing) to the new simdata-api service using FastAPI's CORSMiddleware.  The allowed origins were set to the same list used by combine-api.