### PR TITLE
fix: correct usage of NdArray in results.service

### DIFF
--- a/apps/api/src/results/results.service.ts
+++ b/apps/api/src/results/results.service.ts
@@ -169,19 +169,17 @@ export class ResultsService {
     // The index field will be needed when we are doing slicing of the data so this will need to change
     try {
       const response: NdArray = await this.results.getDatasetValues(runId, datasetId);
-      if (response && 'values' in response) {
+      if (response) {
         if (response.shape.length != 2) {
           throw Error(`The shape of the dataset '${outputUri}' is not 2d`);
         } else {
           // rewrite the following using numjs
           const shape = response.shape;
           const array: SimulationRunOutputDatumElement[][] = [];
-          let index = 0;
           for (let i = 0; i < shape[0]; i++) {
             const row: SimulationRunOutputDatumElement[] = [];
             for (let j = 0; j < shape[1]; j++) {
-              row.push(response.tolist()[index]);
-              index++;
+              row.push(response.get(i,j));
             }
             array.push(row);
           }


### PR DESCRIPTION
**What new features does this PR implement?**
processing of numeric data from simulation results required a translation from a return NdArray (inspired by numpy), but the processing did not properly extract the data. This fix follows the design of the NdArray.

**What bugs does this PR fix?**
biosimulations.dev failed to retrieve numerical data.

**How have you tested this PR?**
debugged and tested the `api` service API directly using `http://localhost:3333/results/65b72877ad7ecfadf1f0d3d5?includeData=true` and forced the invocation of the `simdata-api` to use `https://simdata.api.biosimulations.dev`. 

