### PR TITLE
docs: point Zenodo DOI/citation to new concept record

### DIFF
--- a/.github/workflows/zenodo-archive-drift.yml
+++ b/.github/workflows/zenodo-archive-drift.yml
@@ -1,0 +1,103 @@
+name: Zenodo archive drift check
+
+# Verifies that the latest GitHub release has actually been archived to Zenodo.
+#
+# Reads ONLY public APIs (GitHub releases + Zenodo records) — no secrets, so this
+# monitor cannot itself break from an expired credential. It opens/updates a
+# tracking issue and fails the run when archiving has drifted, so a silently
+# broken release->Zenodo pipeline can't go unnoticed (as it did from v9.57.0
+# through v9.65.4, ~2 years, when the Zenodo GitHub webhook was removed).
+
+on:
+  schedule:
+    - cron: '0 12 * * 1' # weekly, Mondays 12:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  # Concept (all-versions) record id for the BioSimulations DOI lineage.
+  # Concept DOI: 10.5281/zenodo.21053715
+  ZENODO_CONCEPT_RECID: '21053715'
+
+jobs:
+  drift-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compare latest GitHub release with latest Zenodo version
+        id: compare
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Latest published (non-prerelease, non-draft) GitHub release.
+          gh_tag=$(gh api "repos/${{ github.repository }}/releases/latest" --jq '.tag_name')
+
+          # Latest version archived in the Zenodo concept. Requesting the concept
+          # record id with redirects returns the latest version's record (public).
+          zen=$(curl -fsSL -H 'Accept: application/json' \
+            "https://zenodo.org/api/records/${ZENODO_CONCEPT_RECID}")
+          zen_ver=$(echo "$zen" | jq -r '.metadata.version // "none"')
+          zen_id=$(echo "$zen" | jq -r '.id')
+
+          echo "Latest GitHub release : $gh_tag"
+          echo "Latest Zenodo version : $zen_ver (record $zen_id)"
+
+          {
+            echo "gh_tag=$gh_tag"
+            echo "zen_ver=$zen_ver"
+            echo "zen_id=$zen_id"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$gh_tag" = "$zen_ver" ]; then
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::In sync — $gh_tag is archived on Zenodo."
+          else
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+            echo "::warning::Drift — GitHub latest ($gh_tag) != latest Zenodo version ($zen_ver)."
+          fi
+
+      - name: Open or update tracking issue
+        if: steps.compare.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_TAG: ${{ steps.compare.outputs.gh_tag }}
+          ZEN_VER: ${{ steps.compare.outputs.zen_ver }}
+          ZEN_ID: ${{ steps.compare.outputs.zen_id }}
+        run: |
+          set -euo pipefail
+          title="Zenodo release archiving has drifted"
+
+          {
+            echo "The latest GitHub release is **not** the latest version archived on Zenodo."
+            echo ""
+            echo "| | Version |"
+            echo "|---|---|"
+            echo "| Latest GitHub release | \`${GH_TAG}\` |"
+            echo "| Latest Zenodo version | \`${ZEN_VER}\` (record ${ZEN_ID}) |"
+            echo ""
+            echo "Concept DOI: https://doi.org/10.5281/zenodo.21053715"
+            echo ""
+            echo "This usually means the release->Zenodo archiving pipeline has stopped"
+            echo "working (an expired token, a revoked OAuth grant, or a disabled integration)."
+            echo ""
+            echo "_Filed automatically by the \`zenodo-archive-drift\` workflow._"
+          } > issue_body.md
+
+          num=$(gh issue list --state open --search "$title in:title" --json number --jq '.[0].number // empty')
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --body "Still drifting: GitHub \`${GH_TAG}\` vs Zenodo \`${ZEN_VER}\`."
+            echo "Updated existing issue #$num"
+          else
+            gh issue create --title "$title" --body-file issue_body.md
+            echo "Opened a new drift issue"
+          fi
+
+      - name: Fail the run if drifted
+        if: steps.compare.outputs.drift == 'true'
+        run: |
+          echo "Marking the run red so the drift is visible."
+          exit 1

--- a/.github/workflows/zenodo-archive-release.yml
+++ b/.github/workflows/zenodo-archive-release.yml
@@ -38,16 +38,23 @@ jobs:
 
       - name: Resolve tag, date, and prerelease flag
         id: meta
+        # All GitHub-context/user-controlled values are passed via env (never
+        # interpolated into the run script) to avoid shell script injection.
         env:
           GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REL_TAG: ${{ github.event.release.tag_name }}
+          REL_PRERELEASE: ${{ github.event.release.prerelease }}
+          REL_PUBDATE: ${{ github.event.release.published_at }}
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "release" ]; then
-            tag='${{ github.event.release.tag_name }}'
-            prerelease='${{ github.event.release.prerelease }}'
-            pubdate='${{ github.event.release.published_at }}'
+          if [ "$EVENT_NAME" = "release" ]; then
+            tag="$REL_TAG"
+            prerelease="$REL_PRERELEASE"
+            pubdate="$REL_PUBDATE"
           else
