### PR TITLE
fix: look for reports.h5 in both contents and outputs S3 paths

### DIFF
--- a/apps/simdata-api/simdata_api/datastore.py
+++ b/apps/simdata-api/simdata_api/datastore.py
@@ -16,11 +16,13 @@ from simdata_api.internal.tensorstore_utils import write_ts_metadata_root, write
 
 logger = logging.getLogger(__name__)
 
+STORE_DIR_NAME = "store"
+
 
 async def get_dataset_data(run_id: str, dataset_name: str) -> tuple[np.ndarray, dict[str, str | list[str]]]:
     settings = get_settings()
     S3_STORE_NAME = f"reports.h5.{settings.storage_tensorstore_driver}"
-    S3_DIR_PATH = Path("simulations") / run_id / "contents"
+    S3_DIR_PATH = Path("simulations") / run_id / STORE_DIR_NAME
     DRIVER = settings.storage_tensorstore_driver
     KVSTORE_DRIVER = settings.storage_tensorstore_kvstore_driver
 
@@ -42,13 +44,18 @@ async def get_dataset_data(run_id: str, dataset_name: str) -> tuple[np.ndarray, 
 
 async def get_results_timestamp(run_id: str) -> datetime:
     S3_HDF5_FILENAME = 'reports.h5'
-    S3_DIR_PATH = Path("simulations") / run_id / "contents"
-    return await get_s3_modified_date(s3_path=str(S3_DIR_PATH / S3_HDF5_FILENAME))
+    S3_DIR_PATH = Path("simulations") / run_id / "outputs"
+    try:
+        return await get_s3_modified_date(s3_path=str(S3_DIR_PATH / S3_HDF5_FILENAME))
+    except FileNotFoundError:
+        logger.info(f"modified date not found for {str(S3_DIR_PATH / S3_HDF5_FILENAME)}, try alternate location")
+        S3_DIR_PATH = Path("simulations") / run_id / "contents"
+        return await get_s3_modified_date(s3_path=str(S3_DIR_PATH / S3_HDF5_FILENAME))
 
 
 async def get_hdf5_metadata(run_id: str) -> HDF5File:
     S3_METADATA_FILENAME = "reports.h5.json"
-    S3_DIR_PATH = Path("simulations") / run_id / "contents"
+    S3_DIR_PATH = Path("simulations") / run_id / STORE_DIR_NAME
 
     try:
         metadata_json = (await get_s3_file_contents(s3_path=str(S3_DIR_PATH / S3_METADATA_FILENAME))).decode('utf-8')
@@ -61,7 +68,7 @@ async def get_hdf5_metadata(run_id: str) -> HDF5File:
                 'utf-8')
             return HDF5File.model_validate_json(metadata_json)
         except FileNotFoundError as e2:
-            logger.info(f"failed to retrieve metadata: {str(e2)}")
+            logger.exception(msg=f"failed to retrieve metadata: {str(e2)}")
             raise FileNotFoundError(f"File {S3_DIR_PATH / S3_METADATA_FILENAME} not found in S3")
 
 
@@ -71,45 +78,50 @@ async def _upload_to_store_if_needed(run_id: str) -> None:
     S3_HDF5_FILENAME = 'reports.h5'
     S3_METADATA_FILENAME = "reports.h5.json"
     S3_STORE_NAME = f"reports.h5.{settings.storage_tensorstore_driver}"
-    S3_DIR_PATH = Path("simulations") / run_id / "contents"
+    S3_RUN_PATH = Path("simulations") / run_id
     LOCAL_HDF5_PATH = Path(settings.storage_local_cache_dir) / f"{run_id}_{uuid4().hex[:6]}.h5"
     DRIVER = settings.storage_tensorstore_driver
     KVSTORE_DRIVER = settings.storage_tensorstore_kvstore_driver
 
-    s3_items: list[ListingItem] = await get_listing_of_s3_path(s3_path=str(S3_DIR_PATH))
+    s3_items: list[ListingItem] = await get_listing_of_s3_path(s3_path=str(S3_RUN_PATH))
 
