### PR TITLE
fix(release): add missing Netlify CLI install to prod frontend deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -247,6 +247,9 @@ jobs:
           with:
             node-version: '18'
 
+        - name: Install Netlify CLI
+          run: npm install -g netlify-cli
+
         - name: Download build for app
           uses: actions/download-artifact@v4
           with:


### PR DESCRIPTION
## Summary
- The prod `deployProdFrontend` job was missing the `npm install -g netlify-cli` step
- The dev `deployDevFrontend` job has this step and deploys successfully
- Both jobs are now structurally identical (same steps, differing only in artifact names and environment)

## Test plan
- [x] Dev frontend deploy succeeded with this pattern
- [ ] Merge and verify prod frontend deploy succeeds on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)