### PR TITLE
fix: synch kisao terms between combine-api and api services to fix runtime error

### DIFF
--- a/apps/combine-api/pyproject.toml
+++ b/apps/combine-api/pyproject.toml
@@ -17,7 +17,7 @@ orjson = "^3.8.7"
 flask-cors = "^3.0.10"
 pyyaml = "^6.0"
 boto3 = "^1.26.89"
-kisao = ">=2.34"
+kisao = ">=2.34"  # check consistency with https://raw.githubusercontent.com/SED-ML/KiSAO/deploy/kisao.owl
 biosimulators-utils = {extras = ["bngl", "cellml", "lems", "logging", "neuroml", "sbml", "smoldyn"], version = "^0.2.3"}
 parameterized = "^0.8.1"
 pytest = "^7.2.2"

--- a/tools/generate-ontologies
+++ b/tools/generate-ontologies
@@ -13,6 +13,8 @@ declare -A ONTOLOGY_URLS=( \
     ["sio"]="https://raw.githubusercontent.com/MaastrichtU-IDS/semanticscience/master/ontology/sio/release/sio-release.owl" \
     ["spdx"]="https://raw.githubusercontent.com/spdx/license-list-data/master/json/licenses.json" \
     )
+      
+# KiSAO url should be consistent with kisao python package used in combine-api service.
 
 # list of ontologies that needs to be updated
 # specified by single command-line argument with comma-separated list of ontology ids


### PR DESCRIPTION
**What new features does this PR implement?**
the API service was using KiSAO terms from v2.30 and the Combine API service was using terms from KiSAO v2.34.  This caused unexpected runtime errors during simulation post-processing.

The fix involved updating the 'deploy' branch of the KiSAO repo to the latest v2.34 such that the generate-ontologies script would pull the correct terms.  Then the "update ontologies" github action was run manually to update the kisao.owl terms directly in the dev branch without making a new release or deployment.  Finally, this PR will kick off the release/deploy process to make a new deployment to fix this runtime error.

Technically, this PR only documents the synchronization of the kisao terms between combine-api and api - through comments in the generate-ontologies script and the pyproject.toml file.

**What bugs does this PR fix?**
some recent KiSAO terms (e.g. KISAO_0000694) were not known to the API service and so runtime errors were generated on some newer OMEX archives.

**How have you tested this PR?**
I did not test this PR prior to deployment to dev site - we are working on a "Dev Containers" approach for local execution of the integrated services.