-    # if reports.h5 not found in S3, then abort
-    if not any([s3_item.Key == str(S3_DIR_PATH / S3_HDF5_FILENAME) for s3_item in s3_items]):
+    # find either '/simulations/{run_id}/outputs/reports.h5' or '/simulations/{run_id}/contents/reports.h5'
+    if any([s3_item.Key == str(S3_RUN_PATH / "outputs" / S3_HDF5_FILENAME) for s3_item in s3_items]):
+        s3_reports_h5_path = str(S3_RUN_PATH / "outputs" / S3_HDF5_FILENAME)
+    elif any([s3_item.Key == str(S3_RUN_PATH / "contents" / S3_HDF5_FILENAME) for s3_item in s3_items]):
+        s3_reports_h5_path = str(S3_RUN_PATH / "contents" / S3_HDF5_FILENAME)
+    else:
         # NB: not considering the case where reports.h5 is not found but reports.h5.[n5|zarr|zarr3] is found
-        raise FileNotFoundError(f"File {S3_DIR_PATH / S3_HDF5_FILENAME} not found in S3")
+        raise FileNotFoundError(f"File {S3_HDF5_FILENAME} not found in S3 at {S3_RUN_PATH} in 'outputs' or 'contents'")
 
-    # if reports.h5.[n5|zarr|zarr3] S3 store not found
+    # if '/simulations/{run_id}/store/reports.h5.zarr3' store not found in S3 (not in file listing)
     #    then create a new S3 store from the reports.h5 downloaded to local file cache
-    if not any([item.Key.startswith(str(S3_DIR_PATH / S3_STORE_NAME)) for item in s3_items]):
+    s3_zarr_path = S3_RUN_PATH / STORE_DIR_NAME / S3_STORE_NAME
+    if not any([item.Key == str(s3_zarr_path) for item in s3_items]):
         # download reports.h5 from S3 if needed
         if not await aiofiles.ospath.exists(str(LOCAL_HDF5_PATH)):
-            await download_s3_file(s3_path=str(S3_DIR_PATH / S3_HDF5_FILENAME), file_path=LOCAL_HDF5_PATH)
+            await download_s3_file(s3_path=s3_reports_h5_path, file_path=LOCAL_HDF5_PATH)
 
         # read metadata from reports.h5
         hdf5_file: HDF5File = extract_hdf5_metadata(local_file_path=LOCAL_HDF5_PATH)
         hdf5_file.filename = S3_HDF5_FILENAME
         hdf5_file.id = run_id
         hdf5_file.uri = (f"{settings.storage_endpoint_url}/{settings.storage_bucket}/simulations/"
-                         f"{run_id}/contents/reports.h5")
+                         f"{run_id}/outputs/reports.h5")
 
-        # upload reports.h5 to store in S3 using tensorstore
+        # upload contents of reports.h5 to store in S3 using tensorstore
         await write_ts_metadata_root(driver=DRIVER, kvstore_driver=KVSTORE_DRIVER,
-                                     kvstore_root_path=S3_DIR_PATH / S3_STORE_NAME, hdf5_file=hdf5_file)
+                                     kvstore_root_path=s3_zarr_path, hdf5_file=hdf5_file)
         for group in hdf5_file.groups:
             for dataset in group.datasets:
                 array = extract_hdf5_dataset_array(local_file_path=LOCAL_HDF5_PATH, dataset_name=dataset.name)
                 await write_ts_dataset(driver=DRIVER, kvstore_driver=KVSTORE_DRIVER,
-                                       kvstore_path=S3_DIR_PATH / S3_STORE_NAME / Path(dataset.name),
+                                       kvstore_path=s3_zarr_path / Path(dataset.name),
                                        data=array, attributes={attr.key: attr.value for attr in dataset.attributes})
 
         # serialize hdf5_file to JSON and upload to S3
         metadata_json = hdf5_file.model_dump_json()