-            tag='${{ inputs.tag }}'
+            tag="$INPUT_TAG"
             prerelease=$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease')
             pubdate=$(gh release view "$tag" --json publishedAt --jq '.publishedAt')
           fi
@@ -60,7 +67,9 @@ jobs:
 
       - name: Skip prereleases
         if: steps.meta.outputs.prerelease == 'true'
-        run: echo "Skipping prerelease ${{ steps.meta.outputs.tag }}."
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: echo "Skipping prerelease $TAG."
 
       - name: Archive to Zenodo
         if: steps.meta.outputs.prerelease != 'true'

--- a/.github/workflows/zenodo-archive-release.yml
+++ b/.github/workflows/zenodo-archive-release.yml
@@ -1,0 +1,73 @@
+name: Archive release to Zenodo
+
+# On each published (non-prerelease) GitHub release, add it as a new version of
+# the BioSimulations Zenodo concept record (concept DOI 10.5281/zenodo.21053715),
+# keeping the DOI lineage and author metadata consistent with prior versions.
+#
+# Replaces the old Zenodo<->GitHub webhook (which was tied to a single account's
+# OAuth grant and silently broke). Requires a repo/org secret ZENODO_TOKEN
+# (scopes: deposit:write, deposit:actions) from the account that owns the concept
+# record. The companion `zenodo-archive-drift` workflow alerts if archiving ever
+# silently stops. The archive script is idempotent and no-ops if the secret is
+# absent, so this is safe to merge before the secret is configured.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to archive (e.g. v9.66.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+# Versions must be created sequentially (each branches off the latest), so never
+# run two archiving jobs at once; queue instead of cancelling.
+concurrency:
+  group: zenodo-archive
+  cancel-in-progress: false
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve tag, date, and prerelease flag
+        id: meta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag='${{ github.event.release.tag_name }}'
+            prerelease='${{ github.event.release.prerelease }}'
+            pubdate='${{ github.event.release.published_at }}'
+          else
+            tag='${{ inputs.tag }}'
+            prerelease=$(gh release view "$tag" --json isPrerelease --jq '.isPrerelease')
+            pubdate=$(gh release view "$tag" --json publishedAt --jq '.publishedAt')
+          fi
+          {
+            echo "tag=$tag"
+            echo "prerelease=$prerelease"
+            echo "pubdate=${pubdate:0:10}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved: tag=$tag pubdate=${pubdate:0:10} prerelease=$prerelease"
+
+      - name: Skip prereleases
+        if: steps.meta.outputs.prerelease == 'true'
+        run: echo "Skipping prerelease ${{ steps.meta.outputs.tag }}."
+
+      - name: Archive to Zenodo
+        if: steps.meta.outputs.prerelease != 'true'
+        env:
+          ZENODO_TOKEN: ${{ secrets.ZENODO_TOKEN }}
+          TAG: ${{ steps.meta.outputs.tag }}
+          PUBDATE: ${{ steps.meta.outputs.pubdate }}
+          CONCEPT_RECID: '21053715'
+          REPO: ${{ github.repository }}
+        run: python3 tools/zenodo_archive_release.py

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,24 +15,37 @@ authors:
     given-names: Bilal
     orcid: 'https://orcid.org/0000-0001-5801-5510'
   - affiliation: 'University of Connecticut School of Medicine'
+    family-names: Patrie
+    given-names: Alexander
+    orcid: 'https://orcid.org/0009-0002-6886-2291'
+  - affiliation: 'University of Connecticut School of Medicine'
+    family-names: Schaff
+    given-names: James C.
+    orcid: 'https://orcid.org/0000-0003-3286-7736'
+  - affiliation: 'University of Connecticut School of Medicine'
     family-names: Marupilla
     given-names: Gnaneswara
+    orcid: 'https://orcid.org/0000-0002-6030-8707'
   - affiliation: 'University of Connecticut School of Medicine'
     family-names: Wilson
     given-names: Mike
     orcid: 'https://orcid.org/0000-0001-5892-6074'
   - affiliation: 'University of Connecticut School of Medicine'
-    family-names: Michael
-    given-names: Blinov L.
+    family-names: Blinov
+    given-names: Michael L.
     orcid: 'https://orcid.org/0000-0002-9363-9705'
   - affiliation: 'University of Connecticut School of Medicine'
-    family-names: Moraru
-    given-names: Ion I.
-    orcid: 'https://orcid.org/0000-0002-3746-9676'
+    family-names: Agmon
+    given-names: Eran
+    orcid: 'https://orcid.org/0000-0003-1279-2474'
   - affiliation: 'Icahn School of Medicine at Mount Sinai'
     family-names: Karr
     given-names: Jonathan R.
     orcid: 'https://orcid.org/0000-0002-2605-5080'
+  - affiliation: 'University of Connecticut School of Medicine'
+    family-names: Moraru
+    given-names: Ion I.
+    orcid: 'https://orcid.org/0000-0002-3746-9676'
 cff-version: '1.2.0'
 keywords:
   - numerical simulation
@@ -55,17 +68,20 @@ keywords:
   - biochemical networks
   - biosimulations
   - biosimulators
-doi: '10.5281/zenodo.5057108'
+doi: '10.5281/zenodo.21053715'
 identifiers:
   - type: url
     description: The repository for the software
     value: http://identifiers.org/github/biosimulations/biosimulations
   - type: url
     description: The Zenodo entry for the software
-    value: http://identifiers.org/doi/10.5281/zenodo.5057108
+    value: http://identifiers.org/doi/10.5281/zenodo.21053715
+  - type: doi
+    value: 10.5281/zenodo.21053715
+    description: The concept DOI of the work.
   - type: doi
     value: 10.5281/zenodo.5057108
-    description: The concept DOI of the work.
+    description: The original concept DOI (archived versions through v9.57.0).
   - type: other
     value: biocatalogue.service:4043
     description: BioCatalogue entry for BioSimulations

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-1.4-4baaaa.svg)](CODE_OF_CONDUCT.md)
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
-[![DOI](https://zenodo.org/badge/207730765.svg)](https://zenodo.org/badge/latestdoi/207730765) 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21053715.svg)](https://doi.org/10.5281/zenodo.21053715)
 
 # BioSimulations 🧬
 
@@ -60,8 +60,8 @@ If you find this project interesting or useful, please give our repo a ⭐ and s
 
 ```
 @software{Shaikh_BioSimulations,
-author = {Shaikh, Bilal and Marupilla, Gnaneswara and Wilson, Mike and Michael, Blinov L. and Moraru, Ion I. and Karr, Jonathan R.},
-doi = {10.5281/zenodo.5057108},
+author = {Shaikh, Bilal and Patrie, Alexander and Schaff, James C. and Marupilla, Gnaneswara and Wilson, Mike and Blinov, Michael L. and Agmon, Eran and Karr, Jonathan R. and Moraru, Ion I.},
+doi = {10.5281/zenodo.21053715},
 license = {MIT},
 title = {{BioSimulations}},
 url = {https://github.com/biosimulations/biosimulations}

--- a/tools/zenodo_archive_release.py
+++ b/tools/zenodo_archive_release.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Archive a single GitHub release tag as a new version of the BioSimulations
+Zenodo concept record, preserving the DOI lineage and author metadata.
+
+Idempotent: if the tag is already archived in the concept, it does nothing.
+Metadata (authors, title, description, keywords, license) is inherited from the
+previous version, so the author list stays consistent automatically; only the
+version, publication date, and lineage identifiers are set per release.
+
+Environment:
+  ZENODO_TOKEN     Zenodo personal access token (scopes: deposit:write,
+                   deposit:actions) from the account that owns the concept
+                   record. If empty/unset, the script no-ops (exit 0) so the
+                   release workflow doesn't fail before the secret is configured.
+  TAG              release tag to archive, e.g. v9.66.0
+  PUBDATE          publication date, YYYY-MM-DD
+  CONCEPT_RECID    Zenodo concept record id (default 21053715)
+  REPO             owner/repo (default biosimulations/biosimulations)
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+API = 'https://zenodo.org/api'
+TOK = os.environ.get('ZENODO_TOKEN', '').strip()
+TAG = os.environ['TAG']
+PUBDATE = os.environ['PUBDATE']
+CONCEPT = os.environ.get('CONCEPT_RECID', '21053715')
+REPO = os.environ.get('REPO', 'biosimulations/biosimulations')
+OLD_CONCEPT_DOI = '10.5281/zenodo.5057108'  # pre-fork lineage, linked for provenance
+
+
+def call(method, url, data=None, raw=False):
+    headers = {'Authorization': f'Bearer {TOK}'}
+    body = None
+    if raw:
+        body = data
+        headers['Content-Type'] = 'application/octet-stream'
+    elif data is not None:
+        body = json.dumps(data).encode()
+        headers['Content-Type'] = 'application/json'
+    req = urllib.request.Request(url, data=body, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req) as r:
+            c = r.read()
+            return r.status, (json.loads(c) if c else None)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode(errors='replace')
+
+
+def main():
+    if not TOK:
+        print('::warning::ZENODO_TOKEN is not set; skipping Zenodo archiving. '
+              'Add the secret to enable automatic archiving.')
+        return
+
+    # Existing published versions in the concept (idempotency + latest pointer).
+    st, deps = call('GET', f'{API}/deposit/depositions'
+                           f'?q=conceptrecid:{CONCEPT}&all_versions=true&size=100')
+    if st != 200 or not isinstance(deps, list):
+        sys.exit(f'failed to list concept versions: {st} {deps}')
+    published = [d for d in deps if d.get('submitted')]
+    by_version = {d['metadata'].get('version'): d for d in published}
+    if TAG in by_version:
+        print(f'{TAG} already archived (record {by_version[TAG]["id"]}); nothing to do.')
+        return
+    if not published:
+        sys.exit('no published version found in concept; cannot create a new version')
+
+    latest = max(published, key=lambda d: d.get('created', ''))
+    latest_id = latest['id']
+    print(f'latest published version: {latest["metadata"].get("version")} (id {latest_id})')
+
+    # Download the release source tarball (same form as the existing versions).
+    tar = f'/tmp/biosimulations-{TAG}.tar.gz'
+    url = f'https://github.com/{REPO}/archive/refs/tags/{TAG}.tar.gz'
+    print(f'downloading {url}')
+    urllib.request.urlretrieve(url, tar)
+    if os.path.getsize(tar) < 1000:
+        sys.exit(f'tarball for {TAG} is suspiciously small')
+
+    # Create a new version branched off the latest, swap in the new file.
+    st, r = call('POST', f'{API}/deposit/depositions/{latest_id}/actions/newversion')
+    if st not in (200, 201):
+        sys.exit(f'newversion failed {st}: {r}')
+    st, draft = call('GET', r['links']['latest_draft'])
+    if st != 200:
+        sys.exit(f'get draft failed {st}: {draft}')
+    nid = draft['id']
+    bucket = draft['links']['bucket']
+    for f in draft.get('files', []):
+        call('DELETE', f"{API}/deposit/depositions/{nid}/files/{f['id']}")
+    with open(tar, 'rb') as fh:
+        st, _ = call('PUT', f'{bucket}/biosimulations-{TAG}.tar.gz', data=fh.read(), raw=True)
+    if st not in (200, 201):
+        sys.exit(f'upload failed {st}')
+
+    # Inherit metadata (authors etc.); set only version/date/lineage.
+    md = dict(draft['metadata'])
+    md['version'] = TAG
+    md['publication_date'] = PUBDATE
+    md['related_identifiers'] = [
+        {'relation': 'isNewVersionOf', 'identifier': OLD_CONCEPT_DOI, 'scheme': 'doi'},
+        {'relation': 'isSupplementTo',
+         'identifier': f'https://github.com/{REPO}/tree/{TAG}', 'scheme': 'url'},
+    ]
+    md.pop('doi', None)
+    md.pop('prereserve_doi', None)
+    st, r = call('PUT', f'{API}/deposit/depositions/{nid}', data={'metadata': md})
+    if st != 200:
+        sys.exit(f'metadata update failed {st}: {r}')
+
+    st, r = call('POST', f'{API}/deposit/depositions/{nid}/actions/publish')
+    if st != 202:
+        sys.exit(f'publish failed {st}: {r}')
+    print(f'archived {TAG} -> {r.get("doi")}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/zenodo_archive_release.py
+++ b/tools/zenodo_archive_release.py
@@ -102,7 +102,10 @@ def main():
     md['version'] = TAG
     md['publication_date'] = PUBDATE
     md['related_identifiers'] = [
-        {'relation': 'isNewVersionOf', 'identifier': OLD_CONCEPT_DOI, 'scheme': 'doi'},
+        # This lineage continues the pre-fork archive (frozen at v9.57.0). Kept on
+        # every version so it stays visible on the concept DOI page, which always
+        # shows the latest version's metadata.
+        {'relation': 'continues', 'identifier': OLD_CONCEPT_DOI, 'scheme': 'doi'},
         {'relation': 'isSupplementTo',
          'identifier': f'https://github.com/{REPO}/tree/{TAG}', 'scheme': 'url'},
     ]


### PR DESCRIPTION
## Why

Automated archiving of releases to Zenodo silently broke after **v9.57.0 (Feb 2024)** — the GitHub→Zenodo webhook had been removed, and nobody noticed for ~2 years. The original Zenodo record (concept DOI `10.5281/zenodo.5057108`) is owned by a Zenodo account the current team can no longer access, so re-pointing the existing lineage isn't possible.

A **new concept record** was created under the team's account (concept DOI `10.5281/zenodo.21053715`), and the 19 missed releases (v9.58.0 → v9.65.4) have been **backfilled** into it. This PR updates citation metadata to the new record and adds the automation + monitoring so this can't silently recur.

## Changes

### Citation metadata
- **README badge** → new concept DOI `10.5281/zenodo.21053715` (static DOI badge instead of the old GitHub-integration auto-badge)
- **CITATION.cff** `doi` + identifiers → new concept DOI; old DOI `5057108` **retained** as a labeled historical identifier (archived versions ≤ v9.57.0)
- **Author lists** in `CITATION.cff` and README BibTeX aligned to current contributor-credit order; fixed `Michael, Blinov L.` → `Blinov, Michael L.`; added Marupilla's ORCID

### Release-time archiving (`.github/workflows/zenodo-archive-release.yml` + `tools/zenodo_archive_release.py`)
- On each published (non-prerelease) release, appends it as a **new version of concept `21053715`** via the Zenodo deposit API
- Inherits author metadata from the prior version (authorship stays consistent automatically); **idempotent** (skips already-archived tags); supports manual `workflow_dispatch` by tag
- Replaces the fragile per-account Zenodo↔GitHub webhook
- **Requires a new secret `ZENODO_TOKEN`** (scopes `deposit:write`, `deposit:actions`) from the account that owns the concept record. **No-ops safely if the secret is absent**, so this is fine to merge before the secret is added.

### Drift monitor (`.github/workflows/zenodo-archive-drift.yml`)
- Weekly + on-demand check that the latest GitHub release equals the latest Zenodo version
- **Public APIs only — no secrets**, so the monitor itself can't break
- On drift: opens/updates a tracking issue and fails the run (visible red)

## Operational follow-ups (not blocking merge)
- Add the **`ZENODO_TOKEN`** repo/org secret (owning account).
- **Disable the native Zenodo↔GitHub integration** that was recently re-enabled, so it doesn't create a competing DOI on the next release (this Action replaces it).
- Old DOI `10.5281/zenodo.5057108` stays live as a frozen snapshot (≤ v9.57.0); new DOI covers v9.58.0 onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)