### PR TITLE
fix: allow for all plots to render regardless of title

### DIFF
--- a/apps/platform/src/app/components/simulations/browse/browse.component.html
+++ b/apps/platform/src/app/components/simulations/browse/browse.component.html
@@ -1,5 +1,5 @@
 <div class="data-table-parent-container platform-runs">
-  <mat-card class="data-table-card platform-runs">
+  <mat-card class="data-table-card platform">
     <mat-card-header class="multipurpose-card-header table-name">
       Your simulation runs
       <div class="table-buttons">

--- a/apps/platform/src/app/components/simulations/view/view.component.html
+++ b/apps/platform/src/app/components/simulations/view/view.component.html
@@ -200,8 +200,8 @@
       <ng-container *ngIf="visualizations$ | async as visualizations">
         <ng-container *ngFor="let visualizationList of visualizations">
           <ng-container *ngFor="let visualization of visualizationList.visualizations">
-            <biosimulations-project-visualization [visualization]="visualization">
-            </biosimulations-project-visualization>
+              <biosimulations-project-visualization [visualization]="visualization" class="view-viz">
+              </biosimulations-project-visualization>
           </ng-container>
         </ng-container>
       </ng-container>

--- a/apps/platform/src/app/components/simulations/view/view.component.scss
+++ b/apps/platform/src/app/components/simulations/view/view.component.scss
@@ -6,6 +6,10 @@
   justify-content: center;
 }
 
