### PR TITLE
fix: accommodate undefined image url array in create project from sbml

### DIFF
--- a/libs/simulation-project-utils/simulation-project-utils/src/lib/service/create-project/archive-creation.ts
+++ b/libs/simulation-project-utils/simulation-project-utils/src/lib/service/create-project/archive-creation.ts
@@ -380,7 +380,7 @@ function CompleteArchiveFromFiles(
 }
 
 function AddImagesToArchive(urls: string[], archive: CombineArchive): CombineArchive {
-  if (urls.length >= 1) {
+  if (urls?.length >= 1) {
     urls.forEach((url: string) => {
       const imgPath = getFileNameFromUrl(url) as string;
       const archiveContent = {


### PR DESCRIPTION
**What bugs does this PR fix?**
There is a runtime error in [biosimulations.org/utils/create-project](http://biosimulations.org/utils/create-project), where the project creation from a SBML file fails while trying to process the array of imageUrls associated with the model, but this array is undefined.

The fix is to check for undefined while processing the create-project request.

**Does this PR introduce any additional changes?**
No.

**How have you tested this PR?**
not tested locally

**Additional information**
Please describe any information needed to review this PR.
