### PR TITLE
fix(config): convert SSH private key \n literals to real newlines

### DIFF
--- a/libs/config/nest/src/lib/biosimulations-hpc-config.ts
+++ b/libs/config/nest/src/lib/biosimulations-hpc-config.ts
@@ -8,7 +8,7 @@ export default registerAs('hpc', () => {
       host: process.env.HPC_SSH_HOST,
       port: process.env.HPC_SSH_PORT,
       username: process.env.HPC_SSH_USERNAME,
-      privateKey: process.env.HPC_SSH_PRIVATE_KEY,
+      privateKey: process.env.HPC_SSH_PRIVATE_KEY?.replace(/\\n/g, '\n'),
     },
     sshInit: process.env.HPC_SSH_INIT, // set to false to disable ssh init when testing
     hpcBaseDir: process.env.HPC_BASE_DIR,


### PR DESCRIPTION
## Summary
- The HPC SSH private key stored in env/secrets uses literal `\n` two-character sequences
- The ssh2 library needs actual newline characters to parse the PEM format
- Adds `.replace(/\\n/g, '\n')` when reading `HPC_SSH_PRIVATE_KEY`
- This fixes "All configured authentication methods failed" errors on the dispatch-service

## Test plan
- [ ] Deploy dispatch-service with new image and verify SSH connection succeeds
- [ ] Verify simulation runs progress past CREATED status

🤖 Generated with [Claude Code](https://claude.com/claude-code)