### PR TITLE
fix: use async DynamicModule with config to initialize simdata-api path

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -52,6 +52,9 @@ async function bootstrap(): Promise<void> {
       'http://idl.cs.washington.edu', // Lyra Vega visual editor
     ];
     const allow = allowedOrigins.includes(requestOrigin);
+    if (!allow) {
+      logger.error('Origin not allowed: ' + requestOrigin);
+    }
     const error = null;
     callback(error, allow);
   };

--- a/libs/simdata-api/nest-client-wrapper/src/lib/simdata-api-nest-client-wrapper.module.ts
+++ b/libs/simdata-api/nest-client-wrapper/src/lib/simdata-api-nest-client-wrapper.module.ts
@@ -1,12 +1,43 @@
-import { Module } from '@nestjs/common';
-import { HttpModule } from '@nestjs/axios';
-import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
-
+import { Abstract, Global, Logger, Module, Type } from '@nestjs/common';
+import { ApiModule, Configuration as SimdataAPIConfiguration } from '@biosimulations/simdata-api-nest-client';
+import { ConfigService } from '@nestjs/config';
 import { SimulationHDFService } from './dataset.service';
-import { ApiModule } from '@biosimulations/simdata-api-nest-client';
+import { BiosimulationsConfigModule } from '@biosimulations/config/nest';
+import { HttpModule } from '@nestjs/axios';
+import { Endpoints } from '@biosimulations/config/common';
 
+export { SimdataAPIConfiguration };
+
+export type SimdataAPIConnectionOptionsFactory = (...args: any[]) => SimdataAPIConfiguration;
+
+export interface SimdataAPIConnectionAsyncOptions {
+  imports: any[];
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  inject: (string | symbol | Function | Type<any> | Abstract<any>)[];
+  useFactory: SimdataAPIConnectionOptionsFactory;
+}
+
+@Global()
 @Module({
-  imports: [HttpModule, BiosimulationsConfigModule, ApiModule],
+  imports: [
+    HttpModule,
+    BiosimulationsConfigModule,
+    ApiModule.forRootAsync({
+      imports: [BiosimulationsConfigModule],
+      inject: [ConfigService],
+      useFactory: async (configService: ConfigService) => {
+        const env = configService.get('server.env');
+        const endpoints = new Endpoints(env);
+        const simdataBaseUrl = endpoints.getSimdataApiBaseUrl(false);
+        const logger = new Logger(SimdataApiNestClientWrapperModule.name);
+        logger.log(`Using Combine API: ${simdataBaseUrl}`);
+        return new SimdataAPIConfiguration({
+          basePath: simdataBaseUrl,
+        });
+      },
+    })
+  ],
+  controllers: [],
   providers: [SimulationHDFService],
   exports: [SimulationHDFService],
 })


### PR DESCRIPTION
**What new features does this PR implement?**
incorporated server config into module dependency injection to initialize the correct baseUrl for `simdata-api` API client library.  Solution was inspired by that used by combine-api, but is more compact.

**What bugs does this PR fix?**
communication from `api` service to `simdata-api` failed when deployed because the url was wrong.

**How have you tested this PR?**
tested this locally using `local` environment settings and running both `api` and `simdata-api` services from the IDE and `platform` app from browser.