### PR TITLE
chore(deps): upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/buildLintTest.yml
+++ b/.github/workflows/buildLintTest.yml
@@ -33,7 +33,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         name: Checkout
         with:
           fetch-depth: 0
@@ -54,7 +54,7 @@ jobs:
         run: pipx install poetry==1.4.0
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"
@@ -63,7 +63,7 @@ jobs:
         run: |
           python -m pip install flake8
 
-      - uses: actions/setup-node@v3.3.0
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 
@@ -192,7 +192,7 @@ jobs:
 #      matrix:
 #        agent: [ 1, 2, 3, 4, 5 ]
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v4
 #
 #      - name: Install dependencies
 #        run: sudo apt-get update && sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
@@ -201,7 +201,7 @@ jobs:
 #        run: pipx install poetry==1.4.0
 #
 #      - name: Install Python
-#        uses: actions/setup-python@v4
+#        uses: actions/setup-python@v5
 #        with:
 #          python-version: "3.9"
 #          architecture: "x64"
@@ -210,7 +210,7 @@ jobs:
 #        run: |
 #          python -m pip install flake8
 #
-#      - uses: actions/setup-node@v3.3.0
+#      - uses: actions/setup-node@v4
 #        with:
 #          node-version: '18'
 #

--- a/.github/workflows/buildSitemaps.yml
+++ b/.github/workflows/buildSitemaps.yml
@@ -32,13 +32,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_ACCESS_TOKEN}}
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"

--- a/.github/workflows/checkExampleSimulationRunsSucceeded.yml
+++ b/.github/workflows/checkExampleSimulationRunsSucceeded.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_ACCESS_TOKEN}}
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/closeStaleTodos.yml
+++ b/.github/workflows/closeStaleTodos.yml
@@ -12,7 +12,7 @@ jobs:
     name: close-issues
     steps:
       - name: Close Stale Issues
-        uses: actions/stale@v4
+        uses: actions/stale@v9
         with:
           # The message to post on the issue when tagging it. If none provided, will not mark issues stale.
           stale-issue-message: This issue has been marked as stale. If still relevent, the label can be removed.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/dependencyLicense.yml
+++ b/.github/workflows/dependencyLicense.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN}}
           ref: ${{inputs.branch}}
@@ -31,7 +31,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
       - name: Install Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: |
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Install Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 
@@ -158,7 +158,7 @@ jobs:
     environment: dev_environment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Call webhook
         env:
@@ -181,10 +181,10 @@ jobs:
     environment: dev_test_environment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"
@@ -233,7 +233,7 @@ jobs:
 
       steps:
         - name: Install Node.js
-          uses: actions/setup-node@v3.3.0
+          uses: actions/setup-node@v4
           with:
             node-version: '18'
 
@@ -260,7 +260,7 @@ jobs:
     environment: prod_environment
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Call webhook
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,20 +41,20 @@ jobs:
 
     steps:
       - name: Checkout [dev]
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ github.event_name != 'pull_request' }}
         with:
           fetch-depth: 0
 
       - name: Checkout [pr]
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         if: ${{ github.event_name == 'pull_request' }}
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
 
@@ -65,7 +65,7 @@ jobs:
         run: pipx install poetry==1.4.0
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         run: pipx install poetry==1.4.0
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN}}
           ref:  ${{inputs.branch}}
 
       - name: Install Node.js
-        uses: actions/setup-node@v3.3.0
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: npm

--- a/.github/workflows/generateCombineApiClient.yml
+++ b/.github/workflows/generateCombineApiClient.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
           sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
           sudo apt-get -y install perl
 
-      - uses: actions/setup-node@v3.3.0
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 

--- a/.github/workflows/monitor-todos.yml
+++ b/.github/workflows/monitor-todos.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: "Create issues for new todos and close issues for removed todos"
         uses: alstr/todo-to-issue-action@v4.6.6

--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Ensure a compatible version of dotnet is installed.
     # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
   Release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           token: ${{secrets.GH_RELEASE_TOKEN}}
           ref: ${{inputs.branch}}
@@ -37,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y install build-essential libcairo2-dev libpango1.0-dev libjpeg-dev libgif-dev librsvg2-dev
 
-      - uses: actions/setup-node@v3.3.0
+      - uses: actions/setup-node@v4
         with:
           node-version: '18'
 

--- a/.github/workflows/semantic-commits.yml
+++ b/.github/workflows/semantic-commits.yml
@@ -24,5 +24,5 @@ jobs:
     name: Lint Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: bilalshaikh42/action-conventional-commits@v2.0.1

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - name: checkout-merge
       if: "contains(github.event_name, 'pull_request')"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: refs/pull/${{github.event.pull_request.number}}/merge
     - name: checkout
@@ -22,7 +22,7 @@ jobs:
         (
           contains(github.event.comment.body, '@check-spelling-bot apply')
         ) }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     # Debugging before check-spelling action
     - name: Debug before check-spelling
       if: ${{ github.event_name != 'issue_comment' ||

--- a/.github/workflows/testSimulationsWorking.yaml
+++ b/.github/workflows/testSimulationsWorking.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
           architecture: "x64"

--- a/.github/workflows/updateLicenseYear.yml
+++ b/.github/workflows/updateLicenseYear.yml
@@ -11,7 +11,7 @@ jobs:
   update-license-year:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: FantasticFiasco/action-update-license-year@v2

--- a/.github/workflows/updateOntologies.yml
+++ b/.github/workflows/updateOntologies.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2.4.2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           token: ${{ secrets.GH_ACCESS_TOKEN}}
@@ -27,7 +27,7 @@ jobs:
         run: sudo apt-get install -y --no-install-recommends wget
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 

--- a/.github/workflows/validateOpenApiSpecs.yml
+++ b/.github/workflows/validateOpenApiSpecs.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: "!startsWith(matrix.apiSpecs, 'https://')"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                
                                                                                                                                                                                                                         
  - Upgrade all GitHub Actions across 20 workflow files to their latest major versions:                                                                                                                                  
    - actions/checkout: v2/v3 → v4                                                                                                                                                                                       
    - actions/setup-node: v3.3.0 → v4                                                                                                                                                                                  
    - actions/setup-python: v4 → v5                                                                                                                                                                                      
    - actions/stale: v4 → v9                                                                                                                                                                                             
                                                                                                                                                                                                                         
  Motivation                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  The older actions/setup-node@v3 uses the deprecated save-state command, which now causes Cache service responded with 400 errors and fails CI runs. Upgrading to v4 resolves this by using the current Environment     
  Files API.                                                                                                                                                                                                             
                                                                                                                                                                                                                         
  Test plan                                                                                                                                                                                                              
                                                                                                                                                                                                                         
  - CI workflows (format, dependency-license, build/lint/test, docs) pass without cache errors                                                                                                                           
  - No regressions in existing workflow behavior                                                                                                                                                                         