-        await upload_bytes_to_s3(s3_path=str(S3_DIR_PATH / S3_METADATA_FILENAME),
+        await upload_bytes_to_s3(s3_path=str(S3_RUN_PATH / STORE_DIR_NAME / S3_METADATA_FILENAME),
                                  file_contents=metadata_json.encode('utf-8'))
 
         # use aiofiles to remove local hdf5 file

--- a/apps/simdata-api/simdata_api/log_config.py
+++ b/apps/simdata-api/simdata_api/log_config.py
@@ -3,8 +3,11 @@ import logging
 
 def setup_logging():
     # Create a root logger
-    logger = logging.getLogger("uvicorn.access")
-    logger.setLevel(logging.INFO)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # Create a uvicorn access logger
+    uvicorn_logger = logging.getLogger("uvicorn.access")
 
     # Create a console handler
     console_handler = logging.StreamHandler()
@@ -18,5 +21,6 @@ def setup_logging():
     # Add the formatter to the console handler
     console_handler.setFormatter(formatter)
 
-    # Add the console handler to the root logger
-    logger.addHandler(console_handler)
+    # Add the console handler to the root logger and uvicorn logger
+    root_logger.addHandler(console_handler)
+    uvicorn_logger.addHandler(console_handler)

--- a/apps/simdata-api/tests/internal/test_tensorstore_utils.py
+++ b/apps/simdata-api/tests/internal/test_tensorstore_utils.py
@@ -12,9 +12,7 @@ from simdata_api.internal.hdf5_utils import extract_hdf5_metadata, extract_hdf5_
 from simdata_api.internal.tensorstore_utils import write_ts_dataset, write_ts_metadata_root, TS_DRIVER, KV_DRIVER, \
     read_ts_dataset
 
-RUN_ID = "61fd573874bc0ce059643515"
 DATASET_NAME = "/simulation_1.sedml/report"
-S3_PATH = f"simulations/{RUN_ID}/contents/reports.h5"
 ROOT_DIR = Path(__file__).parent.parent.parent
 TEST_MATRIX = [
     ('n5', 'file'), ('n5', 'gcs'),  # ('n5', 's3'),

--- a/apps/simdata-api/tests/test_main.py
+++ b/apps/simdata-api/tests/test_main.py
@@ -37,8 +37,24 @@ async def test_health():
 @pytest.mark.skipif(os.path.exists(get_settings().storage_gcs_credentials_file) is False,
                     reason="STORAGE_GCS_CREDENTIALS_FILE not found")
 @pytest.mark.asyncio
-async def test_read_dataset():
-    RUN_ID = "61fd573874bc0ce059643515"
+async def test_read_dataset_from_outputs_dir():
+    RUN_ID = "64863d6fb933577dfcdf172c"  # reports.h5 only in outputs dir
+    DATASET_NAME = quote("BIOMD0000000001_url.sedml/autogen_report_for_task1", safe="")
+    url = f"/datasets/{RUN_ID}/data?dataset_name={DATASET_NAME}"
+    response = client.get(url)
+    data = response.json()
+    assert response.status_code == 200
+    assert data["shape"] == [66, 1001]
+    settings = get_settings()
+    LOCAL_PATH = Path(settings.storage_local_cache_dir) / f"{RUN_ID}.h5"
+    assert LOCAL_PATH.exists() is False
+
+
+@pytest.mark.skipif(os.path.exists(get_settings().storage_gcs_credentials_file) is False,
+                    reason="STORAGE_GCS_CREDENTIALS_FILE not found")
+@pytest.mark.asyncio
+async def test_read_dataset_from_contents_dir():
+    RUN_ID = "61fd573874bc0ce059643515"  # reports.h5 only in contents dir
     DATASET_NAME = quote("simulation_1.sedml/report", safe="")
     url = f"/datasets/{RUN_ID}/data?dataset_name={DATASET_NAME}"
     response = client.get(url)

--- a/libs/config/common/src/lib/endpointLoader.ts
+++ b/libs/config/common/src/lib/endpointLoader.ts
@@ -54,7 +54,7 @@ export class EndpointLoader {
 
         this.endpointsTemplate.combineApi = dynamicEndpoints?.combineApi || 'https://combine.api.biosimulations.dev';
 
-        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://data.biosimulations.dev';
+        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://simdata.api.biosimulations.dev';
 
         this.endpointsTemplate.simulatorsApp = dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
@@ -69,7 +69,7 @@ export class EndpointLoader {
           dynamicEndpoints?.externalCombineApi || 'https://combine.api.biosimulations.dev';
 
         this.endpointsTemplate.externalSimdataApi =
-          dynamicEndpoints?.externalSimdataApi || 'https://data.biosimulations.dev';
+          dynamicEndpoints?.externalSimdataApi || 'https://simdata.api.biosimulations.dev';
         break;
 
       case 'dev':
@@ -79,7 +79,7 @@ export class EndpointLoader {
 
         this.endpointsTemplate.combineApi = dynamicEndpoints?.combineApi || 'https://combine.api.biosimulations.dev';
 
-        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://data.biosimulations.dev';
+        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://simdata.api.biosimulations.dev';
 
         this.endpointsTemplate.simulatorsApp = dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
@@ -94,7 +94,7 @@ export class EndpointLoader {
           dynamicEndpoints?.externalCombineApi || 'https://combine.api.biosimulations.dev';
 
         this.endpointsTemplate.externalSimdataApi =
-          dynamicEndpoints?.externalSimdataApi || 'https://data.biosimulations.dev';
+          dynamicEndpoints?.externalSimdataApi || 'https://simdata.api.biosimulations.dev';
 
         break;
 
@@ -105,7 +105,7 @@ export class EndpointLoader {
 
         this.endpointsTemplate.combineApi = dynamicEndpoints?.combineApi || 'https://combine.api.biosimulations.dev';
 
-        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://data.biosimulations.dev';
+        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://simdata.api.biosimulations.dev';
 
         this.endpointsTemplate.simulatorsApp = dynamicEndpoints?.simulatorsApp || 'https://biosimulators.dev';
 
@@ -120,7 +120,7 @@ export class EndpointLoader {
           dynamicEndpoints?.externalCombineApi || 'https://combine.api.biosimulations.dev';
 
         this.endpointsTemplate.externalSimdataApi =
-          dynamicEndpoints?.externalSimdataApi || 'https://data.biosimulations.dev';
+          dynamicEndpoints?.externalSimdataApi || 'https://simdata.api.biosimulations.dev';
 
         break;
 
@@ -131,7 +131,7 @@ export class EndpointLoader {
 
         this.endpointsTemplate.combineApi = dynamicEndpoints?.combineApi || 'https://combine.api.biosimulations.org';
 
-        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://data.biosimulations.org';
+        this.endpointsTemplate.simdataApi = dynamicEndpoints?.simdataApi || 'https://simdata.api.biosimulations.org';
 
         this.endpointsTemplate.simulatorsApp = dynamicEndpoints?.simulatorsApp || 'https://biosimulators.org';
 
@@ -148,7 +148,7 @@ export class EndpointLoader {
           dynamicEndpoints?.externalCombineApi || 'https://combine.api.biosimulations.org';
 
         this.endpointsTemplate.externalSimdataApi =
-          dynamicEndpoints?.externalSimdataApi || 'https://data.biosimulations.org';
+          dynamicEndpoints?.externalSimdataApi || 'https://simdata.api.biosimulations.org';
 
         break;
     }


### PR DESCRIPTION
**What new features does this PR implement?**
- some datasets only have the simulation results in `files.biosimulations.dev/simulations/{run_id}/contents`, others have it only in `files.biosimulations.dev/simulations/{run_id}/outputs`, some have reports.h5 in both locations.  simdata-api should be able to support both conventions.
- renamed path for simdata-api from data.biosimulations.dev to simdata.api.biosimulations.dev for symmetry with other secondary services (e.g. combine-api).  Was temporarily named data.biosimulations.dev to reuse networking from hsds service which was recently replaced.
- fixed root logger configuration in simdata-api so that INFO and above will be logged - we may revisit in the future after simdata-api becomes more mature.

**What bugs does this PR fix?**
simulation runs which stored their reports.h5 in 'outputs' subdirectory were not supported.

**How have you tested this PR?**
altered unit testing in simdata-api to verify simulation data support for both 'contents' and 'outputs' subdirectories.

