### PR TITLE
fix(release): use pre-built output for Netlify deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           export NETLIFY_SITE_ID=${{secrets[env.idKey]}}
           export NETLIFY_AUTH_TOKEN=${{secrets.NETLIFY_AUTH_TOKEN}}
-          netlify deploy --prod
+          netlify deploy --no-build --prod --dir .
 
   triggerDevDeployment:
     name: Trigger a new deployment of the dev backend
@@ -259,7 +259,7 @@ jobs:
           run: |
             export NETLIFY_SITE_ID=${{secrets[env.idKey]}}
             export NETLIFY_AUTH_TOKEN=${{secrets.NETLIFY_AUTH_TOKEN}}
-            netlify deploy --prod
+            netlify deploy --no-build --prod --dir .
 
   triggerProdDeployment:
     name: Trigger a new deployment of the production backend


### PR DESCRIPTION
## Summary
- Pass `--no-build` and `--dir .` to `netlify deploy` in both dev and prod frontend deploy jobs
- Prevents Netlify from re-running its own build step, since artifacts are already built by the workflow

## Test plan
- [ ] Verify dev frontend deploy succeeds on next push to dev
- [ ] Verify prod frontend deploy succeeds on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)