+.view-viz {
+  margin-top: 5rem !important;
+}
+
 biosimulations-tab-page ::ng-deep .icon-list {
   & > li:not(:first-child) {
     margin-top: 0.125rem;

--- a/apps/platform/src/app/components/simulations/view/view.component.ts
+++ b/apps/platform/src/app/components/simulations/view/view.component.ts
@@ -50,7 +50,8 @@ export class ViewComponent implements OnInit {
   public outputs$!: Observable<File[] | null | undefined | false>;
 
   public visualizations$!: Observable<VisualizationList[] | null | undefined | false>;
-  public visualization: Visualization | null = null;
+  public visualization?: Visualization | null;
+  // public visualization: Visualization | null = null;
 
   public logs$!: Observable<SimulationLogs | null | undefined | false>;
 
@@ -248,6 +249,7 @@ export class ViewComponent implements OnInit {
 
   public renderVisualization(visualization: Visualization): void {
     this.visualization = visualization;
+    console.log('Received visualization for rendering:', visualization);
     this.viewVisualizationTabDisabled = false;
     this.selectedTabIndex = this.visualizationTabIndex;
   }

--- a/libs/shared/styles/src/lib/_global.scss
+++ b/libs/shared/styles/src/lib/_global.scss
@@ -1602,6 +1602,7 @@ biosimulations-home biosimulations-home-subsection {
   }
 
   &.simulators,
+  &.platform,
   &.dispatch {
     padding-bottom: 0.5rem;
     height: fit-content;

--- a/libs/shared/ui/src/lib/app-footer/app-footer.component.scss
+++ b/libs/shared/ui/src/lib/app-footer/app-footer.component.scss
@@ -1,7 +1,6 @@
 @media (max-width: 768px) {
   .app-footer-container {
-    display: flex;
-    flex-direction: column;
+    display: none !important;
   }
 }
 

--- a/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.html
+++ b/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.html
@@ -1,14 +1,13 @@
-<div class="container">
+<!--<div class="container">
   <div *ngIf="visualization; else noPlot">
     <div *ngIf="projectTitle">
       <div *ngIf="plotTitle">
-        <!-- Case: Vega -->
+
         <biosimulations-vega-visualization
           *ngIf="visualization.renderer === 'Vega'"
           [spec]="visualization.vegaSpec"
           [name]="visualization.name + '_vega'">
         </biosimulations-vega-visualization>
-        <!-- Case: Plotly -->
 
         <biosimulations-plotly-visualization
           *ngIf="visualization.renderer === 'Plotly'"
@@ -27,4 +26,34 @@
       </mat-card>
     </div>
   </ng-template>
+</div>-->
+
+
+<div class="container">
+  <ng-container *ngIf="visualization; else noPlot">
+    <!-- Case: Vega -->
+    <biosimulations-vega-visualization
+      *ngIf="visualization.renderer === 'Vega'"
+      [spec]="visualization.vegaSpec"
+      [name]="visualization.name + '_vega'">
+    </biosimulations-vega-visualization>
+
+    <!-- Case: Plotly -->
+    <biosimulations-plotly-visualization
+      *ngIf="visualization.renderer === 'Plotly'"
+      [dataLayout]="visualization.plotlyDataLayout | async | async"
+      [plotTitle]="plotTitle"
+      [customizedAxis]="customAxis">
+    </biosimulations-plotly-visualization>
+  </ng-container>
+
+
+  <ng-template #noPlot>
+    <div class="no-plot">
+      <mat-card>
+        <mat-card-header> No Project Visualizations Available </mat-card-header>
+      </mat-card>
+    </div>
+  </ng-template>
 </div>
+

--- a/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.html
+++ b/libs/simulation-runs/ui/src/lib/render-viz/render-viz.component.html
@@ -1,34 +1,3 @@
-<!--<div class="container">
-  <div *ngIf="visualization; else noPlot">
-    <div *ngIf="projectTitle">
-      <div *ngIf="plotTitle">
-
-        <biosimulations-vega-visualization
-          *ngIf="visualization.renderer === 'Vega'"
-          [spec]="visualization.vegaSpec"
-          [name]="visualization.name + '_vega'">
-        </biosimulations-vega-visualization>
-
-        <biosimulations-plotly-visualization
-          *ngIf="visualization.renderer === 'Plotly'"
-          [dataLayout]="visualization.plotlyDataLayout | async | async"
-          [plotTitle]="plotTitle"
-          [customizedAxis]="customAxis">
-        </biosimulations-plotly-visualization>
-      </div>
-    </div>
-  </div>
-
-  <ng-template #noPlot>
-    <div class="no-plot">
-      <mat-card>
-        <mat-card-header> No Project Visualizations Available </mat-card-header>
-      </mat-card>
-    </div>
-  </ng-template>
-</div>-->
-
-
 <div class="container">
   <ng-container *ngIf="visualization; else noPlot">
     <!-- Case: Vega -->
@@ -56,4 +25,3 @@
     </div>
   </ng-template>
 </div>
-

--- a/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.html
+++ b/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.html
@@ -6,9 +6,7 @@
           <mat-label>Select a chart</mat-label>
           <mat-select
             formControlName="visualization"
-            required
-            (ngModelChange)="selectVisualization()"
-            disableOptionCentering>
+            [required]="true">
             <mat-optgroup *ngFor="let visualizationList of visualizations">
               {{ visualizationList.title }}
               <mat-option

--- a/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.ts
+++ b/libs/simulation-runs/ui/src/lib/select-viz/select-viz.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter, ViewChild, OnDestroy } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, Output, EventEmitter, ViewChild, OnInit, OnDestroy } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
 import { Observable, of, Subscription, map } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -27,7 +27,7 @@ type DesignVisualizationComponent =
   styleUrls: ['./select-viz.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SelectVisualizationComponent implements OnDestroy {
+export class SelectVisualizationComponent implements OnInit, OnDestroy {
   private vegaFormatCombineUri: string;
 
   @Input()
@@ -78,6 +78,14 @@ export class SelectVisualizationComponent implements OnDestroy {
     this.userLine2DFormGroup.disable();
   }
 
+  public ngOnInit() {
+    this.formGroup.get('visualization')?.valueChanges.subscribe(selectedVisualization => {
+      console.log('Visualization selected:', selectedVisualization);
+      console.log(`The form group control for viz: `)
+      this.selectVisualization();
+    });
+  }
+
   public ngOnDestroy(): void {
     this.subscriptions.forEach((subscription) => subscription.unsubscribe());
   }
@@ -87,16 +95,22 @@ export class SelectVisualizationComponent implements OnDestroy {
   }
 
   selectVisualization(): void {
+    console.log('Disabling all form groups...');
     this.userHistogram1DFormGroup.disable();
     this.userHeatmap2DFormGroup.disable();
     this.userLine2DFormGroup.disable();
 
     const visualization = this.getSelectedVisualization();
+    console.log(`THE VISUALIZATION SELECTED: ${visualization._type}`);
     if (visualization._type === 'Histogram1DVisualization') {
       this.userHistogram1DFormGroup.enable();
     } else if (visualization._type === 'Heatmap2DVisualization') {
       this.userHeatmap2DFormGroup.enable();
     } else if (visualization._type === 'Line2DVisualization') {
+      this.userLine2DFormGroup.enable();
+    } else if (visualization._type === 'SedPlot2DVisualization') {
+      console.log('Its sed plot');
+      this.userLine2DFormGroup.enable();
       this.userHeatmap2DFormGroup.enable();
     }
   }
@@ -118,6 +132,7 @@ export class SelectVisualizationComponent implements OnDestroy {
         designVisualizationComponent.getPlotlyDataLayout(),
       );
     }
+    console.log(`Emitting vis: ${visualization}`);
     this.renderVisualization.emit(visualization);
   }
 

--- a/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.scss
+++ b/libs/simulation-runs/viz/src/lib/plotly-visualization/plotly-visualization.component.scss
@@ -1,3 +1,8 @@
 .plotly-visualization {
   transform: scale(0.875);
+  margin-right: 8rem !important;
+}
+
+.plot-container {
+  padding-top: 2rem;
 }


### PR DESCRIPTION
_What does this PR do?:_
- Fixes `plotly-visualization` component declaration to appropriately provide access to all simulation run output plots. (closes: #4765 and #4779)
- Minor style fixes as need.