### PR TITLE
fix: use lowercase containers in simulator container URLs

### DIFF
--- a/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
+++ b/apps/dispatch-service/src/app/services/sbatch/sbatch.service.ts
@@ -58,7 +58,7 @@ export class SbatchService {
     const storageKey = this.configService.get('storage.accessKey');
     const storageSecret = this.configService.get('storage.secret');
 
-    const simulatorImage = `docker://ghcr.io/biosimulators/${simulator}:${simulatorVersion}`;
+    const simulatorImage = `docker://ghcr.io/biosimulators/${simulator.toLowerCase()}:${simulatorVersion}`;
 
     const memoryFormatted = Math.ceil(memory * 1000);
 

--- a/libs/messages/messages/src/lib/images.ts
+++ b/libs/messages/messages/src/lib/images.ts
@@ -14,7 +14,7 @@ export class ImageMessagePayload {
       this.simulator = simulator;
       this.version = version;
       this.force = force;
-      this.url = `docker://ghcr.io/biosimulators/${this.simulator}:${this.version}`;
+      this.url = `docker://ghcr.io/biosimulators/${this.simulator.toLowerCase()}:${this.version}`;
     }
   }
 }

--- a/libs/messages/messages/src/lib/queues.ts
+++ b/libs/messages/messages/src/lib/queues.ts
@@ -9,7 +9,7 @@ export const BullModuleOptions = {
   imports: [BiosimulationsConfigModule],
   useFactory: async (configService: ConfigService) => {
     const logger = new Logger('BullModuleInit');
-    logger.log(`Connecting to ${configService.get('queue.host')}:${configService.get('queue.port')}`);
+    logger.log(`Bull is connecting to Redis at ${configService.get('queue.host')}:${configService.get('queue.port')}`);
     return {
       connection: {
         host: configService.get('queue.host'),


### PR DESCRIPTION
**What new features does this PR implement?**
The Virtual Cell simulator container image URL was generated from the simulator `id` as defined in its biosimulator.json which was `VCell` rather than the lower case `vcell`.  For the recent submission of VCell 7.7.0.12, this created a docker URL used by singularity of docker://ghcr.io/biosimulators/VCell:7.7.0.12, which is rejected with the following message:

> While making image from oci registry: error fetching image to cache: failed to get checksum for 
> docker://ghcr.io/biosimulators/VCell:7.7.0.12: unable to parse image name docker://ghcr.io/biosimulators/VCell:7.7.0.12: 
> invalid reference format: repository name must be lowercase

now, when constructing the URL of a simulator docker image, the simulator name is always forced to be lowercase.  VCell may or may not be the only simulator whose `id` is mixed case, this fix should handle all cases.  There are other places in the code which compare the "normalized" simulator ids, accounting for mixed case.

**What bugs does this PR fix?**
This fixes the problem where the Virtual Cell simulator jobs timeout after being recently deployed, because the singularity image pre-generation fails with the message above.

**Does this PR introduce any additional changes?**
also, improved a logging message when the api connects to Redis.

**How have you tested this PR?**
this has not been tested, but is very unlikely to do any harm.

